### PR TITLE
Remove the readlink call in format/link

### DIFF
--- a/shell/format.sh
+++ b/shell/format.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-base_dir=$(dirname $(dirname $(readlink -f $0)))
+base_dir=$(dirname $(dirname $0))
 
 isort --sl ${base_dir}
 black --line-length 80 ${base_dir}

--- a/shell/lint.sh
+++ b/shell/lint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-base_dir=$(dirname $(dirname $(readlink -f $0)))
+base_dir=$(dirname $(dirname $0))
 
 isort --sl -c "${base_dir}"
 if ! [ $? -eq 0 ]; then


### PR DESCRIPTION
This is not supported across all OSes in a standard way (default
readlink on mac does not support -f). We can probably safely remove
this.
