### PR TITLE
Fix version issues in a clean environment

### DIFF
--- a/keras_nlp/__init__.py
+++ b/keras_nlp/__init__.py
@@ -14,4 +14,4 @@
 
 from keras_nlp import layers
 
-__version__ = "master"
+__version__ = "0.1.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[metadata]
-version = attr: keras_nlp.__version__
-
 [tool:pytest]
 filterwarnings =
     error

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     description=(
         "Industry-strength Natural Language Processing extensions for Keras."
     ),
+    version="0.1.0",
     url="https://github.com/keras-team/keras-nlp",
     author="Keras team",
     author_email="keras-nlp@google.com",


### PR DESCRIPTION
We were attempting to do a solution described here, and copied from
keras-tuner and autokeras:
https://packaging.python.org/en/latest/guides/single-sourcing-package-version/

But the approach relies on a certain version of setuptools beyond what
most linux distros have by default, and would fail in confusing ways with
earlier versions.

Simplest approach seems to be to declare the version in two places, so
let's just do that for now.