### PR TITLE
Add contributing guide and update README

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,111 @@
+# Contribution guide
+
+## How to contribute code
+
+Follow these steps to submit your code contribution.
+
+### Step 1. Open an issue
+
+Before making any changes, we recommend opening an issue (if one doesn't already
+exist) and discussing your proposed changes. This way, we can give you feedback
+and validate the proposed changes.
+
+If your code change involves the fixing of a bug, please include a
+[Colab](https://colab.research.google.com/) notebook that shows
+how to reproduce the broken behavior.
+
+If the changes are minor (simple bug fix or documentation fix), then feel free
+to open a PR without discussion.
+
+### Step 2. Make code changes
+
+To make code changes, you need to fork the repository. You will need to setup a
+development environment and run the unit tests. This is covered in section
+"Setup environment".
+
+### Step 3. Create a pull request
+
+Once the change is ready, open a pull request from your branch in your fork to
+the master branch in [keras-team/keras-nlp](https://github.com/keras-team/keras-nlp).
+
+### Step 4. Sign the Contributor License Agreement
+
+After creating the pull request, you will need to sign the Google CLA agreement.
+The agreement can be foiund at [https://cla.developers.google.com/clas](https://cla.developers.google.com/clas).
+
+### Step 5. Code review
+
+CI tests will automatically be run directly on your pull request.  Their
+status will be reported back via GitHub actions.
+
+There may be several rounds of comments and code changes before the pull
+request gets approved by the reviewer.
+
+### Step 6. Merging
+
+Once the pull request is approved, a team member will take care of merging.
+
+## Setup environment
+
+Setting up your KerasNLP development environment requires you to fork the
+KerasNLP repository, clone the repository, install dependencies, and execute
+`python setup.py develop`.
+
+You can achieve this by running the following commands:
+
+```shell
+gh repo fork keras-team/keras-nlp --clone --remote
+cd keras-nlp
+pip install ".[tests]"
+python setup.py develop
+```
+
+The first line relies on having an installation of [the GitHub CLI](https://github.com/cli/cli).
+
+Following these commands you should be able to run the tests using
+`pytest keras_nlp`. Please report any issues running tests following these
+steps.
+
+## Run tests
+
+KerasNLP is tested using [PyTest](https://docs.pytest.org/en/6.2.x/).
+
+### Run a test file
+
+To run a test file, run `pytest path/to/file` from the root directory of the
+repository.
+
+### Run a single test case
+
+To run a single test, you can use `-k=<your_regex>`
+to use regular expression to match the test you want to run. For example, you
+can use the following command to run all the tests in `import_test.py`
+whose names contain `import`:
+
+```shell
+pytest keras_nlp/keras_nlp/integration_tests/import_test.py -k="import"
+```
+
+### Run all tests
+
+You can run the unit tests for KerasNLP by running:
+
+```shell
+pytest keras_nlp/
+```
+
+## Formatting the Code
+
+We use `flake8`, `isort` and `black` for code formatting.  You can run
+the following commands manually every time you want to format your code:
+
+- Run `shell/format.sh` to format your code
+- Run `shell/lint.sh` to check the result.
+
+If after running these the CI flow is still failing, try updating `flake8`,
+`isort` and `black`. This can be done by running `pip install --upgrade black`,
+`pip install --upgrade flake8`, and `pip install --upgrade isort`.
+
+## Community Guidelines
+
+This project follows [Google's Open Source Community Guidelines](https://opensource.google/conduct/).

--- a/README.md
+++ b/README.md
@@ -1,9 +1,26 @@
 # KerasNLP
 
-KerasNLP is a repository of modular building blocks (layers, metrics, losses). Engineers working with applied natural language processing can leverage it to rapidly assemble training and inference pipelines that are both state-of-the-art and production-grade. Common use cases for application include sentiment analysis, named entity recognition, text generation, etc.
+KerasNLP is a repository of modular building blocks (layers, metrics, losses).
+Engineers working with applied natural language processing can leverage it to
+rapidly assemble training and inference pipelines that are both state-of-the-art
+and production-grade. Common use cases for application include sentiment
+analysis, named entity recognition, text generation, etc.
 
-KerasNLP can be understood as a horizontal extension of the Keras API: they're new first-party Keras objects (layers, metrics, etc) that are too specialized to be added to core Keras, but that receive the same level of polish and backwards compatibility guarantees as the rest of the Keras API and that are maintained by the Keras team itself (unlike TFAddons).
+KerasNLP can be understood as a horizontal extension of the Keras API: they're
+new first-party Keras objects (layers, metrics, etc) that are too specialized to
+be added to core Keras, but that receive the same level of polish and backwards
+compatibility guarantees as the rest of the Keras API and that are maintained by
+the Keras team itself (unlike TFAddons).
 
-## Under Construction
+Currently, KerasNLP is operating pre-release. Upon launch of KerasNLP 1.0, full
+API docs and code examples will be available.
 
-KerasNLP is a relatively new project. Expect regular updates and changes in the near future.
+## Contributors
+
+If you'd like to contribute, please see our [contributing guide](.github/CONTRIBUTING.md).
+
+Thank you to all of our wonderful contributors!
+
+<a href="https://github.com/keras-team/keras-nlp/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=keras-team/keras-nlp" />
+</a>


### PR DESCRIPTION
This is mainly to keep messaging in sync with keras-cv. We won't publish
a call for contributions with issues list until we are further along
in planning.