### PR TITLE
Exclude test files from package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,5 +57,5 @@ setup(
         "Topic :: Scientific/Engineering",
         "Topic :: Software Development",
     ],
-    packages=find_packages(exclude=("tests",)),
+    packages=find_packages(exclude=("*_test.py",)),
 )


### PR DESCRIPTION
Given that we keep tests in tree, we should switch this.