### PR TITLE
Set ruler for VScode.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
     "python.testing.pytestEnabled": true,
-    "python.formatting.provider": "black"
+    "python.formatting.provider": "black",
+    "editor.rulers": [
+        80
+    ]
 }


### PR DESCRIPTION
Set ruler of size 80 for VScode, which is compatible with our style check.