### PR TITLE
Add initial bert example

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/examples/bert/README.md
+++ b/examples/bert/README.md
@@ -1,0 +1,203 @@
+# BERT with keras-nlp
+
+This example will show how to train a Bidirectional Encoder
+Representations from Transformers (BERT) model end-to-end using the keras-nlp
+library. This README contains instructions on how to run pretraining directly
+from raw data, followed by fine tuning and evaluation on the GLUE dataset.
+
+## Quickly test out the code
+
+To exercise the code in this directory by training a tiny BERT model, you can
+run the following commands from the base of the keras-nlp repository. This can
+be useful to validate any code changes, but note that a useful BERT model would
+need to be trained for much longer on a much larger dataset.
+
+```shell
+DIR=bert_test_output
+DATA_URL=https://storage.googleapis.com/tensorflow/keras-nlp/examples/bert
+
+# Create a virtual env and install dependencies.
+mkdir $DIR
+python3 -m venv $DIR/env
+source $DIR/env/bin/activate
+pip install -e ".[tests,examples]"
+
+# Download example data.
+wget ${DATA_URL}/bert_vocab_uncased.txt -O $DIR/bert_vocab_uncased.txt
+wget ${DATA_URL}/wiki_example_data.txt -O $DIR/wiki_example_data.txt
+
+# Run preprocessing.
+python3 examples/bert/create_sentence_split_data.py \
+    --input_files $DIR/wiki_example_data.txt \
+    --output_directory $DIR/sentence-split-data --num_shards 1
+python3 examples/bert/create_pretraining_data.py \
+    --input_files $DIR/sentence-split-data/ \
+    --vocab_file $DIR/bert_vocab_uncased.txt \
+    --output_file $DIR/pretraining-data/pretraining.tfrecord
+
+# Run pretraining.
+python3 examples/bert/run_pretraining.py \
+    --input_files $DIR/pretraining-data/ \
+    --vocab_file $DIR/bert_vocab_uncased.txt \
+    --bert_config_file examples/bert/configs/bert_tiny.json \
+    --saved_model_output $DIR/model/
+```
+
+## Installing dependencies
+
+Pip dependencies for all keras-nlp examples are listed in `setup.py`. To install
+both the keras-nlp library from source and all other dependencies required to
+run the example, run the below command. You may want to install to a self
+contained environment (e.g. a container or a virtualenv).
+
+```shell
+pip install -e ".[examples]"
+```
+
+## Pretraining BERT
+
+Training a BERT model happens in two stages. First, the model is "pretrained" on
+a large corpus of input text. This is computationally expensive. After
+pretraining, the model can be "fine tuned" on a downstream task with
+
+### Downloading pretraining data
+
+The GLUE pretraining data (Wikipedia + BooksCorpus) is fairly large. The raw
+input data takes roughly ~20GB of space, and after preprocessing, the full
+corpus will take ~400GB.
+
+The latest wikipedia dump can be downloaded [at this link](https://dumps.wikimedia.org/enwiki/latest/enwiki-latest-pages-articles.xml.bz2).
+The dump can be extracted with the `wikiextractor` tool.
+
+```shell
+python -m wikiextractor.WikiExtractor enwiki-latest-pages-articles.xml.bz2
+```
+
+BooksCorpus is no longer hosted by
+[it's creators](https://yknzhu.wixsite.com/mbweb), but you can find instructions
+for downloading or reproducing the corpus in this
+[README](https://github.com/soskek/bookcorpus/blob/master/README.md).
+
+Preparing the pretraining data will happen in two stages. First, raw text needs
+to be split into lists of sentences per document. Second, this sentence split
+data needs to use to create training examples with both masked words and
+next sentence predictions.
+
+### Splitting raw text into sentences
+
+The `create_sentence_split_data.py` will process raw input files and split them
+into output files where each line contains a sentence, and a blank line marks
+the start of a new document.
+
+The script supports two types of inputs files. Plain text files, where each
+individual file is assumed to be an entire document, and wikipedia dump files
+in the format outputted by the wikiextractor tool (each document is enclosed in
+`<doc>` tags).
+
+For example, if wikipedia files are located in `~/datasets/wikipedia` and
+bookscorpus in `~/datasets/bookscorpus`, the following command will output
+sentence split documents to a configurable number of output file shards:
+
+```shell
+python examples/bert/create_sentence_split_data.py \
+    --input_files ~/datasets/wikipedia,~/datasets/bookscorpus \
+    --output_directory ~/datasets/sentence-split-data
+```
+
+### Computing a WordPiece vocabulary
+
+The `create_vocabulary.py` script allows you to compute your own WordPiece
+vocabulary for use with BERT. In most cases however, it is desirable to use the
+standard BERT vocabularies from the original models. You can download the
+English uncased vocabulary
+[here](https://storage.googleapis.com/tensorflow/keras-nlp/examples/bert/bert_vocab_uncased.txt).
+
+### Tokenize, mask, and combine sentences into training examples
+
+The `create_pretraining_data.py` scrip will take in a set of sentence split
+files, and set up training examples for the next sentence prediction and masked
+word tasks.
+
+The output of the script will be TFRecord files with a number of fields per
+example. Below shows a complete output example with the addition of a string
+`tokens` field for clarity. The actual script will only serialize the token ids
+to conserve disk space.
+
+```python
+tokens:  ['[CLS]', 'resin', '##s', 'are', 'today', '[MASK]', 'produced', 'by', 
+          'ang', '##ios', '##per', '##ms', ',', 'and', 'tend', 'to', '[SEP]', 
+          '[MASK]', 'produced', 'a', '[MASK]', '[MASK]', 'of', 'resin', ',', 
+          'which', '[MASK]', 'often', 'found', 'as', 'amber', '[SEP]']
+input_ids:  [101, 24604, 2015, 2024, 2651, 103, 2550, 2011, 17076, 10735, 4842,
+             5244, 1010, 1998, 7166, 2000, 102, 103, 2550, 1037, 103, 103, 1997,
+             24604, 1010, 2029, 103, 2411, 2179, 2004, 8994, 102]
+input_mask:  [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+              1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+segment_ids:  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1,
+               1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+masked_lm_positions:  [5, 17, 20, 21, 26]
+masked_lm_ids:  [2069, 3619, 2353, 2828, 2003]
+masked_lm_weights:  [1.0, 1.0, 1.0, 1.0, 1.0]
+next_sentence_labels:  [0]
+```
+
+In order to set up the next sentence prediction task, the script will load the
+entire input into memory. As such, it is recommended to run this script on a
+subset of the input data at a time.
+
+For example, you can run the script on each file shard in
+`~/datasets/sentence-split-data`, with the following:
+
+```shell
+for file in ~/datasets/sentence-split-data/*; do
+    output="~/datasets/pretraining-data/$(basename -- "$file" .txt).tfrecord"
+    python examples/bert/create_pretraining_data.py \
+        --input_files ${file} \
+        --vocab_file vocab.txt \
+        --output_file ${output}
+done
+```
+
+If memory is available, this could be further sped up by running this script
+multiple times in parallel:
+
+```shell
+NUM_JOBS=5
+for file in ~/datasets/sentence-split-data/*; do
+    output="~/datasets/pretraining-data/$(basename -- "$file" .txt).tfrecord"
+    echo python examples/bert/create_pretraining_data.py \
+        --input_files ${file} \
+        --vocab_file vocab.txt \
+        --output_file ${output}
+done | parallel -j ${NUM_JOBS}
+```
+
+### Running BERT pretraining
+
+After preprocessing, we can run pretraining with the `run_pretraining.py`
+script. This will train a model and save it to the `--saved_model_output`
+directory.
+
+```shell
+python3 examples/bert/run_pretraining.py \
+    --input_files $DIR/data/ \
+    --vocab_file $DIR/bert_vocab_uncased.txt \
+    --bert_config_file examples/bert/configs/bert_tiny.json \
+    --saved_model_output $DIR/model/
+```
+
+## Evaluating BERT with GLUE
+
+After pretraining, we can evaluate the performance of a BERT model with the
+General Language Understanding Evaluation (GLUE) benchmark. This will
+fine tune the model and running classification for a number of downstream tasks.
+
+The GLUE starter code repository hosts [a script](https://github.com/nyu-mll/GLUE-baselines/blob/master/download_glue_data.py).
+to download the GLUE dataset. You can download the data to `~/datasets/glue` as
+follows:
+
+```shell
+python ~/Downloads/download_glue_data.py --data_dir ~/datasets/glue
+```
+
+TODO(mattdangerw): Complete evaluation instructions.

--- a/examples/bert/__init__.py
+++ b/examples/bert/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/examples/bert/bert_model.py
+++ b/examples/bert/bert_model.py
@@ -1,0 +1,824 @@
+# Copyright 2022 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+from tensorflow import keras
+
+
+class SelfAttentionMask(tf.keras.layers.Layer):
+    """Create 3D attention mask from a 2D tensor mask.
+
+    inputs[0]: from_tensor: 2D or 3D Tensor of shape
+        [batch_size, from_seq_length, ...].
+    inputs[1]: to_mask: int32 Tensor of shape [batch_size, to_seq_length].
+
+    Returns:
+        float Tensor of shape [batch_size, from_seq_length, to_seq_length].
+    """
+
+    def call(self, inputs, to_mask=None):
+        if isinstance(inputs, list) and to_mask is None:
+            to_mask = inputs[1]
+            inputs = inputs[0]
+        from_shape = tf.shape(inputs)
+        batch_size = from_shape[0]
+        from_seq_length = from_shape[1]
+
+        to_shape = tf.shape(to_mask)
+        to_seq_length = to_shape[1]
+
+        to_mask = tf.cast(
+            tf.reshape(to_mask, [batch_size, 1, to_seq_length]),
+            dtype=inputs.dtype,
+        )
+
+        # We don't assume that `from_tensor` is a mask (although it could be).
+        # We don't actually care if we attend *from* padding tokens (only *to*
+        # padding) tokens so we create a tensor of all ones.
+        #
+        # `broadcast_ones` = [batch_size, from_seq_length, 1]
+        broadcast_ones = tf.ones(
+            shape=[batch_size, from_seq_length, 1], dtype=inputs.dtype
+        )
+
+        # Here we broadcast along two dimensions to create the mask.
+        mask = broadcast_ones * to_mask
+
+        return mask
+
+
+class TransformerEncoderBlock(tf.keras.layers.Layer):
+    """TransformerEncoderBlock layer.
+
+    This layer implements the Transformer Encoder from
+    "Attention Is All You Need". (https://arxiv.org/abs/1706.03762),
+    which combines a `tf.keras.layers.MultiHeadAttention` layer with a
+    two-layer feedforward network.
+
+    References:
+      [Attention Is All You Need](https://arxiv.org/abs/1706.03762)
+      [BERT: Pre-training of Deep Bidirectional Transformers for Language
+       Understanding](https://arxiv.org/abs/1810.04805)
+    """
+
+    def __init__(
+        self,
+        num_attention_heads,
+        inner_dim,
+        inner_activation,
+        output_range=None,
+        kernel_initializer="glorot_uniform",
+        bias_initializer="zeros",
+        kernel_regularizer=None,
+        bias_regularizer=None,
+        activity_regularizer=None,
+        kernel_constraint=None,
+        bias_constraint=None,
+        use_bias=True,
+        norm_first=False,
+        norm_epsilon=1e-12,
+        output_dropout=0.0,
+        attention_dropout=0.0,
+        inner_dropout=0.0,
+        attention_initializer=None,
+        attention_axes=None,
+        **kwargs
+    ):
+        """Initializes `TransformerEncoderBlock`.
+
+        Args:
+            num_attention_heads: Number of attention heads.
+            inner_dim: The output dimension of the first Dense layer in a
+                two-layer feedforward network.
+            inner_activation: The activation for the first Dense layer in a
+                two-layer feedforward network.
+            output_range: the sequence output range, [0, output_range) for
+                slicing the target sequence. `None` means the target sequence is
+                not sliced.
+            kernel_initializer: Initializer for dense layer kernels.
+            bias_initializer: Initializer for dense layer biases.
+            kernel_regularizer: Regularizer for dense layer kernels.
+            bias_regularizer: Regularizer for dense layer biases.
+            activity_regularizer: Regularizer for dense layer activity.
+            kernel_constraint: Constraint for dense layer kernels.
+            bias_constraint: Constraint for dense layer kernels.
+            use_bias: Whether to enable use_bias in attention layer. If set
+                False, use_bias in attention layer is disabled.
+            norm_first: Whether to normalize inputs to attention and
+                intermediate dense layers. If set False, output of attention and
+                intermediate dense layers is normalized.
+            norm_epsilon: Epsilon value to initialize normalization layers.
+            output_dropout: Dropout probability for the post-attention and
+                output dropout.
+            attention_dropout: Dropout probability for within the attention
+                layer.
+            inner_dropout: Dropout probability for the first Dense layer in a
+              two-layer feedforward network.
+            attention_initializer: Initializer for kernels of attention layers.
+                If set `None`, attention layers use kernel_initializer as
+                initializer for kernel.
+            attention_axes: axes over which the attention is applied. `None`
+                means attention over all axes, but batch, heads, and features.
+            **kwargs: keyword arguments.
+        """
+        util.filter_kwargs(kwargs)
+        super().__init__(**kwargs)
+
+        self._num_heads = num_attention_heads
+        self._inner_dim = inner_dim
+        self._inner_activation = inner_activation
+        self._attention_dropout = attention_dropout
+        self._attention_dropout_rate = attention_dropout
+        self._output_dropout = output_dropout
+        self._output_dropout_rate = output_dropout
+        self._output_range = output_range
+        self._kernel_initializer = tf.keras.initializers.get(kernel_initializer)
+        self._bias_initializer = tf.keras.initializers.get(bias_initializer)
+        self._kernel_regularizer = tf.keras.regularizers.get(kernel_regularizer)
+        self._bias_regularizer = tf.keras.regularizers.get(bias_regularizer)
+        self._activity_regularizer = tf.keras.regularizers.get(
+            activity_regularizer
+        )
+        self._kernel_constraint = tf.keras.constraints.get(kernel_constraint)
+        self._bias_constraint = tf.keras.constraints.get(bias_constraint)
+        self._use_bias = use_bias
+        self._norm_first = norm_first
+        self._norm_epsilon = norm_epsilon
+        self._inner_dropout = inner_dropout
+        if attention_initializer:
+            self._attention_initializer = tf.keras.initializers.get(
+                attention_initializer
+            )
+        else:
+            self._attention_initializer = self._kernel_initializer
+        self._attention_axes = attention_axes
+
+    def build(self, input_shape):
+        if isinstance(input_shape, tf.TensorShape):
+            input_tensor_shape = input_shape
+        elif isinstance(input_shape, (list, tuple)):
+            input_tensor_shape = tf.TensorShape(input_shape[0])
+        else:
+            raise ValueError(
+                "The type of input shape argument is not supported, got: %s"
+                % type(input_shape)
+            )
+        einsum_equation = "abc,cd->abd"
+        if len(input_tensor_shape.as_list()) > 3:
+            einsum_equation = "...bc,cd->...bd"
+        hidden_size = input_tensor_shape[-1]
+        if hidden_size % self._num_heads != 0:
+            raise ValueError(
+                "The input size (%d) is not a multiple of the number of "
+                "attention heads (%d)" % (hidden_size, self._num_heads)
+            )
+        self._attention_head_size = int(hidden_size // self._num_heads)
+        common_kwargs = dict(
+            bias_initializer=self._bias_initializer,
+            kernel_regularizer=self._kernel_regularizer,
+            bias_regularizer=self._bias_regularizer,
+            activity_regularizer=self._activity_regularizer,
+            kernel_constraint=self._kernel_constraint,
+            bias_constraint=self._bias_constraint,
+        )
+        self._attention_layer = tf.keras.layers.MultiHeadAttention(
+            num_heads=self._num_heads,
+            key_dim=self._attention_head_size,
+            dropout=self._attention_dropout,
+            use_bias=self._use_bias,
+            kernel_initializer=self._attention_initializer,
+            attention_axes=self._attention_axes,
+            name="self_attention",
+            **common_kwargs
+        )
+        self._attention_dropout = tf.keras.layers.Dropout(
+            rate=self._output_dropout
+        )
+        # Use float32 in layernorm for numeric stability.
+        # It is probably safe in mixed_float16, but we haven't validated this
+        # yet.
+        self._attention_layer_norm = tf.keras.layers.LayerNormalization(
+            name="self_attention_layer_norm",
+            axis=-1,
+            epsilon=self._norm_epsilon,
+            dtype=tf.float32,
+        )
+        self._intermediate_dense = tf.keras.layers.experimental.EinsumDense(
+            einsum_equation,
+            output_shape=(None, self._inner_dim),
+            bias_axes="d",
+            kernel_initializer=self._kernel_initializer,
+            name="intermediate",
+            **common_kwargs
+        )
+        policy = tf.keras.mixed_precision.global_policy()
+        if policy.name == "mixed_bfloat16":
+            # bfloat16 causes BERT with the LAMB optimizer to not converge
+            # as well, so we use float32.
+            # TODO(b/154538392): Investigate this.
+            policy = tf.float32
+        self._intermediate_activation_layer = tf.keras.layers.Activation(
+            self._inner_activation, dtype=policy
+        )
+        self._inner_dropout_layer = tf.keras.layers.Dropout(
+            rate=self._inner_dropout
+        )
+        self._output_dense = tf.keras.layers.experimental.EinsumDense(
+            einsum_equation,
+            output_shape=(None, hidden_size),
+            bias_axes="d",
+            name="output",
+            kernel_initializer=self._kernel_initializer,
+            **common_kwargs
+        )
+        self._output_dropout = tf.keras.layers.Dropout(
+            rate=self._output_dropout
+        )
+        # Use float32 in layernorm for numeric stability.
+        self._output_layer_norm = tf.keras.layers.LayerNormalization(
+            name="output_layer_norm",
+            axis=-1,
+            epsilon=self._norm_epsilon,
+            dtype=tf.float32,
+        )
+
+        super(TransformerEncoderBlock, self).build(input_shape)
+
+    def get_config(self):
+        config = {
+            "num_attention_heads": self._num_heads,
+            "inner_dim": self._inner_dim,
+            "inner_activation": self._inner_activation,
+            "output_dropout": self._output_dropout_rate,
+            "attention_dropout": self._attention_dropout_rate,
+            "output_range": self._output_range,
+            "kernel_initializer": tf.keras.initializers.serialize(
+                self._kernel_initializer
+            ),
+            "bias_initializer": tf.keras.initializers.serialize(
+                self._bias_initializer
+            ),
+            "kernel_regularizer": tf.keras.regularizers.serialize(
+                self._kernel_regularizer
+            ),
+            "bias_regularizer": tf.keras.regularizers.serialize(
+                self._bias_regularizer
+            ),
+            "activity_regularizer": tf.keras.regularizers.serialize(
+                self._activity_regularizer
+            ),
+            "kernel_constraint": tf.keras.constraints.serialize(
+                self._kernel_constraint
+            ),
+            "bias_constraint": tf.keras.constraints.serialize(
+                self._bias_constraint
+            ),
+            "use_bias": self._use_bias,
+            "norm_first": self._norm_first,
+            "norm_epsilon": self._norm_epsilon,
+            "inner_dropout": self._inner_dropout,
+            "attention_initializer": tf.keras.initializers.serialize(
+                self._attention_initializer
+            ),
+            "attention_axes": self._attention_axes,
+        }
+        base_config = super(TransformerEncoderBlock, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+    def call(self, inputs):
+        """Transformer self-attention encoder block call.
+
+        Args:
+            inputs: a single tensor or a list of tensors.
+                `input tensor` as the single sequence of embeddings.
+                [`input tensor`, `attention mask`] to have the additional
+                    attention mask.
+                [`query tensor`, `key value tensor`, `attention mask`] to have
+                    separate input streams for the query, and key/value to the
+                    multi-head attention.
+
+        Returns:
+          An output tensor with the same dimensions as input/query tensor.
+        """
+        if isinstance(inputs, (list, tuple)):
+            if len(inputs) == 2:
+                input_tensor, attention_mask = inputs
+                key_value = None
+            elif len(inputs) == 3:
+                input_tensor, key_value, attention_mask = inputs
+            else:
+                raise ValueError(
+                    "Unexpected inputs to %s with length at %d"
+                    % (self.__class__, len(inputs))
+                )
+        else:
+            input_tensor, key_value, attention_mask = (inputs, None, None)
+
+        if self._output_range:
+            if self._norm_first:
+                source_tensor = input_tensor[:, 0 : self._output_range, :]
+                input_tensor = self._attention_layer_norm(input_tensor)
+                if key_value is not None:
+                    key_value = self._attention_layer_norm(key_value)
+            target_tensor = input_tensor[:, 0 : self._output_range, :]
+            if attention_mask is not None:
+                attention_mask = attention_mask[:, 0 : self._output_range, :]
+        else:
+            if self._norm_first:
+                source_tensor = input_tensor
+                input_tensor = self._attention_layer_norm(input_tensor)
+                if key_value is not None:
+                    key_value = self._attention_layer_norm(key_value)
+            target_tensor = input_tensor
+
+        if key_value is None:
+            key_value = input_tensor
+        attention_output = self._attention_layer(
+            query=target_tensor, value=key_value, attention_mask=attention_mask
+        )
+        attention_output = self._attention_dropout(attention_output)
+        if self._norm_first:
+            attention_output = source_tensor + attention_output
+        else:
+            attention_output = self._attention_layer_norm(
+                target_tensor + attention_output
+            )
+        if self._norm_first:
+            source_attention_output = attention_output
+            attention_output = self._output_layer_norm(attention_output)
+        inner_output = self._intermediate_dense(attention_output)
+        inner_output = self._intermediate_activation_layer(inner_output)
+        inner_output = self._inner_dropout_layer(inner_output)
+        layer_output = self._output_dense(inner_output)
+        layer_output = self._output_dropout(layer_output)
+
+        if self._norm_first:
+            return source_attention_output + layer_output
+
+        # During mixed precision training, layer norm output is always fp32 for
+        # now. Casts fp32 for the subsequent add.
+        layer_output = tf.cast(layer_output, tf.float32)
+        return self._output_layer_norm(layer_output + attention_output)
+
+
+class PositionEmbedding(tf.keras.layers.Layer):
+    """Creates a positional embedding.
+
+    Example:
+    ```python
+    position_embedding = PositionEmbedding(max_length=100)
+    inputs = tf.keras.Input((100, 32), dtype=tf.float32)
+    outputs = position_embedding(inputs)
+    ```
+
+    Args:
+        max_length: The maximum size of the dynamic sequence.
+        initializer: The initializer to use for the embedding weights. Defaults
+            to "glorot_uniform".
+        seq_axis: The axis of the input tensor where we add the embeddings.
+
+    Reference: This layer creates a positional embedding as described in
+    [BERT: Pre-training of Deep Bidirectional Transformers for Language
+    Understanding](https://arxiv.org/abs/1810.04805).
+    """
+
+    def __init__(
+        self, max_length, initializer="glorot_uniform", seq_axis=1, **kwargs
+    ):
+
+        super(PositionEmbedding, self).__init__(**kwargs)
+        if max_length is None:
+            raise ValueError("`max_length` must be an Integer, not `None`.")
+        self._max_length = max_length
+        self._initializer = tf.keras.initializers.get(initializer)
+        self._seq_axis = seq_axis
+
+    def get_config(self):
+        config = {
+            "max_length": self._max_length,
+            "initializer": tf.keras.initializers.serialize(self._initializer),
+            "seq_axis": self._seq_axis,
+        }
+        base_config = super(PositionEmbedding, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+    def build(self, input_shape):
+        dimension_list = input_shape.as_list()
+        width = dimension_list[-1]
+        weight_sequence_length = self._max_length
+
+        self._position_embeddings = self.add_weight(
+            "embeddings",
+            shape=[weight_sequence_length, width],
+            initializer=self._initializer,
+        )
+
+        super(PositionEmbedding, self).build(input_shape)
+
+    def call(self, inputs):
+        input_shape = tf.shape(inputs)
+        actual_seq_len = input_shape[self._seq_axis]
+        position_embeddings = self._position_embeddings[:actual_seq_len, :]
+        new_shape = [1 for _ in inputs.get_shape().as_list()]
+        new_shape[self._seq_axis] = actual_seq_len
+        new_shape[-1] = position_embeddings.get_shape().as_list()[-1]
+        position_embeddings = tf.reshape(position_embeddings, new_shape)
+        return tf.broadcast_to(position_embeddings, input_shape)
+
+
+class OnDeviceEmbedding(tf.keras.layers.Layer):
+    """Performs an embedding lookup suitable for accelerator devices.
+
+    This layer uses either tf.gather or tf.one_hot to translate integer indices
+    to float embeddings.
+
+    Args:
+        vocab_size: Number of elements in the vocabulary.
+        embedding_width: Output size of the embedding layer.
+        initializer: The initializer to use for the embedding weights. Defaults
+            to "glorot_uniform".
+        use_one_hot: Whether to use tf.one_hot over tf.gather for the embedding
+            lookup. Defaults to False (that is, using tf.gather). Setting this
+            option to True may improve performance, especially on small
+            vocabulary sizes, but will generally require more memory.
+        scale_factor: Whether to scale the output embeddings. Defaults to None
+            (that is, not to scale). Setting this option to a float will let
+            values in output embeddings multiplied by scale_factor.
+    """
+
+    def __init__(
+        self,
+        vocab_size,
+        embedding_width,
+        initializer="glorot_uniform",
+        use_one_hot=False,
+        scale_factor=None,
+        **kwargs
+    ):
+
+        super(OnDeviceEmbedding, self).__init__(**kwargs)
+        self._vocab_size = vocab_size
+        self._embedding_width = embedding_width
+        self._initializer = initializer
+        self._use_one_hot = use_one_hot
+        self._scale_factor = scale_factor
+
+    def get_config(self):
+        config = {
+            "vocab_size": self._vocab_size,
+            "embedding_width": self._embedding_width,
+            "initializer": self._initializer,
+            "use_one_hot": self._use_one_hot,
+            "scale_factor": self._scale_factor,
+        }
+        base_config = super(OnDeviceEmbedding, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+    def build(self, input_shape):
+        self.embeddings = self.add_weight(
+            "embeddings",
+            shape=[self._vocab_size, self._embedding_width],
+            initializer=self._initializer,
+            dtype=tf.float32,
+        )
+
+        super(OnDeviceEmbedding, self).build(input_shape)
+
+    def call(self, inputs):
+        flat_inputs = tf.reshape(inputs, [-1])
+        if self._use_one_hot:
+            dtype = self._compute_dtype
+            if not tf.dtypes.as_dtype(dtype).is_floating:
+                # TensorFlow 1 compatibility. In TF1, self._compute_dtype is
+                # int32 instead of a floating-point dtype, as the dtype is
+                # inferred from the dtype of the inputs
+                dtype = tf.float32
+            one_hot_data = tf.one_hot(
+                flat_inputs, depth=self._vocab_size, dtype=dtype
+            )
+            embeddings = tf.matmul(one_hot_data, self.embeddings)
+        else:
+            embeddings = tf.gather(self.embeddings, flat_inputs)
+
+        embeddings = tf.reshape(
+            embeddings,
+            # Work around b/142213824: prefer concat to shape over a Python
+            # list.
+            tf.concat([tf.shape(inputs), [self._embedding_width]], axis=0),
+        )
+        embeddings.set_shape(inputs.shape.as_list() + [self._embedding_width])
+        if self._scale_factor:
+            embeddings *= self._scale_factor
+        return embeddings
+
+    @property
+    def vocab_size(self):
+        return self._vocab_size
+
+    @property
+    def embedding_width(self):
+        return self._embedding_width
+
+
+class BertEncoderV2(tf.keras.layers.Layer):
+    """Bi-directional Transformer-based encoder network.
+
+    This network implements a bi-directional Transformer-based encoder as
+    described in "BERT: Pre-training of Deep Bidirectional Transformers for
+    Language Understanding" (https://arxiv.org/abs/1810.04805). It includes the
+    embedding lookups and transformer layers, but not the masked language model
+    or classification task networks.
+
+    The default values for this object are taken from the BERT-Base
+    implementation in "BERT: Pre-training of Deep Bidirectional Transformers for
+    Language Understanding".
+
+    Args:
+        vocab_size: The size of the token vocabulary.
+        hidden_size: The size of the transformer hidden layers.
+        num_layers: The number of transformer layers.
+        num_attention_heads: The number of attention heads for each transformer.
+            The hidden size must be divisible by the number of attention heads.
+        max_sequence_length: The maximum sequence length that this encoder can
+            consume. If None, max_sequence_length uses the value from sequence
+            length. This determines the variable shape for positional
+            embeddings.
+        type_vocab_size: The number of types that the 'type_ids' input can take.
+        inner_dim: The output dimension of the first Dense layer in a two-layer
+          feedforward network for each transformer.
+        inner_activation: The activation for the first Dense layer in a
+            two-layer feedforward network for each transformer.
+        output_dropout: Dropout probability for the post-attention and output
+          dropout.
+        attention_dropout: The dropout rate to use for the attention layers
+            within the transformer layers.
+        initializer: The initialzer to use for all weights in this encoder.
+        output_range: The sequence output range, [0, output_range), by slicing
+            the target sequence of the last transformer layer. `None` means the
+            entire target sequence will attend to the source sequence, which
+            yields the full output.
+        embedding_width: The width of the word embeddings. If the embedding
+            width is not equal to hidden size, embedding parameters will be
+            factorized into two matrices in the shape of ['vocab_size',
+            'embedding_width'] and ['embedding_width', 'hidden_size']
+            ('embedding_width' is usually much smaller than 'hidden_size').
+        embedding_layer: An optional Layer instance which will be called to
+            generate embeddings for the input word IDs.
+        norm_first: Whether to normalize inputs to attention and intermediate
+            dense layers. If set False, output of attention and intermediate
+            dense layers is normalized.
+        with_dense_inputs: Whether to accept dense embeddings as the input.
+    """
+
+    def __init__(
+        self,
+        vocab_size: int,
+        hidden_size: int = 768,
+        num_layers: int = 12,
+        num_attention_heads: int = 12,
+        max_sequence_length: int = 512,
+        type_vocab_size: int = 16,
+        inner_dim: int = 3072,
+        inner_activation: _Activation = _approx_gelu,
+        output_dropout: float = 0.1,
+        attention_dropout: float = 0.1,
+        initializer: _Initializer = tf.keras.initializers.TruncatedNormal(
+            stddev=0.02
+        ),
+        output_range: Optional[int] = None,
+        embedding_width: Optional[int] = None,
+        embedding_layer: Optional[tf.keras.layers.Layer] = None,
+        norm_first: bool = False,
+        with_dense_inputs: bool = False,
+        **kwargs
+    ):
+        # Pops kwargs that are used in V1 implementation.
+        if "dict_outputs" in kwargs:
+            kwargs.pop("dict_outputs")
+        if "return_all_encoder_outputs" in kwargs:
+            kwargs.pop("return_all_encoder_outputs")
+        if "intermediate_size" in kwargs:
+            inner_dim = kwargs.pop("intermediate_size")
+        if "activation" in kwargs:
+            inner_activation = kwargs.pop("activation")
+        if "dropout_rate" in kwargs:
+            output_dropout = kwargs.pop("dropout_rate")
+        if "attention_dropout_rate" in kwargs:
+            attention_dropout = kwargs.pop("attention_dropout_rate")
+        super().__init__(**kwargs)
+
+        activation = tf.keras.activations.get(inner_activation)
+        initializer = tf.keras.initializers.get(initializer)
+
+        if embedding_width is None:
+            embedding_width = hidden_size
+
+        if embedding_layer is None:
+            self._embedding_layer = layers.OnDeviceEmbedding(
+                vocab_size=vocab_size,
+                embedding_width=embedding_width,
+                initializer=initializer,
+                name="word_embeddings",
+            )
+        else:
+            self._embedding_layer = embedding_layer
+
+        self._position_embedding_layer = layers.PositionEmbedding(
+            initializer=initializer,
+            max_length=max_sequence_length,
+            name="position_embedding",
+        )
+
+        self._type_embedding_layer = layers.OnDeviceEmbedding(
+            vocab_size=type_vocab_size,
+            embedding_width=embedding_width,
+            initializer=initializer,
+            use_one_hot=True,
+            name="type_embeddings",
+        )
+
+        self._embedding_norm_layer = tf.keras.layers.LayerNormalization(
+            name="embeddings/layer_norm",
+            axis=-1,
+            epsilon=1e-12,
+            dtype=tf.float32,
+        )
+
+        self._embedding_dropout = tf.keras.layers.Dropout(
+            rate=output_dropout, name="embedding_dropout"
+        )
+
+        # We project the 'embedding' output to 'hidden_size' if it is not
+        # already 'hidden_size'.
+        self._embedding_projection = None
+        if embedding_width != hidden_size:
+            self._embedding_projection = (
+                tf.keras.layers.experimental.EinsumDense(
+                    "...x,xy->...y",
+                    output_shape=hidden_size,
+                    bias_axes="y",
+                    kernel_initializer=initializer,
+                    name="embedding_projection",
+                )
+            )
+
+        self._transformer_layers = []
+        self._attention_mask_layer = layers.SelfAttentionMask(
+            name="self_attention_mask"
+        )
+        for i in range(num_layers):
+            layer = layers.TransformerEncoderBlock(
+                num_attention_heads=num_attention_heads,
+                inner_dim=inner_dim,
+                inner_activation=inner_activation,
+                output_dropout=output_dropout,
+                attention_dropout=attention_dropout,
+                norm_first=norm_first,
+                output_range=output_range if i == num_layers - 1 else None,
+                kernel_initializer=initializer,
+                name="transformer/layer_%d" % i,
+            )
+            self._transformer_layers.append(layer)
+
+        self._pooler_layer = tf.keras.layers.Dense(
+            units=hidden_size,
+            activation="tanh",
+            kernel_initializer=initializer,
+            name="pooler_transform",
+        )
+
+        self._config = {
+            "vocab_size": vocab_size,
+            "hidden_size": hidden_size,
+            "num_layers": num_layers,
+            "num_attention_heads": num_attention_heads,
+            "max_sequence_length": max_sequence_length,
+            "type_vocab_size": type_vocab_size,
+            "inner_dim": inner_dim,
+            "inner_activation": tf.keras.activations.serialize(activation),
+            "output_dropout": output_dropout,
+            "attention_dropout": attention_dropout,
+            "initializer": tf.keras.initializers.serialize(initializer),
+            "output_range": output_range,
+            "embedding_width": embedding_width,
+            "embedding_layer": embedding_layer,
+            "norm_first": norm_first,
+            "with_dense_inputs": with_dense_inputs,
+        }
+        if with_dense_inputs:
+            self.inputs = dict(
+                input_word_ids=tf.keras.Input(shape=(None,), dtype=tf.int32),
+                input_mask=tf.keras.Input(shape=(None,), dtype=tf.int32),
+                input_type_ids=tf.keras.Input(shape=(None,), dtype=tf.int32),
+                dense_inputs=tf.keras.Input(
+                    shape=(None, embedding_width), dtype=tf.float32
+                ),
+                dense_mask=tf.keras.Input(shape=(None,), dtype=tf.int32),
+                dense_type_ids=tf.keras.Input(shape=(None,), dtype=tf.int32),
+            )
+        else:
+            self.inputs = dict(
+                input_word_ids=tf.keras.Input(shape=(None,), dtype=tf.int32),
+                input_mask=tf.keras.Input(shape=(None,), dtype=tf.int32),
+                input_type_ids=tf.keras.Input(shape=(None,), dtype=tf.int32),
+            )
+
+    def call(self, inputs):
+        word_embeddings = None
+        if isinstance(inputs, dict):
+            word_ids = inputs.get("input_word_ids")
+            mask = inputs.get("input_mask")
+            type_ids = inputs.get("input_type_ids")
+            word_embeddings = inputs.get("input_word_embeddings", None)
+
+            dense_inputs = inputs.get("dense_inputs", None)
+            dense_mask = inputs.get("dense_mask", None)
+            dense_type_ids = inputs.get("dense_type_ids", None)
+        else:
+            raise ValueError("Unexpected inputs type to %s." % self.__class__)
+
+        if word_embeddings is None:
+            word_embeddings = self._embedding_layer(word_ids)
+
+        if dense_inputs is not None:
+            # Concat the dense embeddings at sequence end.
+            word_embeddings = tf.concat([word_embeddings, dense_inputs], axis=1)
+            type_ids = tf.concat([type_ids, dense_type_ids], axis=1)
+            mask = tf.concat([mask, dense_mask], axis=1)
+
+        # absolute position embeddings.
+        position_embeddings = self._position_embedding_layer(word_embeddings)
+        type_embeddings = self._type_embedding_layer(type_ids)
+
+        embeddings = word_embeddings + position_embeddings + type_embeddings
+        embeddings = self._embedding_norm_layer(embeddings)
+        embeddings = self._embedding_dropout(embeddings)
+
+        if self._embedding_projection is not None:
+            embeddings = self._embedding_projection(embeddings)
+
+        attention_mask = self._attention_mask_layer(embeddings, mask)
+
+        encoder_outputs = []
+        x = embeddings
+        for layer in self._transformer_layers:
+            x = layer([x, attention_mask])
+            encoder_outputs.append(x)
+
+        last_encoder_output = encoder_outputs[-1]
+        first_token_tensor = last_encoder_output[:, 0, :]
+        pooled_output = self._pooler_layer(first_token_tensor)
+
+        return dict(
+            sequence_output=encoder_outputs[-1],
+            pooled_output=pooled_output,
+            encoder_outputs=encoder_outputs,
+        )
+
+    def get_embedding_table(self):
+        return self._embedding_layer.embeddings
+
+    def get_embedding_layer(self):
+        return self._embedding_layer
+
+    def get_config(self):
+        return dict(self._config)
+
+    @property
+    def transformer_layers(self):
+        """List of Transformer layers in the encoder."""
+        return self._transformer_layers
+
+    @property
+    def pooler_layer(self):
+        """The pooler dense layer after the transformer layers."""
+        return self._pooler_layer
+
+    @classmethod
+    def from_config(cls, config, custom_objects=None):
+        if (
+            "embedding_layer" in config
+            and config["embedding_layer"] is not None
+        ):
+            warn_string = (
+                "You are reloading a model that was saved with a "
+                "potentially-shared embedding layer object. If you contine to "
+                "train this model, the embedding layer will no longer be "
+                "shared. To work around this, load the model outside of the "
+                "Keras API."
+            )
+            print("WARNING: " + warn_string)
+            logging.warn(warn_string)
+
+        return cls(**config)

--- a/examples/bert/bert_utils.py
+++ b/examples/bert/bert_utils.py
@@ -1,0 +1,30 @@
+# Copyright 2022 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utility files for BERT scripts."""
+
+import glob
+import os
+
+
+def list_filenames_for_arg(arg_pattern):
+    """List filenames from a comma separated list of files, dirs, and globs."""
+    input_filenames = []
+    for pattern in arg_pattern.split(","):
+        pattern = os.path.expanduser(pattern)
+        if os.path.isdir(pattern):
+            pattern = os.path.join(pattern, "**", "*")
+        for filename in glob.iglob(pattern, recursive=True):
+            if not os.path.isdir(filename):
+                input_filenames.append(filename)
+    return input_filenames

--- a/examples/bert/configs/bert_base.json
+++ b/examples/bert/configs/bert_base.json
@@ -1,0 +1,11 @@
+{
+  "num_layers": 12,
+  "hidden_size": 768,
+  "hidden_dropout": 0.1,
+  "num_attention_heads": 12,
+  "attention_dropout": 0.1,
+  "inner_size": 3072,
+  "inner_activation": "gelu",
+  "initializer_range": 0.02,
+  "max_sequence_length": 512
+}

--- a/examples/bert/configs/bert_large.json
+++ b/examples/bert/configs/bert_large.json
@@ -1,0 +1,11 @@
+{
+  "num_layers": 24,
+  "hidden_size": 1024,
+  "hidden_dropout": 0.1,
+  "num_attention_heads": 16,
+  "attention_dropout": 0.1,
+  "inner_size": 4096,
+  "inner_activation": "gelu",
+  "initializer_range": 0.02,
+  "max_sequence_length": 512
+}

--- a/examples/bert/configs/bert_medium.json
+++ b/examples/bert/configs/bert_medium.json
@@ -1,0 +1,11 @@
+{
+  "num_layers": 8,
+  "hidden_size": 512,
+  "hidden_dropout": 0.1,
+  "num_attention_heads": 8,
+  "attention_dropout": 0.1,
+  "inner_size": 2048,
+  "inner_activation": "gelu",
+  "initializer_range": 0.02,
+  "max_sequence_length": 512
+}

--- a/examples/bert/configs/bert_mini.json
+++ b/examples/bert/configs/bert_mini.json
@@ -1,0 +1,11 @@
+{
+  "num_layers": 4,
+  "hidden_size": 256,
+  "hidden_dropout": 0.1,
+  "num_attention_heads": 4,
+  "attention_dropout": 0.1,
+  "inner_size": 1024,
+  "inner_activation": "gelu",
+  "initializer_range": 0.02,
+  "max_sequence_length": 512
+}

--- a/examples/bert/configs/bert_small.json
+++ b/examples/bert/configs/bert_small.json
@@ -1,0 +1,11 @@
+{
+  "num_layers": 4,
+  "hidden_size": 512,
+  "hidden_dropout": 0.1,
+  "num_attention_heads": 8,
+  "attention_dropout": 0.1,
+  "inner_size": 2048,
+  "inner_activation": "gelu",
+  "initializer_range": 0.02,
+  "max_sequence_length": 512
+}

--- a/examples/bert/configs/bert_tiny.json
+++ b/examples/bert/configs/bert_tiny.json
@@ -1,0 +1,11 @@
+{
+  "num_layers": 2,
+  "hidden_size": 128,
+  "hidden_dropout": 0.1,
+  "num_attention_heads": 2,
+  "attention_dropout": 0.1,
+  "inner_size": 512,
+  "inner_activation": "gelu",
+  "initializer_range": 0.02,
+  "max_sequence_length": 512
+}

--- a/examples/bert/create_pretraining_data.py
+++ b/examples/bert/create_pretraining_data.py
@@ -1,0 +1,795 @@
+# Copyright 2022 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Create masked LM/next sentence masked_lm TF examples for BERT."""
+
+import collections
+import itertools
+import random
+
+# Import libraries
+from absl import app
+from absl import flags
+from absl import logging
+import tensorflow as tf
+
+from official.nlp.bert import tokenization
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string(
+    "input_file",
+    None,
+    "Input raw text file (or comma-separated list of files).",
+)
+
+flags.DEFINE_string(
+    "output_file",
+    None,
+    "Output TF example file (or comma-separated list of files).",
+)
+
+flags.DEFINE_string(
+    "vocab_file",
+    None,
+    "The vocabulary file that the BERT model was trained on.",
+)
+
+flags.DEFINE_bool(
+    "do_lower_case",
+    True,
+    "Whether to lower case the input text. Should be True for uncased "
+    "models and False for cased models.",
+)
+
+flags.DEFINE_bool(
+    "do_whole_word_mask",
+    False,
+    "Whether to use whole word masking rather than per-WordPiece masking.",
+)
+
+flags.DEFINE_integer(
+    "max_ngram_size",
+    None,
+    "Mask contiguous whole words (n-grams) of up to `max_ngram_size` using a "
+    "weighting scheme to favor shorter n-grams. "
+    "Note: `--do_whole_word_mask=True` must also be set when n-gram masking.",
+)
+
+flags.DEFINE_bool(
+    "gzip_compress",
+    False,
+    "Whether to use `GZIP` compress option to get compressed TFRecord files.",
+)
+
+flags.DEFINE_bool(
+    "use_v2_feature_names",
+    False,
+    "Whether to use the feature names consistent with the models.",
+)
+
+flags.DEFINE_integer("max_seq_length", 128, "Maximum sequence length.")
+
+flags.DEFINE_integer(
+    "max_predictions_per_seq",
+    20,
+    "Maximum number of masked LM predictions per sequence.",
+)
+
+flags.DEFINE_integer("random_seed", 12345, "Random seed for data generation.")
+
+flags.DEFINE_integer(
+    "dupe_factor",
+    10,
+    "Number of times to duplicate the input data (with different masks).",
+)
+
+flags.DEFINE_float("masked_lm_prob", 0.15, "Masked LM probability.")
+
+flags.DEFINE_float(
+    "short_seq_prob",
+    0.1,
+    "Probability of creating sequences which are shorter than the "
+    "maximum length.",
+)
+
+
+class TrainingInstance(object):
+    """A single training instance (sentence pair)."""
+
+    def __init__(
+        self,
+        tokens,
+        segment_ids,
+        masked_lm_positions,
+        masked_lm_labels,
+        is_random_next,
+    ):
+        self.tokens = tokens
+        self.segment_ids = segment_ids
+        self.is_random_next = is_random_next
+        self.masked_lm_positions = masked_lm_positions
+        self.masked_lm_labels = masked_lm_labels
+
+    def __str__(self):
+        s = ""
+        s += "tokens: %s\n" % (
+            " ".join([tokenization.printable_text(x) for x in self.tokens])
+        )
+        s += "segment_ids: %s\n" % (
+            " ".join([str(x) for x in self.segment_ids])
+        )
+        s += "is_random_next: %s\n" % self.is_random_next
+        s += "masked_lm_positions: %s\n" % (
+            " ".join([str(x) for x in self.masked_lm_positions])
+        )
+        s += "masked_lm_labels: %s\n" % (
+            " ".join(
+                [tokenization.printable_text(x) for x in self.masked_lm_labels]
+            )
+        )
+        s += "\n"
+        return s
+
+    def __repr__(self):
+        return self.__str__()
+
+
+def write_instance_to_example_files(
+    instances,
+    tokenizer,
+    max_seq_length,
+    max_predictions_per_seq,
+    output_files,
+    gzip_compress,
+    use_v2_feature_names,
+):
+    """Creates TF example files from `TrainingInstance`s."""
+    writers = []
+    for output_file in output_files:
+        writers.append(
+            tf.io.TFRecordWriter(
+                output_file, options="GZIP" if gzip_compress else ""
+            )
+        )
+
+    writer_index = 0
+
+    total_written = 0
+    for (inst_index, instance) in enumerate(instances):
+        input_ids = tokenizer.convert_tokens_to_ids(instance.tokens)
+        input_mask = [1] * len(input_ids)
+        segment_ids = list(instance.segment_ids)
+        assert len(input_ids) <= max_seq_length
+
+        while len(input_ids) < max_seq_length:
+            input_ids.append(0)
+            input_mask.append(0)
+            segment_ids.append(0)
+
+        assert len(input_ids) == max_seq_length
+        assert len(input_mask) == max_seq_length
+        assert len(segment_ids) == max_seq_length
+
+        masked_lm_positions = list(instance.masked_lm_positions)
+        masked_lm_ids = tokenizer.convert_tokens_to_ids(
+            instance.masked_lm_labels
+        )
+        masked_lm_weights = [1.0] * len(masked_lm_ids)
+
+        while len(masked_lm_positions) < max_predictions_per_seq:
+            masked_lm_positions.append(0)
+            masked_lm_ids.append(0)
+            masked_lm_weights.append(0.0)
+
+        next_sentence_label = 1 if instance.is_random_next else 0
+
+        features = collections.OrderedDict()
+        if use_v2_feature_names:
+            features["input_word_ids"] = create_int_feature(input_ids)
+            features["input_type_ids"] = create_int_feature(segment_ids)
+        else:
+            features["input_ids"] = create_int_feature(input_ids)
+            features["segment_ids"] = create_int_feature(segment_ids)
+
+        features["input_mask"] = create_int_feature(input_mask)
+        features["masked_lm_positions"] = create_int_feature(
+            masked_lm_positions
+        )
+        features["masked_lm_ids"] = create_int_feature(masked_lm_ids)
+        features["masked_lm_weights"] = create_float_feature(masked_lm_weights)
+        features["next_sentence_labels"] = create_int_feature(
+            [next_sentence_label]
+        )
+
+        tf_example = tf.train.Example(
+            features=tf.train.Features(feature=features)
+        )
+
+        writers[writer_index].write(tf_example.SerializeToString())
+        writer_index = (writer_index + 1) % len(writers)
+
+        total_written += 1
+
+        if inst_index < 20:
+            logging.info("*** Example ***")
+            logging.info(
+                "tokens: %s",
+                " ".join(
+                    [tokenization.printable_text(x) for x in instance.tokens]
+                ),
+            )
+
+            for feature_name in features.keys():
+                feature = features[feature_name]
+                values = []
+                if feature.int64_list.value:
+                    values = feature.int64_list.value
+                elif feature.float_list.value:
+                    values = feature.float_list.value
+                logging.info(
+                    "%s: %s", feature_name, " ".join([str(x) for x in values])
+                )
+
+    for writer in writers:
+        writer.close()
+
+    logging.info("Wrote %d total instances", total_written)
+
+
+def create_int_feature(values):
+    feature = tf.train.Feature(
+        int64_list=tf.train.Int64List(value=list(values))
+    )
+    return feature
+
+
+def create_float_feature(values):
+    feature = tf.train.Feature(
+        float_list=tf.train.FloatList(value=list(values))
+    )
+    return feature
+
+
+def create_training_instances(
+    input_files,
+    tokenizer,
+    max_seq_length,
+    dupe_factor,
+    short_seq_prob,
+    masked_lm_prob,
+    max_predictions_per_seq,
+    rng,
+    do_whole_word_mask=False,
+    max_ngram_size=None,
+):
+    """Create `TrainingInstance`s from raw text."""
+    all_documents = [[]]
+
+    # Input file format:
+    # (1) One sentence per line. These should ideally be actual sentences, not
+    # entire paragraphs or arbitrary spans of text. (Because we use the
+    # sentence boundaries for the "next sentence prediction" task).
+    # (2) Blank lines between documents. Document boundaries are needed so
+    # that the "next sentence prediction" task doesn't span between documents.
+    for input_file in input_files:
+        with tf.io.gfile.GFile(input_file, "rb") as reader:
+            while True:
+                line = tokenization.convert_to_unicode(reader.readline())
+                if not line:
+                    break
+                line = line.strip()
+
+                # Empty lines are used as document delimiters
+                if not line:
+                    all_documents.append([])
+                tokens = tokenizer.tokenize(line)
+                if tokens:
+                    all_documents[-1].append(tokens)
+
+    # Remove empty documents
+    all_documents = [x for x in all_documents if x]
+    rng.shuffle(all_documents)
+
+    vocab_words = list(tokenizer.vocab.keys())
+    instances = []
+    for _ in range(dupe_factor):
+        for document_index in range(len(all_documents)):
+            instances.extend(
+                create_instances_from_document(
+                    all_documents,
+                    document_index,
+                    max_seq_length,
+                    short_seq_prob,
+                    masked_lm_prob,
+                    max_predictions_per_seq,
+                    vocab_words,
+                    rng,
+                    do_whole_word_mask,
+                    max_ngram_size,
+                )
+            )
+
+    rng.shuffle(instances)
+    return instances
+
+
+def create_instances_from_document(
+    all_documents,
+    document_index,
+    max_seq_length,
+    short_seq_prob,
+    masked_lm_prob,
+    max_predictions_per_seq,
+    vocab_words,
+    rng,
+    do_whole_word_mask=False,
+    max_ngram_size=None,
+):
+    """Creates `TrainingInstance`s for a single document."""
+    document = all_documents[document_index]
+
+    # Account for [CLS], [SEP], [SEP]
+    max_num_tokens = max_seq_length - 3
+
+    # We *usually* want to fill up the entire sequence since we are padding
+    # to `max_seq_length` anyways, so short sequences are generally wasted
+    # computation. However, we *sometimes*
+    # (i.e., short_seq_prob == 0.1 == 10% of the time) want to use shorter
+    # sequences to minimize the mismatch between pre-training and fine-tuning.
+    # The `target_seq_length` is just a rough target however, whereas
+    # `max_seq_length` is a hard limit.
+    target_seq_length = max_num_tokens
+    if rng.random() < short_seq_prob:
+        target_seq_length = rng.randint(2, max_num_tokens)
+
+    # We DON'T just concatenate all of the tokens from a document into a long
+    # sequence and choose an arbitrary split point because this would make the
+    # next sentence prediction task too easy. Instead, we split the input into
+    # segments "A" and "B" based on the actual "sentences" provided by the user
+    # input.
+    instances = []
+    current_chunk = []
+    current_length = 0
+    i = 0
+    while i < len(document):
+        segment = document[i]
+        current_chunk.append(segment)
+        current_length += len(segment)
+        if i == len(document) - 1 or current_length >= target_seq_length:
+            if current_chunk:
+                # `a_end` is how many segments from `current_chunk` go into the
+                # `A` (first) sentence.
+                a_end = 1
+                if len(current_chunk) >= 2:
+                    a_end = rng.randint(1, len(current_chunk) - 1)
+
+                tokens_a = []
+                for j in range(a_end):
+                    tokens_a.extend(current_chunk[j])
+
+                tokens_b = []
+                # Random next
+                is_random_next = False
+                if len(current_chunk) == 1 or rng.random() < 0.5:
+                    is_random_next = True
+                    target_b_length = target_seq_length - len(tokens_a)
+
+                    # This should rarely go for more than one iteration for
+                    # large corpora. However, just to be careful, we try to make
+                    # sure that the random document is not the same as the
+                    # document we're processing.
+                    for _ in range(10):
+                        random_document_index = rng.randint(
+                            0, len(all_documents) - 1
+                        )
+                        if random_document_index != document_index:
+                            break
+
+                    random_document = all_documents[random_document_index]
+                    random_start = rng.randint(0, len(random_document) - 1)
+                    for j in range(random_start, len(random_document)):
+                        tokens_b.extend(random_document[j])
+                        if len(tokens_b) >= target_b_length:
+                            break
+                    # We didn't actually use these segments so we "put them
+                    # back" so they don't go to waste.
+                    num_unused_segments = len(current_chunk) - a_end
+                    i -= num_unused_segments
+                # Actual next
+                else:
+                    is_random_next = False
+                    for j in range(a_end, len(current_chunk)):
+                        tokens_b.extend(current_chunk[j])
+                truncate_seq_pair(tokens_a, tokens_b, max_num_tokens, rng)
+
+                assert len(tokens_a) >= 1
+                assert len(tokens_b) >= 1
+
+                tokens = []
+                segment_ids = []
+                tokens.append("[CLS]")
+                segment_ids.append(0)
+                for token in tokens_a:
+                    tokens.append(token)
+                    segment_ids.append(0)
+
+                tokens.append("[SEP]")
+                segment_ids.append(0)
+
+                for token in tokens_b:
+                    tokens.append(token)
+                    segment_ids.append(1)
+                tokens.append("[SEP]")
+                segment_ids.append(1)
+
+                (
+                    tokens,
+                    masked_lm_positions,
+                    masked_lm_labels,
+                ) = create_masked_lm_predictions(
+                    tokens,
+                    masked_lm_prob,
+                    max_predictions_per_seq,
+                    vocab_words,
+                    rng,
+                    do_whole_word_mask,
+                    max_ngram_size,
+                )
+                instance = TrainingInstance(
+                    tokens=tokens,
+                    segment_ids=segment_ids,
+                    is_random_next=is_random_next,
+                    masked_lm_positions=masked_lm_positions,
+                    masked_lm_labels=masked_lm_labels,
+                )
+                instances.append(instance)
+            current_chunk = []
+            current_length = 0
+        i += 1
+
+    return instances
+
+
+MaskedLmInstance = collections.namedtuple(
+    "MaskedLmInstance", ["index", "label"]
+)
+
+# A _Gram is a [half-open) interval of token indices which form a word.
+# E.g.,
+#   words:  ["The", "doghouse"]
+#   tokens: ["The", "dog", "##house"]
+#   grams:  [(0,1), (1,3)]
+_Gram = collections.namedtuple("_Gram", ["begin", "end"])
+
+
+def _window(iterable, size):
+    """Helper to create a sliding window iterator with a given size.
+
+    E.g.,
+      input = [1, 2, 3, 4]
+      _window(input, 1) => [1], [2], [3], [4]
+      _window(input, 2) => [1, 2], [2, 3], [3, 4]
+      _window(input, 3) => [1, 2, 3], [2, 3, 4]
+      _window(input, 4) => [1, 2, 3, 4]
+      _window(input, 5) => None
+
+    Args:
+        iterable: elements to iterate over.
+        size: size of the window.
+
+    Yields:
+        Elements of `iterable` batched into a sliding window of length `size`.
+    """
+    i = iter(iterable)
+    window = []
+    try:
+        for e in range(0, size):
+            window.append(next(i))
+        yield window
+    except StopIteration:
+        # handle the case where iterable's length is less than the window size.
+        return
+    for e in i:
+        window = window[1:] + [e]
+        yield window
+
+
+def _contiguous(sorted_grams):
+    """Test whether a sequence of grams is contiguous.
+
+    Args:
+        sorted_grams: _Grams which are sorted in increasing order.
+    Returns:
+        True if `sorted_grams` are touching each other.
+
+    E.g.,
+      _contiguous([(1, 4), (4, 5), (5, 10)]) == True
+      _contiguous([(1, 2), (4, 5)]) == False
+    """
+    for a, b in _window(sorted_grams, 2):
+        if a.end != b.begin:
+            return False
+    return True
+
+
+def _masking_ngrams(grams, max_ngram_size, max_masked_tokens, rng):
+    """Create a list of masking {1, ..., n}-grams from a list of one-grams.
+
+    This is an extention of 'whole word masking' to mask multiple, contiguous
+    words such as (e.g., "the red boat").
+
+    Each input gram represents the token indices of a single word,
+       words:  ["the", "red", "boat"]
+       tokens: ["the", "red", "boa", "##t"]
+       grams:  [(0,1), (1,2), (2,4)]
+
+    For a `max_ngram_size` of three, possible outputs masks include:
+      1-grams: (0,1), (1,2), (2,4)
+      2-grams: (0,2), (1,4)
+      3-grams; (0,4)
+
+    Output masks will not overlap and contain less than `max_masked_tokens`
+    total tokens.  E.g., for the example above with `max_masked_tokens` as
+    three, valid outputs are,
+         [(0,1), (1,2)]  # "the", "red" covering two tokens
+         [(1,2), (2,4)]  # "red", "boa", "##t" covering three tokens
+
+    The length of the selected n-gram follows a zipf weighting to
+    favor shorter n-gram sizes (weight(1)=1, weight(2)=1/2, weight(3)=1/3, ...).
+
+    Args:
+        grams: List of one-grams.
+        max_ngram_size: Maximum number of contiguous one-grams combined to
+            create an n-gram.
+      max_masked_tokens: Maximum total number of tokens to be masked.
+      rng: `random.Random` generator.
+
+    Returns:
+        A list of n-grams to be used as masks.
+    """
+    if not grams:
+        return None
+
+    grams = sorted(grams)
+    num_tokens = grams[-1].end
+
+    # Ensure our grams are valid (i.e., they don't overlap).
+    for a, b in _window(grams, 2):
+        if a.end > b.begin:
+            raise ValueError("overlapping grams: {}".format(grams))
+
+    # Build map from n-gram length to list of n-grams.
+    ngrams = {i: [] for i in range(1, max_ngram_size + 1)}
+    for gram_size in range(1, max_ngram_size + 1):
+        for g in _window(grams, gram_size):
+            if _contiguous(g):
+                # Add an n-gram which spans these one-grams.
+                ngrams[gram_size].append(_Gram(g[0].begin, g[-1].end))
+
+    # Shuffle each list of n-grams.
+    for v in ngrams.values():
+        rng.shuffle(v)
+
+    # Create the weighting for n-gram length selection.
+    # Stored cummulatively for `random.choices` below.
+    cummulative_weights = list(
+        itertools.accumulate([1.0 / n for n in range(1, max_ngram_size + 1)])
+    )
+
+    output_ngrams = []
+    # Keep a bitmask of which tokens have been masked.
+    masked_tokens = [False] * num_tokens
+    # Loop until we have enough masked tokens or there are no more candidate
+    # n-grams of any length.
+    # Each code path should ensure one or more elements from `ngrams` are
+    # removed to guarentee this loop terminates.
+    while sum(masked_tokens) < max_masked_tokens and sum(
+        len(s) for s in ngrams.values()
+    ):
+        # Pick an n-gram size based on our weights.
+        sz = random.choices(
+            range(1, max_ngram_size + 1), cum_weights=cummulative_weights
+        )[0]
+
+        # Ensure this size doesn't result in too many masked tokens.
+        # E.g., a two-gram contains _at least_ two tokens.
+        if sum(masked_tokens) + sz > max_masked_tokens:
+            # All n-grams of this length are too long and can be removed from
+            # consideration.
+            ngrams[sz].clear()
+            continue
+
+        # All of the n-grams of this size have been used.
+        if not ngrams[sz]:
+            continue
+
+        # Choose a random n-gram of the given size.
+        gram = ngrams[sz].pop()
+        num_gram_tokens = gram.end - gram.begin
+
+        # Check if this would add too many tokens.
+        if num_gram_tokens + sum(masked_tokens) > max_masked_tokens:
+            continue
+
+        # Check if any of the tokens in this gram have already been masked.
+        if sum(masked_tokens[gram.begin : gram.end]):
+            continue
+
+        # Found a usable n-gram!  Mark its tokens as masked and add it to
+        # return.
+        masked_tokens[gram.begin : gram.end] = [True] * (gram.end - gram.begin)
+        output_ngrams.append(gram)
+    return output_ngrams
+
+
+def _wordpieces_to_grams(tokens):
+    """Reconstitue grams (words) from `tokens`.
+
+    E.g.,
+       tokens: ['[CLS]', 'That', 'lit', '##tle', 'blue', 'tru', '##ck', '[SEP]']
+        grams: [          [1,2), [2,         4),  [4,5) , [5,       6)]
+
+    Args:
+        tokens: list of wordpieces
+    Returns:
+        List of _Grams representing spans of whole words
+        (without "[CLS]" and "[SEP]").
+    """
+    grams = []
+    gram_start_pos = None
+    for i, token in enumerate(tokens):
+        if gram_start_pos is not None and token.startswith("##"):
+            continue
+        if gram_start_pos is not None:
+            grams.append(_Gram(gram_start_pos, i))
+        if token not in ["[CLS]", "[SEP]"]:
+            gram_start_pos = i
+        else:
+            gram_start_pos = None
+    if gram_start_pos is not None:
+        grams.append(_Gram(gram_start_pos, len(tokens)))
+    return grams
+
+
+def create_masked_lm_predictions(
+    tokens,
+    masked_lm_prob,
+    max_predictions_per_seq,
+    vocab_words,
+    rng,
+    do_whole_word_mask,
+    max_ngram_size=None,
+):
+    """Creates the predictions for the masked LM objective."""
+    if do_whole_word_mask:
+        grams = _wordpieces_to_grams(tokens)
+    else:
+        # Here we consider each token to be a word to allow for sub-word masking.
+        if max_ngram_size:
+            raise ValueError(
+                "cannot use ngram masking without whole word masking"
+            )
+        grams = [
+            _Gram(i, i + 1)
+            for i in range(0, len(tokens))
+            if tokens[i] not in ["[CLS]", "[SEP]"]
+        ]
+
+    num_to_predict = min(
+        max_predictions_per_seq,
+        max(1, int(round(len(tokens) * masked_lm_prob))),
+    )
+    # Generate masks.  If `max_ngram_size` in [0, None] it means we're doing
+    # whole word masking or token level masking.  Both of these can be treated
+    # as the `max_ngram_size=1` case.
+    masked_grams = _masking_ngrams(
+        grams, max_ngram_size or 1, num_to_predict, rng
+    )
+    masked_lms = []
+    output_tokens = list(tokens)
+    for gram in masked_grams:
+        # 80% of the time, replace all n-gram tokens with [MASK]
+        if rng.random() < 0.8:
+            replacement_action = lambda idx: "[MASK]"
+        else:
+            # 10% of the time, keep all the original n-gram tokens.
+            if rng.random() < 0.5:
+                replacement_action = lambda idx: tokens[idx]
+            # 10% of the time, replace each n-gram token with a random word.
+            else:
+                replacement_action = lambda idx: rng.choice(vocab_words)
+
+        for idx in range(gram.begin, gram.end):
+            output_tokens[idx] = replacement_action(idx)
+            masked_lms.append(MaskedLmInstance(index=idx, label=tokens[idx]))
+
+    assert len(masked_lms) <= num_to_predict
+    masked_lms = sorted(masked_lms, key=lambda x: x.index)
+
+    masked_lm_positions = []
+    masked_lm_labels = []
+    for p in masked_lms:
+        masked_lm_positions.append(p.index)
+        masked_lm_labels.append(p.label)
+
+    return (output_tokens, masked_lm_positions, masked_lm_labels)
+
+
+def truncate_seq_pair(tokens_a, tokens_b, max_num_tokens, rng):
+    """Truncates a pair of sequences to a maximum sequence length."""
+    while True:
+        total_length = len(tokens_a) + len(tokens_b)
+        if total_length <= max_num_tokens:
+            break
+
+        trunc_tokens = tokens_a if len(tokens_a) > len(tokens_b) else tokens_b
+        assert len(trunc_tokens) >= 1
+
+        # We want to sometimes truncate from the front and sometimes from the
+        # back to add more randomness and avoid biases.
+        if rng.random() < 0.5:
+            del trunc_tokens[0]
+        else:
+            trunc_tokens.pop()
+
+
+def main(_):
+    tokenizer = tokenization.FullTokenizer(
+        vocab_file=FLAGS.vocab_file, do_lower_case=FLAGS.do_lower_case
+    )
+
+    input_files = []
+    for input_pattern in FLAGS.input_file.split(","):
+        input_files.extend(tf.io.gfile.glob(input_pattern))
+
+    logging.info("*** Reading from input files ***")
+    for input_file in input_files:
+        logging.info("  %s", input_file)
+
+    rng = random.Random(FLAGS.random_seed)
+    instances = create_training_instances(
+        input_files,
+        tokenizer,
+        FLAGS.max_seq_length,
+        FLAGS.dupe_factor,
+        FLAGS.short_seq_prob,
+        FLAGS.masked_lm_prob,
+        FLAGS.max_predictions_per_seq,
+        rng,
+        FLAGS.do_whole_word_mask,
+        FLAGS.max_ngram_size,
+    )
+
+    output_files = FLAGS.output_file.split(",")
+    logging.info("*** Writing to output files ***")
+    for output_file in output_files:
+        logging.info("  %s", output_file)
+
+    write_instance_to_example_files(
+        instances,
+        tokenizer,
+        FLAGS.max_seq_length,
+        FLAGS.max_predictions_per_seq,
+        output_files,
+        FLAGS.gzip_compress,
+        FLAGS.use_v2_feature_names,
+    )
+
+
+if __name__ == "__main__":
+    flags.mark_flag_as_required("input_file")
+    flags.mark_flag_as_required("output_file")
+    flags.mark_flag_as_required("vocab_file")
+    app.run(main)

--- a/examples/bert/create_sentence_split_data.py
+++ b/examples/bert/create_sentence_split_data.py
@@ -1,0 +1,174 @@
+# Copyright 2022 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Split sentences from raw input documents using nltk.
+
+A script to sentence split a raw dataset (e.g. wikipedia or bookscorpus) into
+sentences for further preproessing for BERT. The output file format is the
+format expected by `create_pretraining_data.py`, where each file contains one
+line per sentence, with empty newlines between documents.
+
+This script will run muliprocessed, and the number of concurrent process and
+output file shards can be controlled with `--num_jobs` and `--num_shards`.
+
+Usage:
+python create_sentence_split_data.py \
+    --input_files ~/datasets/wikipedia,~/datasets/bookscorpus \
+    --output_directory ~/datasets/bert-sentence-split-data
+"""
+
+import contextlib
+import multiprocessing
+import os
+import random
+import sys
+
+import nltk
+from absl import app
+from absl import flags
+from tensorflow import keras
+
+from examples.bert.bert_utils import list_filenames_for_arg
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string(
+    "input_files",
+    None,
+    "Comma seperated list of directories, files, or globs for input data.",
+)
+
+flags.DEFINE_string(
+    "output_directory",
+    None,
+    "Directory for output data.",
+)
+
+flags.DEFINE_integer("num_jobs", None, "Number of file shards to use.")
+
+flags.DEFINE_integer("num_shards", 500, "Number of file shards to use.")
+
+flags.DEFINE_integer("random_seed", 12345, "Random seed for data generation.")
+
+
+def parse_wiki_file(file):
+    """Read documents from a wikipedia dump file."""
+    documents = []
+    in_article = False
+    article_lines = []
+    for line in file:
+        line = line.strip()
+        # Skip empty lines.
+        if line == "":
+            continue
+        elif "<doc id=" in line:
+            in_article = True
+        elif "</doc>" in line:
+            in_article = False
+            # There are many wikipedia articles that are only titles (one
+            # line) or or redirects (two lines), we will skip these.
+            if len(article_lines) > 2:
+                # Skip the title.
+                documents.append(" ".join(article_lines[1:]))
+            article_lines = []
+        elif in_article:
+            article_lines.append(line)
+    return documents
+
+
+def parse_text_file(file):
+    """Read documents from a plain text file."""
+    documents = []
+    file_lines = []
+    for line in file:
+        line = line.strip()
+        # Skip empty lines.
+        if line == "":
+            continue
+        file_lines.append(line)
+    documents.append(" ".join(file_lines))
+    return documents
+
+
+def read_file(filename):
+    """Read documents from an input file."""
+    with open(filename, mode="r") as file:
+        firstline = file.readline()
+        file.seek(0)
+        # Very basic autodetection of file type.
+        # Wikipedia dump files all start with a doc id tag.
+        if "<doc id=" in firstline:
+            return parse_wiki_file(file)
+        return parse_text_file(file)
+
+
+def process_file(filename):
+    """Read documents from an input file and split into sentences with nltk."""
+    split_documents = []
+    for document in read_file(filename):
+        sentences = nltk.tokenize.sent_tokenize(document)
+        split_documents.append(sentences)
+    return split_documents
+
+
+def main(_):
+    print(f"Reading input data from {FLAGS.input_files}")
+    input_filenames = list_filenames_for_arg(FLAGS.input_files)
+    if not input_filenames:
+        print("No input files found. Check `input_files` flag.")
+        sys.exit(1)
+
+    # Randomize files so we aren't processing input directories sequentially.
+    rng = random.Random(FLAGS.random_seed)
+    rng.shuffle(input_filenames)
+
+    # We will read and sentence split with multiprocessing, but write from
+    # a single thread to balance our shard sizes well.
+    pool = multiprocessing.Pool(FLAGS.num_jobs)
+
+    print(f"Outputting to {FLAGS.output_directory}.")
+    if not os.path.exists(FLAGS.output_directory):
+        os.mkdir(FLAGS.output_directory)
+
+    progbar = keras.utils.Progbar(len(input_filenames), unit_name="files")
+    progbar.update(0)
+    with contextlib.ExitStack() as stack:
+        # Open all files.
+        output_files = []
+        for i in range(FLAGS.num_shards):
+            path = os.path.join(FLAGS.output_directory, f"shard_{i}.txt")
+            output_files.append(stack.enter_context(open(path, "w")))
+
+        # Write documents to disk.
+        total_files = 0
+        total_documents = 0
+        for documents in pool.imap_unordered(process_file, input_filenames):
+            for document in documents:
+                output_file = output_files[total_documents % FLAGS.num_shards]
+                for sentence in document:
+                    output_file.write(sentence + "\n")
+                # Blank newline marks a new document.
+                output_file.write("\n")
+                total_documents += 1
+            total_files += 1
+            progbar.update(total_files)
+
+    print("Done.")
+    print(f"Read {total_files} files.")
+    print(f"Processed {total_documents} documents.")
+
+
+if __name__ == "__main__":
+    flags.mark_flag_as_required("input_files")
+    flags.mark_flag_as_required("output_directory")
+    app.run(main)

--- a/examples/bert/create_vocabulary.py
+++ b/examples/bert/create_vocabulary.py
@@ -1,0 +1,99 @@
+# Copyright 2022 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Create BERT workpiece vocabularies.
+
+This script will create wordpiece vocabularies suitable for pretraining BERT.
+
+Usage:
+python create_vocabulary.py \
+    --input_files ~/datasets/bert-sentence-split-data/ \
+    --output_file vocab.txt
+"""
+
+import os
+import sys
+
+import tensorflow as tf
+from absl import app
+from absl import flags
+from tensorflow_text.tools.wordpiece_vocab import bert_vocab_from_dataset
+
+from examples.bert.bert_utils import list_filenames_for_arg
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string(
+    "input_files",
+    None,
+    "Comma seperated list of directories, files, or globs.",
+)
+
+flags.DEFINE_string(
+    "output_file", None, "Output file for the computed vocabulary."
+)
+
+flags.DEFINE_bool(
+    "do_lower_case",
+    True,
+    "Whether to lower case the input text. Should be True for uncased "
+    "models and False for cased models.",
+)
+
+flags.DEFINE_string(
+    "reserved_tokens",
+    "[PAD],[UNK],[CLS],[SEP],[MASK]",
+    "Comma separated list of reserved tokens in the vocabulary.",
+)
+
+flags.DEFINE_integer("vocabulary_size", 30522, "Number of output files.")
+
+
+def write_vocab_file(filepath, vocab):
+    with open(filepath, "w") as file:
+        for token in vocab:
+            file.write(token + "\n")
+
+
+def main(_):
+    print(f"Reading input data from {FLAGS.input_files}")
+    input_filenames = list_filenames_for_arg(FLAGS.input_files)
+    if not input_filenames:
+        print("No input files found. Check `input_files` flag.")
+        sys.exit(1)
+
+    print(f"Outputting to {FLAGS.output_file}")
+    if os.path.exists(FLAGS.output_file):
+        print(f"File {FLAGS.output_file} already exists.")
+        sys.exit(1)
+
+    with open(FLAGS.output_file, "w") as file:
+        # TODO(mattdangerw): This is the slow and simple BERT vocabulary
+        # learner from tf text, we should try the faster flume option.
+        vocab = bert_vocab_from_dataset.bert_vocab_from_dataset(
+            tf.data.TextLineDataset(input_filenames).batch(1000).prefetch(2),
+            # The target vocabulary size
+            vocab_size=FLAGS.vocabulary_size,
+            # Reserved tokens that must be included in the vocabulary
+            reserved_tokens=FLAGS.reserved_tokens.split(","),
+            # Arguments for `text.BertTokenizer`
+            bert_tokenizer_params={"lower_case": FLAGS.do_lower_case},
+        )
+        for token in vocab:
+            file.write(token + "\n")
+
+
+if __name__ == "__main__":
+    flags.mark_flag_as_required("input_files")
+    flags.mark_flag_as_required("output_file")
+    app.run(main)

--- a/examples/bert/run_pretraining.py
+++ b/examples/bert/run_pretraining.py
@@ -1,0 +1,227 @@
+# Copyright 2022 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class ClassificationHead(tf.keras.layers.Layer):
+    """Pooling head for sentence-level classification tasks."""
+
+    def __init__(
+        self,
+        inner_dim,
+        num_classes,
+        cls_token_idx=0,
+        activation="tanh",
+        dropout_rate=0.0,
+        initializer="glorot_uniform",
+        **kwargs
+    ):
+        """Initializes the `ClassificationHead`.
+
+        Args:
+            inner_dim: The dimensionality of inner projection layer. If 0 or
+                `None` then only the output projection layer is created.
+            num_classes: Number of output classes.
+            cls_token_idx: The index inside the sequence to pool.
+            activation: Dense layer activation.
+            dropout_rate: Dropout probability.
+            initializer: Initializer for dense layer kernels.
+            **kwargs: Keyword arguments.
+        """
+        super().__init__(**kwargs)
+        self.dropout_rate = dropout_rate
+        self.inner_dim = inner_dim
+        self.num_classes = num_classes
+        self.activation = tf_utils.get_activation(activation)
+        self.initializer = tf.keras.initializers.get(initializer)
+        self.cls_token_idx = cls_token_idx
+
+        if self.inner_dim:
+            self.dense = tf.keras.layers.Dense(
+                units=self.inner_dim,
+                activation=self.activation,
+                kernel_initializer=self.initializer,
+                name="pooler_dense",
+            )
+        self.dropout = tf.keras.layers.Dropout(rate=self.dropout_rate)
+
+        self.out_proj = tf.keras.layers.Dense(
+            units=num_classes,
+            kernel_initializer=self.initializer,
+            name="logits",
+        )
+
+    def call(self, features: tf.Tensor, only_project: bool = False):
+        """Implements call().
+
+        Args:
+          features: a rank-3 Tensor when self.inner_dim is specified, otherwise
+            it is a rank-2 Tensor.
+          only_project: a boolean. If True, we return the intermediate Tensor
+            before projecting to class logits.
+
+        Returns:
+          a Tensor, if only_project is True, shape= [batch size, hidden size].
+          If only_project is False, shape= [batch size, num classes].
+        """
+        if not self.inner_dim:
+            x = features
+        else:
+            x = features[:, self.cls_token_idx, :]  # take <CLS> token.
+            x = self.dense(x)
+
+        if only_project:
+            return x
+        x = self.dropout(x)
+        x = self.out_proj(x)
+        return x
+
+    def get_config(self):
+        config = {
+            "cls_token_idx": self.cls_token_idx,
+            "dropout_rate": self.dropout_rate,
+            "num_classes": self.num_classes,
+            "inner_dim": self.inner_dim,
+            "activation": tf.keras.activations.serialize(self.activation),
+            "initializer": tf.keras.initializers.serialize(self.initializer),
+        }
+        config.update(super(ClassificationHead, self).get_config())
+        return config
+
+    @classmethod
+    def from_config(cls, config, custom_objects=None):
+        return cls(**config)
+
+    @property
+    def checkpoint_items(self):
+        return {self.dense.name: self.dense}
+
+
+class MaskedLM(tf.keras.layers.Layer):
+    """Masked language model network head for BERT modeling.
+
+    This layer implements a masked language model based on the provided
+    transformer based encoder. It assumes that the encoder network being passed
+    has a "get_embedding_table()" method.
+
+    Example:
+    ```python
+    encoder=modeling.networks.BertEncoder(...)
+    lm_layer=MaskedLM(embedding_table=encoder.get_embedding_table())
+    ```
+
+    Args:
+        embedding_table: The embedding table from encoder network.
+        activation: The activation, if any, for the dense layer.
+        initializer: The initializer for the dense layer. Defaults to a Glorot
+            uniform initializer.
+        output: The output style for this layer. Can be either 'logits' or
+            'predictions'.
+    """
+
+    def __init__(
+        self,
+        embedding_table,
+        activation=None,
+        initializer="glorot_uniform",
+        output="logits",
+        name=None,
+        **kwargs
+    ):
+        super(MaskedLM, self).__init__(name=name, **kwargs)
+        self.embedding_table = embedding_table
+        self.activation = activation
+        self.initializer = tf.keras.initializers.get(initializer)
+
+        if output not in ("predictions", "logits"):
+            raise ValueError(
+                (
+                    'Unknown `output` value "%s". `output` can be either '
+                    '"logits" or "predictions"'
+                )
+                % output
+            )
+        self._output_type = output
+
+    def build(self, input_shape):
+        self._vocab_size, hidden_size = self.embedding_table.shape
+        self.dense = tf.keras.layers.Dense(
+            hidden_size,
+            activation=self.activation,
+            kernel_initializer=self.initializer,
+            name="transform/dense",
+        )
+        self.layer_norm = tf.keras.layers.LayerNormalization(
+            axis=-1, epsilon=1e-12, name="transform/LayerNorm"
+        )
+        self.bias = self.add_weight(
+            "output_bias/bias",
+            shape=(self._vocab_size,),
+            initializer="zeros",
+            trainable=True,
+        )
+
+        super(MaskedLM, self).build(input_shape)
+
+    def call(self, sequence_data, masked_positions):
+        masked_lm_input = self._gather_indexes(sequence_data, masked_positions)
+        lm_data = self.dense(masked_lm_input)
+        lm_data = self.layer_norm(lm_data)
+        lm_data = tf.matmul(lm_data, self.embedding_table, transpose_b=True)
+        logits = tf.nn.bias_add(lm_data, self.bias)
+        masked_positions_length = (
+            masked_positions.shape.as_list()[1] or tf.shape(masked_positions)[1]
+        )
+        logits = tf.reshape(
+            logits, [-1, masked_positions_length, self._vocab_size]
+        )
+        if self._output_type == "logits":
+            return logits
+        return tf.nn.log_softmax(logits)
+
+    def get_config(self):
+        raise NotImplementedError(
+            "MaskedLM cannot be directly serialized because "
+            "it has variable sharing logic."
+        )
+
+    def _gather_indexes(self, sequence_tensor, positions):
+        """Gathers the vectors at the specific positions, for performance.
+
+        Args:
+            sequence_tensor: Sequence output of shape
+                (`batch_size`, `seq_length`, num_hidden) where num_hidden is
+                number of hidden units.
+            positions: Positions ids of tokens in sequence to mask for
+                pretraining of with dimension (batch_size, num_predictions)
+                where `num_predictions` is maximum number of tokens to mask out
+                and predict per each sequence.
+
+        Returns:
+            Masked out sequence tensor of shape (batch_size * num_predictions,
+            num_hidden).
+        """
+        sequence_shape = tf.shape(sequence_tensor)
+        batch_size, seq_length = sequence_shape[0], sequence_shape[1]
+        width = sequence_tensor.shape.as_list()[2] or sequence_shape[2]
+
+        flat_offsets = tf.reshape(
+            tf.range(0, batch_size, dtype=tf.int32) * seq_length, [-1, 1]
+        )
+        flat_positions = tf.reshape(positions + flat_offsets, [-1])
+        flat_sequence_tensor = tf.reshape(
+            sequence_tensor, [batch_size * seq_length, width]
+        )
+        output_tensor = tf.gather(flat_sequence_tensor, flat_positions)
+
+        return output_tensor

--- a/examples/bert/run_pretraining.py
+++ b/examples/bert/run_pretraining.py
@@ -12,9 +12,69 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import sys
+
+import tensorflow as tf
+from absl import app
+from absl import flags
+from tensorflow import keras
+
+from examples.bert.bert_model import BertModel
+from examples.bert.bert_utils import list_filenames_for_arg
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string(
+    "input_files",
+    None,
+    "Comma seperated list of directories, files, or globs for input data.",
+)
+
+flags.DEFINE_string(
+    "saved_model_output", None, "Output directory to save the model to."
+)
+
+flags.DEFINE_string(
+    "bert_config_file",
+    None,
+    "The json config file for the bert model parameters.",
+)
+
+flags.DEFINE_string(
+    "vocab_file",
+    None,
+    "The vocabulary file that the BERT model was trained on.",
+)
+
+flags.DEFINE_integer("epochs", 10, "The number of training epochs.")
+
+flags.DEFINE_integer("batch_size", 256, "The training batch size.")
+
+flags.DEFINE_float("learning_rate", 1e-4, "The initial learning rate for Adam.")
+
+flags.DEFINE_integer("max_seq_length", 128, "Maximum sequence length.")
+
+flags.DEFINE_integer(
+    "max_predictions_per_seq",
+    20,
+    "Maximum number of masked LM predictions per sequence.",
+)
+
 
 class ClassificationHead(tf.keras.layers.Layer):
-    """Pooling head for sentence-level classification tasks."""
+    """Pooling head for sentence-level classification tasks.
+
+    Args:
+        inner_dim: The dimensionality of inner projection layer. If 0 or `None`
+            then only the output projection layer is created.
+        num_classes: Number of output classes.
+        cls_token_idx: The index inside the sequence to pool.
+        activation: Dense layer activation.
+        dropout_rate: Dropout probability.
+        initializer: Initializer for dense layer kernels.
+        **kwargs: Keyword arguments.
+    """
 
     def __init__(
         self,
@@ -24,55 +84,40 @@ class ClassificationHead(tf.keras.layers.Layer):
         activation="tanh",
         dropout_rate=0.0,
         initializer="glorot_uniform",
-        **kwargs
+        **kwargs,
     ):
-        """Initializes the `ClassificationHead`.
-
-        Args:
-            inner_dim: The dimensionality of inner projection layer. If 0 or
-                `None` then only the output projection layer is created.
-            num_classes: Number of output classes.
-            cls_token_idx: The index inside the sequence to pool.
-            activation: Dense layer activation.
-            dropout_rate: Dropout probability.
-            initializer: Initializer for dense layer kernels.
-            **kwargs: Keyword arguments.
-        """
         super().__init__(**kwargs)
         self.dropout_rate = dropout_rate
         self.inner_dim = inner_dim
         self.num_classes = num_classes
-        self.activation = tf_utils.get_activation(activation)
-        self.initializer = tf.keras.initializers.get(initializer)
+        self.activation = keras.activations.get(activation)
+        self.initializer = keras.initializers.get(initializer)
         self.cls_token_idx = cls_token_idx
 
         if self.inner_dim:
-            self.dense = tf.keras.layers.Dense(
+            self.dense = keras.layers.Dense(
                 units=self.inner_dim,
                 activation=self.activation,
                 kernel_initializer=self.initializer,
                 name="pooler_dense",
             )
-        self.dropout = tf.keras.layers.Dropout(rate=self.dropout_rate)
+        self.dropout = keras.layers.Dropout(rate=self.dropout_rate)
 
-        self.out_proj = tf.keras.layers.Dense(
+        self.out_proj = keras.layers.Dense(
             units=num_classes,
             kernel_initializer=self.initializer,
             name="logits",
         )
 
-    def call(self, features: tf.Tensor, only_project: bool = False):
+    def call(self, features: tf.Tensor):
         """Implements call().
 
         Args:
-          features: a rank-3 Tensor when self.inner_dim is specified, otherwise
-            it is a rank-2 Tensor.
-          only_project: a boolean. If True, we return the intermediate Tensor
-            before projecting to class logits.
+            features: a rank-3 Tensor when self.inner_dim is specified,
+                otherwise it is a rank-2 Tensor.
 
         Returns:
-          a Tensor, if only_project is True, shape= [batch size, hidden size].
-          If only_project is False, shape= [batch size, num classes].
+            a Tensor shape= [batch size, num classes].
         """
         if not self.inner_dim:
             x = features
@@ -80,8 +125,6 @@ class ClassificationHead(tf.keras.layers.Layer):
             x = features[:, self.cls_token_idx, :]  # take <CLS> token.
             x = self.dense(x)
 
-        if only_project:
-            return x
         x = self.dropout(x)
         x = self.out_proj(x)
         return x
@@ -98,17 +141,9 @@ class ClassificationHead(tf.keras.layers.Layer):
         config.update(super(ClassificationHead, self).get_config())
         return config
 
-    @classmethod
-    def from_config(cls, config, custom_objects=None):
-        return cls(**config)
 
-    @property
-    def checkpoint_items(self):
-        return {self.dense.name: self.dense}
-
-
-class MaskedLM(tf.keras.layers.Layer):
-    """Masked language model network head for BERT modeling.
+class MaskedLM(keras.layers.Layer):
+    """Masked language model network head for BERT.
 
     This layer implements a masked language model based on the provided
     transformer based encoder. It assumes that the encoder network being passed
@@ -129,39 +164,16 @@ class MaskedLM(tf.keras.layers.Layer):
             'predictions'.
     """
 
-    def __init__(
-        self,
-        embedding_table,
-        activation=None,
-        initializer="glorot_uniform",
-        output="logits",
-        name=None,
-        **kwargs
-    ):
-        super(MaskedLM, self).__init__(name=name, **kwargs)
+    def __init__(self, embedding_table, **kwargs):
+        super().__init__(**kwargs)
         self.embedding_table = embedding_table
-        self.activation = activation
-        self.initializer = tf.keras.initializers.get(initializer)
-
-        if output not in ("predictions", "logits"):
-            raise ValueError(
-                (
-                    'Unknown `output` value "%s". `output` can be either '
-                    '"logits" or "predictions"'
-                )
-                % output
-            )
-        self._output_type = output
 
     def build(self, input_shape):
         self._vocab_size, hidden_size = self.embedding_table.shape
-        self.dense = tf.keras.layers.Dense(
-            hidden_size,
-            activation=self.activation,
-            kernel_initializer=self.initializer,
-            name="transform/dense",
+        self.dense = keras.layers.Dense(
+            hidden_size, activation=None, name="transform/dense"
         )
-        self.layer_norm = tf.keras.layers.LayerNormalization(
+        self.layer_norm = keras.layers.LayerNormalization(
             axis=-1, epsilon=1e-12, name="transform/LayerNorm"
         )
         self.bias = self.add_weight(
@@ -171,7 +183,7 @@ class MaskedLM(tf.keras.layers.Layer):
             trainable=True,
         )
 
-        super(MaskedLM, self).build(input_shape)
+        super().build(input_shape)
 
     def call(self, sequence_data, masked_positions):
         masked_lm_input = self._gather_indexes(sequence_data, masked_positions)
@@ -182,17 +194,8 @@ class MaskedLM(tf.keras.layers.Layer):
         masked_positions_length = (
             masked_positions.shape.as_list()[1] or tf.shape(masked_positions)[1]
         )
-        logits = tf.reshape(
+        return tf.reshape(
             logits, [-1, masked_positions_length, self._vocab_size]
-        )
-        if self._output_type == "logits":
-            return logits
-        return tf.nn.log_softmax(logits)
-
-    def get_config(self):
-        raise NotImplementedError(
-            "MaskedLM cannot be directly serialized because "
-            "it has variable sharing logic."
         )
 
     def _gather_indexes(self, sequence_tensor, positions):
@@ -200,8 +203,8 @@ class MaskedLM(tf.keras.layers.Layer):
 
         Args:
             sequence_tensor: Sequence output of shape
-                (`batch_size`, `seq_length`, num_hidden) where num_hidden is
-                number of hidden units.
+                (`batch_size`, `seq_length`, `hidden_size`) where `hidden_size`
+                is number of hidden units.
             positions: Positions ids of tokens in sequence to mask for
                 pretraining of with dimension (batch_size, num_predictions)
                 where `num_predictions` is maximum number of tokens to mask out
@@ -209,7 +212,7 @@ class MaskedLM(tf.keras.layers.Layer):
 
         Returns:
             Masked out sequence tensor of shape (batch_size * num_predictions,
-            num_hidden).
+            `hidden_size`).
         """
         sequence_shape = tf.shape(sequence_tensor)
         batch_size, seq_length = sequence_shape[0], sequence_shape[1]
@@ -225,3 +228,128 @@ class MaskedLM(tf.keras.layers.Layer):
         output_tensor = tf.gather(flat_sequence_tensor, flat_positions)
 
         return output_tensor
+
+
+class BertPretrainer(keras.Model):
+    def __init__(self, bert_model, **kwargs):
+        super().__init__(**kwargs)
+        self.bert_model = bert_model
+        self.masked_lm_head = MaskedLM(bert_model.get_embedding_table())
+        self.next_sentence_head = ClassificationHead(
+            inner_dim=768, num_classes=2, dropout_rate=0.1
+        )
+
+    def call(self, data):
+        outputs = self.bert_model(
+            {
+                "input_ids": data["input_ids"],
+                "input_mask": data["input_mask"],
+                "segment_ids": data["segment_ids"],
+            }
+        )
+        lm_preds = self.masked_lm_head(
+            outputs["sequence_output"], data["masked_lm_positions"]
+        )
+        nsp_preds = self.next_sentence_head(outputs["sequence_output"])
+        return lm_preds, nsp_preds
+
+    def train_step(self, data):
+        # TODO(mattdangerw): Add metrics (e.g nsp, lm accuracy).
+        with tf.GradientTape() as tape:
+            lm_preds, nsp_preds = self(data, training=True)
+            lm_loss = keras.metrics.sparse_categorical_crossentropy(
+                data["masked_lm_ids"], lm_preds, from_logits=True
+            )
+            lm_weights = data["masked_lm_weights"]
+            lm_weights_summed = tf.reduce_sum(lm_weights, -1)
+            lm_loss = tf.reduce_sum(lm_loss * lm_weights, -1)
+            lm_loss = tf.math.divide_no_nan(lm_loss, lm_weights_summed)
+            nsp_loss = keras.metrics.sparse_categorical_crossentropy(
+                data["next_sentence_labels"], nsp_preds, from_logits=True
+            )
+            nsp_loss = tf.reduce_mean(nsp_loss)
+            loss = lm_loss + nsp_loss
+
+        # Compute gradients
+        trainable_vars = self.trainable_variables
+        gradients = tape.gradient(loss, trainable_vars)
+        # Update weights
+        self.optimizer.apply_gradients(zip(gradients, trainable_vars))
+        return {"total_loss": loss, "lm_loss": lm_loss, "nsp_loss": nsp_loss}
+
+
+def decode_record(record):
+    """Decodes a record to a TensorFlow example."""
+    seq_length = FLAGS.max_seq_length
+    lm_length = FLAGS.max_predictions_per_seq
+    name_to_features = {
+        "input_ids": tf.io.FixedLenFeature([seq_length], tf.int64),
+        "input_mask": tf.io.FixedLenFeature([seq_length], tf.int64),
+        "segment_ids": tf.io.FixedLenFeature([seq_length], tf.int64),
+        "masked_lm_positions": tf.io.FixedLenFeature([lm_length], tf.int64),
+        "masked_lm_ids": tf.io.FixedLenFeature([lm_length], tf.int64),
+        "masked_lm_weights": tf.io.FixedLenFeature([lm_length], tf.float32),
+        "next_sentence_labels": tf.io.FixedLenFeature([1], tf.int64),
+    }
+    # tf.Example only supports tf.int64, but the TPU only supports tf.int32.
+    # So cast all int64 to int32.
+    example = tf.io.parse_single_example(record, name_to_features)
+    for name in list(example.keys()):
+        value = example[name]
+        if value.dtype == tf.int64:
+            value = tf.cast(value, tf.int32)
+        example[name] = value
+    return example
+
+
+def main(_):
+    print(f"Reading input data from {FLAGS.input_files}")
+    input_filenames = list_filenames_for_arg(FLAGS.input_files)
+    if not input_filenames:
+        print("No input files found. Check `input_files` flag.")
+        sys.exit(1)
+
+    vocab = []
+    with open(FLAGS.vocab_file, "r") as vocab_file:
+        for line in vocab_file:
+            vocab.append(line.strip())
+
+    with open(FLAGS.bert_config_file, "r") as bert_config_file:
+        bert_config = json.loads(bert_config_file.read())
+
+    # Decode and batch data.
+    dataset = tf.data.TFRecordDataset(input_filenames)
+    dataset = dataset.map(
+        lambda record: decode_record(record),
+        num_parallel_calls=tf.data.experimental.AUTOTUNE,
+    )
+    dataset = dataset.batch(FLAGS.batch_size, drop_remainder=True)
+
+    # Create a BERT model the input config.
+    model = BertModel(
+        vocab_size=len(vocab),
+        **bert_config,
+    )
+    # Make sure model has been called.
+    model(model.inputs)
+    model.summary()
+
+    # Wrap with pretraining heads and call fit.
+    pretraining_model = BertPretrainer(model)
+    pretraining_model.compile(
+        # TODO(mattdangerw): Add AdamW and a learning rate schedule.
+        optimizer=keras.optimizers.Adam(learning_rate=FLAGS.learning_rate)
+    )
+    # TODO(mattdangerw): Add TPU strategy support.
+    pretraining_model.fit(dataset, epochs=FLAGS.epochs)
+
+    print(f"Saving to {FLAGS.saved_model_output}")
+    model.save(FLAGS.saved_model_output)
+
+
+if __name__ == "__main__":
+    flags.mark_flag_as_required("input_files")
+    flags.mark_flag_as_required("vocab_file")
+    flags.mark_flag_as_required("bert_config_file")
+    flags.mark_flag_as_required("saved_model_output")
+    app.run(main)

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,13 @@ setup(
     author="Keras team",
     author_email="keras-nlp@google.com",
     license="Apache License 2.0",
-    # tensorflow isn't a dependency because it would force the
-    # download of the gpu version or the cpu version.
-    # users should install it manually.
-    install_requires=["packaging", "tensorflow", "numpy"],
+    install_requires=[
+        "absl-py",
+        "numpy",
+        "packaging",
+        "tensorflow",
+        "tensorflow_text",
+    ],
     extras_require={
         "tests": [
             "black",
@@ -37,6 +40,10 @@ setup(
             "isort",
             "pytest",
             "pytest-cov",
+        ],
+        "examples": [
+            "nltk",
+            "wikiextractor",
         ],
     },
     classifiers=[


### PR DESCRIPTION
This adds an initial BERT code example which we can use to test our upcoming
components (transformer encoder, positional embedding, tokenizers) in
an end to end BERT model.

This uses code from the official bert repository and model garden.
It attempts to be complete--it contains scripts for sentence splitting raw
input data with nltk and computing a wordpiece vocab with tf_text.

Still to come:

 - AdamW optimizer
 - Proper learning rate schedule
 - TPU strategy support
 - GLUE finetuning script
