### PR TITLE
Added Kernel and Bias Initializers to Encoder and Decoder

### DIFF
--- a/keras_nlp/layers/transformer_decoder.py
+++ b/keras_nlp/layers/transformer_decoder.py
@@ -39,9 +39,9 @@ class TransformerDecoder(keras.layers.Layer):
             activation function of feedforward network.
         layer_norm_epsilon: float, defaults to 1e-5. The eps value in layer
             normalization components.
-        kernel_initializer: tf.keras.initializers initializer, defaults to None. 
+        kernel_initializer: tf.keras.initializers initializer, defaults to "glorot_uniform". 
             The kernel initializer for the dense and multiheaded attention layers.
-        bias_initializer: tf.keras.initializers initializer, defaults to None. 
+        bias_initializer: tf.keras.initializers initializer, defaults to "zeros". 
             The bias initializer for the dense and multiheaded attention layers.
         name: string, defaults to None. The name of the layer.
         **kwargs: other keyword arguments.
@@ -78,8 +78,8 @@ class TransformerDecoder(keras.layers.Layer):
         dropout=0,
         activation="relu",
         layer_norm_epsilon=1e-05,
-        kernel_initializer=None,
-        bias_initializer=None,
+        kernel_initializer="glorot_uniform",
+        bias_initializer="zeros",
         name=None,
         **kwargs,
     ):
@@ -90,8 +90,8 @@ class TransformerDecoder(keras.layers.Layer):
         self.activation = activation
         self.layer_norm_epsilon = layer_norm_epsilon
         self._built = False
-        self.kernel_initializer = kernel_initializer
-        self.bias_initializer = bias_initializer
+        self.kernel_initializer = keras.initializers.get(kernel_initializer)
+        self.bias_initializer = keras.initializers.get(bias_initializer)
 
     def _build(self, input_shape):
         # Create layers based on input shape.

--- a/keras_nlp/layers/transformer_decoder.py
+++ b/keras_nlp/layers/transformer_decoder.py
@@ -238,7 +238,7 @@ class TransformerDecoder(keras.layers.Layer):
                 "intermediate_dim": self.intermediate_dim,
                 "num_heads": self.num_heads,
                 "dropout": self.dropout,
-                "activation": self.activation,
+                "activation": keras.activations.serialize(self.activation),
                 "layer_norm_epsilon": self.layer_norm_epsilon,
                 "kernel_initializer": keras.initializers.serialize(
                     self.kernel_initializer

--- a/keras_nlp/layers/transformer_decoder.py
+++ b/keras_nlp/layers/transformer_decoder.py
@@ -16,7 +16,6 @@
 
 import tensorflow as tf
 from tensorflow import keras
-from keras import initializers
 
 from keras_nlp.layers.transformer_layer_utils import (  # isort:skip
     compute_causal_mask,
@@ -40,11 +39,11 @@ class TransformerDecoder(keras.layers.Layer):
             activation function of feedforward network.
         layer_norm_epsilon: float, defaults to 1e-5. The eps value in layer
             normalization components.
-        name: string, defaults to None. The name of the layer.
         kernel_initializer: tf.keras.initializers initializer, defaults to None. 
             The kernel initializer for the dense and multiheaded attention layers.
         bias_initializer: tf.keras.initializers initializer, defaults to None. 
             The bias initializer for the dense and multiheaded attention layers.
+        name: string, defaults to None. The name of the layer.
         **kwargs: other keyword arguments.
 
     Examples:
@@ -79,9 +78,9 @@ class TransformerDecoder(keras.layers.Layer):
         dropout=0,
         activation="relu",
         layer_norm_epsilon=1e-05,
-        name=None,
         kernel_initializer=None,
         bias_initializer=None,
+        name=None,
         **kwargs,
     ):
         super().__init__(name=name, **kwargs)
@@ -236,8 +235,8 @@ class TransformerDecoder(keras.layers.Layer):
                 "dropout": self.dropout,
                 "activation": self.activation,
                 "layer_norm_epsilon": self.layer_norm_epsilon,
-                "kernel_initializer": initializers.serialize(self.kernel_initializer),
-                "bias_initializer": initializers.serialize(self.bias_initializer),
+                "kernel_initializer": keras.initializers.serialize(self.kernel_initializer),
+                "bias_initializer": keras.initializers.serialize(self.bias_initializer),
             }
         )
         return config

--- a/keras_nlp/layers/transformer_decoder.py
+++ b/keras_nlp/layers/transformer_decoder.py
@@ -16,7 +16,7 @@
 
 import tensorflow as tf
 from tensorflow import keras
-from tensorflow.keras import initializers
+from keras import initializers
 
 from keras_nlp.layers.transformer_layer_utils import (  # isort:skip
     compute_causal_mask,
@@ -93,6 +93,7 @@ class TransformerDecoder(keras.layers.Layer):
         self._built = False
         self.kernel_initializer = kernel_initializer
         self.bias_initializer = bias_initializer
+        
     def _build(self, input_shape):
         # Create layers based on input shape.
         self._built = True

--- a/keras_nlp/layers/transformer_decoder.py
+++ b/keras_nlp/layers/transformer_decoder.py
@@ -41,10 +41,10 @@ class TransformerDecoder(keras.layers.Layer):
         layer_norm_epsilon: float, defaults to 1e-5. The eps value in layer
             normalization components.
         name: string, defaults to None. The name of the layer.
-        kernel_initializer: tf.keras.initializers initializer, defaults to None. Sets the
-            kernel initializer for the dense and multiheaded attention layers
-        bias_initializer: tf.keras.initializers initializer, defaults to None. Sets the
-            bias initializer for the dense and multiheaded attention layers
+        kernel_initializer: tf.keras.initializers initializer, defaults to None. 
+            The kernel initializer for the dense and multiheaded attention layers.
+        bias_initializer: tf.keras.initializers initializer, defaults to None. 
+            The bias initializer for the dense and multiheaded attention layers.
         **kwargs: other keyword arguments.
 
     Examples:

--- a/keras_nlp/layers/transformer_decoder.py
+++ b/keras_nlp/layers/transformer_decoder.py
@@ -93,7 +93,7 @@ class TransformerDecoder(keras.layers.Layer):
         self._built = False
         self.kernel_initializer = kernel_initializer
         self.bias_initializer = bias_initializer
-        
+
     def _build(self, input_shape):
         # Create layers based on input shape.
         self._built = True
@@ -236,8 +236,8 @@ class TransformerDecoder(keras.layers.Layer):
                 "dropout": self.dropout,
                 "activation": self.activation,
                 "layer_norm_epsilon": self.layer_norm_epsilon,
-                "kernel_initializer": self.kernel_initializer,
-                "bias_initializer": self.bias_initializer,
+                "kernel_initializer": initializers.serialize(self.kernel_initializer),
+                "bias_initializer": initializers.serialize(self.bias_initializer),
             }
         )
         return config

--- a/keras_nlp/layers/transformer_decoder.py
+++ b/keras_nlp/layers/transformer_decoder.py
@@ -39,9 +39,9 @@ class TransformerDecoder(keras.layers.Layer):
             activation function of feedforward network.
         layer_norm_epsilon: float, defaults to 1e-5. The eps value in layer
             normalization components.
-        kernel_initializer: tf.keras.initializers initializer, defaults to "glorot_uniform". 
+        kernel_initializer: tf.keras.initializers initializer, defaults to "glorot_uniform".
             The kernel initializer for the dense and multiheaded attention layers.
-        bias_initializer: tf.keras.initializers initializer, defaults to "zeros". 
+        bias_initializer: tf.keras.initializers initializer, defaults to "zeros".
             The bias initializer for the dense and multiheaded attention layers.
         name: string, defaults to None. The name of the layer.
         **kwargs: other keyword arguments.
@@ -126,13 +126,18 @@ class TransformerDecoder(keras.layers.Layer):
         # First dense layer in the feedforward network, which maps input
         # feauture size to dimension `self.intermediate_dim`.
         self._intermediate_dense = keras.layers.Dense(
-            self.intermediate_dim, activation=self.activation, 
-            kernel_initializer=self.kernel_initializer, bias_initializer=self.bias_initializer,
+            self.intermediate_dim,
+            activation=self.activation,
+            kernel_initializer=self.kernel_initializer,
+            bias_initializer=self.bias_initializer,
         )
         # Second dense layer in the feedforward network, which maps input
         # feature size back to the input feature size.
-        self._output_dense = keras.layers.Dense(feature_size, 
-            kernel_initializer=self.kernel_initializer, bias_initializer=self.bias_initializer)
+        self._output_dense = keras.layers.Dense(
+            feature_size,
+            kernel_initializer=self.kernel_initializer,
+            bias_initializer=self.bias_initializer,
+        )
         self._outputdropout = keras.layers.Dropout(rate=self.dropout)
 
     def _add_and_norm(self, input1, input2, norm_layer):
@@ -235,7 +240,9 @@ class TransformerDecoder(keras.layers.Layer):
                 "dropout": self.dropout,
                 "activation": self.activation,
                 "layer_norm_epsilon": self.layer_norm_epsilon,
-                "kernel_initializer": keras.initializers.serialize(self.kernel_initializer),
+                "kernel_initializer": keras.initializers.serialize(
+                    self.kernel_initializer
+                ),
                 "bias_initializer": keras.initializers.serialize(self.bias_initializer),
             }
         )

--- a/keras_nlp/layers/transformer_decoder.py
+++ b/keras_nlp/layers/transformer_decoder.py
@@ -243,7 +243,9 @@ class TransformerDecoder(keras.layers.Layer):
                 "kernel_initializer": keras.initializers.serialize(
                     self.kernel_initializer
                 ),
-                "bias_initializer": keras.initializers.serialize(self.bias_initializer),
+                "bias_initializer": keras.initializers.serialize(
+                    self.bias_initializer
+                ),
             }
         )
         return config

--- a/keras_nlp/layers/transformer_decoder.py
+++ b/keras_nlp/layers/transformer_decoder.py
@@ -89,9 +89,9 @@ class TransformerDecoder(keras.layers.Layer):
         self.dropout = dropout
         self.activation = keras.activations.get(activation)
         self.layer_norm_epsilon = layer_norm_epsilon
-        self._built = False
         self.kernel_initializer = keras.initializers.get(kernel_initializer)
         self.bias_initializer = keras.initializers.get(bias_initializer)
+        self._built = False
 
     def _build(self, input_shape):
         # Create layers based on input shape.

--- a/keras_nlp/layers/transformer_decoder.py
+++ b/keras_nlp/layers/transformer_decoder.py
@@ -87,7 +87,7 @@ class TransformerDecoder(keras.layers.Layer):
         self.intermediate_dim = intermediate_dim
         self.num_heads = num_heads
         self.dropout = dropout
-        self.activation = activation
+        self.activation = keras.activations.get(activation)
         self.layer_norm_epsilon = layer_norm_epsilon
         self._built = False
         self.kernel_initializer = keras.initializers.get(kernel_initializer)

--- a/keras_nlp/layers/transformer_decoder.py
+++ b/keras_nlp/layers/transformer_decoder.py
@@ -39,17 +39,19 @@ class TransformerDecoder(keras.layers.Layer):
             activation function of feedforward network.
         layer_norm_epsilon: float, defaults to 1e-5. The eps value in layer
             normalization components.
-        kernel_initializer: tf.keras.initializers initializer, defaults to "glorot_uniform".
-            The kernel initializer for the dense and multiheaded attention layers.
-        bias_initializer: tf.keras.initializers initializer, defaults to "zeros".
-            The bias initializer for the dense and multiheaded attention layers.
+        kernel_initializer: string or tf.keras.initializers initializer,
+            defaults to "glorot_uniform". The kernel initializer for
+            the dense and multiheaded attention layers.
+        bias_initializer: string or tf.keras.initializers initializer,
+            defaults to "zeros". The bias initializer for
+            the dense and multiheaded attention layers.
         name: string, defaults to None. The name of the layer.
         **kwargs: other keyword arguments.
 
     Examples:
     ```python
     # Create a single transformer decoder layer.
-    decoder = keras_nlp.layer.TransformerDecoder(
+    decoder = keras_nlp.layers.TransformerDecoder(
         intermediate_dim=64, num_heads=8)
 
     # Create a simple model containing the decoder.

--- a/keras_nlp/layers/transformer_decoder_test.py
+++ b/keras_nlp/layers/transformer_decoder_test.py
@@ -68,6 +68,8 @@ class TransformerDecoderTest(tf.test.TestCase):
             "dropout": 0,
             "activation": "relu",
             "layer_norm_epsilon": 1e-05,
+            "kernel_initializer": None,
+            "bias_initializer": None,
         }
         self.assertEqual(config, {**config, **expected_config_subset})
 

--- a/keras_nlp/layers/transformer_decoder_test.py
+++ b/keras_nlp/layers/transformer_decoder_test.py
@@ -57,30 +57,16 @@ class TransformerDecoderTest(tf.test.TestCase):
         )
 
     def test_get_config_and_from_config(self):
-        decoder1 = transformer_decoder.TransformerDecoder(
-            intermediate_dim=4,
-            num_heads=2,
-        )
-        decoder2 = transformer_decoder.TransformerDecoder(
+        decoder = transformer_decoder.TransformerDecoder(
             intermediate_dim=4,
             num_heads=2,
             kernel_initializer=initializers.HeNormal(),
             bias_initializer=initializers.Constant(value=2)
         )
 
-        config1 = decoder1.get_config()
-        config2 = decoder2.get_config()
+        config = decoder.get_config()
 
-        expected_config_subset1 = {
-            "intermediate_dim": 4,
-            "num_heads": 2,
-            "dropout": 0,
-            "activation": "relu",
-            "layer_norm_epsilon": 1e-05,
-            "kernel_initializer": None,
-            "bias_initializer": None,
-        }
-        expected_config_subset2 = {
+        expected_config_subset = {
             "intermediate_dim": 4,
             "num_heads": 2,
             "dropout": 0,
@@ -90,21 +76,15 @@ class TransformerDecoderTest(tf.test.TestCase):
             "bias_initializer": initializers.serialize(initializers.Constant(value=2)),
         }
 
-        self.assertEqual(config1, {**config1, **expected_config_subset1})
-        self.assertEqual(config2, {**config2, **expected_config_subset2})
+        self.assertEqual(config, {**config, **expected_config_subset})
+        self.assertEqual(config, {**config, **expected_config_subset})
 
-        restored_decoder1 = transformer_decoder.TransformerDecoder.from_config(
-            config1,
-        )
-        restored_decoder2 = transformer_decoder.TransformerDecoder.from_config(
-            config2,
+        restored_decoder = transformer_decoder.TransformerDecoder.from_config(
+            config,
         )
 
         self.assertEqual(
-            restored_decoder1.get_config(), {**config1, **expected_config_subset1}
-        )
-        self.assertEqual(
-            restored_decoder2.get_config(), {**config2, **expected_config_subset2}
+            restored_decoder.get_config(), {**config, **expected_config_subset}
         )
 
     def test_one_training_step_of_transformer_encoder(self):

--- a/keras_nlp/layers/transformer_decoder_test.py
+++ b/keras_nlp/layers/transformer_decoder_test.py
@@ -17,7 +17,6 @@ import os
 
 import tensorflow as tf
 from tensorflow import keras
-from keras import initializers
 from keras_nlp.layers import transformer_decoder
 
 
@@ -60,8 +59,8 @@ class TransformerDecoderTest(tf.test.TestCase):
         decoder = transformer_decoder.TransformerDecoder(
             intermediate_dim=4,
             num_heads=2,
-            kernel_initializer=initializers.HeNormal(),
-            bias_initializer=initializers.Constant(value=2)
+            kernel_initializer=keras.initializers.HeNormal(),
+            bias_initializer=keras.initializers.Constant(value=2)
         )
 
         config = decoder.get_config()
@@ -72,8 +71,8 @@ class TransformerDecoderTest(tf.test.TestCase):
             "dropout": 0,
             "activation": "relu",
             "layer_norm_epsilon": 1e-05,
-            "kernel_initializer": initializers.serialize(initializers.HeNormal()),
-            "bias_initializer": initializers.serialize(initializers.Constant(value=2)),
+            "kernel_initializer": keras.initializers.serialize(keras.initializers.HeNormal()),
+            "bias_initializer": keras.initializers.serialize(keras.initializers.Constant(value=2)),
         }
 
         self.assertEqual(config, {**config, **expected_config_subset})

--- a/keras_nlp/layers/transformer_decoder_test.py
+++ b/keras_nlp/layers/transformer_decoder_test.py
@@ -90,14 +90,14 @@ class TransformerDecoderTest(tf.test.TestCase):
             restored_decoder.get_config(), {**config, **expected_config_subset}
         )
 
-        self.assertRaises(
-            ValueError,
-            transformer_decoder.TransformerDecoder,
-            intermediate_dim=4,
-            num_heads=2,
-            dropout=0.5,
-            kernel_initializer="Invalid",
-        )
+    def test_value_error_when_invalid_kernel_inititalizer(self):
+        with self.assertRaises(ValueError):
+            transformer_decoder.TransformerDecoder(
+                intermediate_dim=4,
+                num_heads=2,
+                dropout=0.5,
+                kernel_initializer="Invalid",
+            )
 
     def test_one_training_step_of_transformer_encoder(self):
         class MyModel(keras.Model):

--- a/keras_nlp/layers/transformer_decoder_test.py
+++ b/keras_nlp/layers/transformer_decoder_test.py
@@ -60,7 +60,7 @@ class TransformerDecoderTest(tf.test.TestCase):
             intermediate_dim=4,
             num_heads=2,
             kernel_initializer=keras.initializers.HeNormal(),
-            bias_initializer=keras.initializers.Constant(value=2)
+            bias_initializer=keras.initializers.Constant(value=2),
         )
 
         config = decoder.get_config()
@@ -71,8 +71,12 @@ class TransformerDecoderTest(tf.test.TestCase):
             "dropout": 0,
             "activation": "relu",
             "layer_norm_epsilon": 1e-05,
-            "kernel_initializer": keras.initializers.serialize(keras.initializers.HeNormal()),
-            "bias_initializer": keras.initializers.serialize(keras.initializers.Constant(value=2)),
+            "kernel_initializer": keras.initializers.serialize(
+                keras.initializers.HeNormal()
+            ),
+            "bias_initializer": keras.initializers.serialize(
+                keras.initializers.Constant(value=2)
+            ),
         }
 
         self.assertEqual(config, {**config, **expected_config_subset})

--- a/keras_nlp/layers/transformer_decoder_test.py
+++ b/keras_nlp/layers/transformer_decoder_test.py
@@ -90,6 +90,15 @@ class TransformerDecoderTest(tf.test.TestCase):
             restored_decoder.get_config(), {**config, **expected_config_subset}
         )
 
+        self.assertRaises(
+            ValueError,
+            transformer_decoder.TransformerDecoder,
+            intermediate_dim=4,
+            num_heads=2,
+            dropout=0.5,
+            kernel_initializer="Invalid",
+        )
+
     def test_one_training_step_of_transformer_encoder(self):
         class MyModel(keras.Model):
             def __init__(self):

--- a/keras_nlp/layers/transformer_decoder_test.py
+++ b/keras_nlp/layers/transformer_decoder_test.py
@@ -17,6 +17,7 @@ import os
 
 import tensorflow as tf
 from tensorflow import keras
+
 from keras_nlp.layers import transformer_decoder
 
 

--- a/keras_nlp/layers/transformer_decoder_test.py
+++ b/keras_nlp/layers/transformer_decoder_test.py
@@ -59,8 +59,8 @@ class TransformerDecoderTest(tf.test.TestCase):
         decoder = transformer_decoder.TransformerDecoder(
             intermediate_dim=4,
             num_heads=2,
-            kernel_initializer=keras.initializers.HeNormal(),
-            bias_initializer=keras.initializers.Constant(value=2),
+            kernel_initializer="HeNormal",
+            bias_initializer="Zeros",
         )
 
         config = decoder.get_config()
@@ -75,7 +75,7 @@ class TransformerDecoderTest(tf.test.TestCase):
                 keras.initializers.HeNormal()
             ),
             "bias_initializer": keras.initializers.serialize(
-                keras.initializers.Constant(value=2)
+                keras.initializers.Zeros()
             ),
         }
 

--- a/keras_nlp/layers/transformer_encoder.py
+++ b/keras_nlp/layers/transformer_encoder.py
@@ -39,10 +39,10 @@ class TransformerEncoder(keras.layers.Layer):
         layer_norm_epsilon: float, defaults to 1e-5. The epsilon value in layer
             normalization components.
         name: string, defaults to None. The name of the layer.
-        kernel_initializer: tf.keras.initializers initializer, defaults to None. Sets the
-            kernel initializer for the dense and multiheaded attention layers
-        bias_initializer: tf.keras.initializers initializer, defaults to None. Sets the
-            bias initializer for the dense and multiheaded attention layers
+        kernel_initializer: tf.keras.initializers initializer, defaults to None. 
+            The kernel initializer for the dense and multiheaded attention layers.
+        bias_initializer: tf.keras.initializers initializer, defaults to None. 
+            The bias initializer for the dense and multiheaded attention layers.
         **kwargs: other keyword arguments.
 
     Examples:

--- a/keras_nlp/layers/transformer_encoder.py
+++ b/keras_nlp/layers/transformer_encoder.py
@@ -15,7 +15,6 @@
 """Transformer encoder block implementation based on `keras.layers.Layer`."""
 
 from tensorflow import keras
-from keras import initializers
 
 from keras_nlp.layers.transformer_layer_utils import (  # isort:skip
     merge_padding_and_attention_mask,
@@ -38,11 +37,11 @@ class TransformerEncoder(keras.layers.Layer):
             activation function of feedforward network.
         layer_norm_epsilon: float, defaults to 1e-5. The epsilon value in layer
             normalization components.
-        name: string, defaults to None. The name of the layer.
         kernel_initializer: tf.keras.initializers initializer, defaults to None. 
             The kernel initializer for the dense and multiheaded attention layers.
         bias_initializer: tf.keras.initializers initializer, defaults to None. 
             The bias initializer for the dense and multiheaded attention layers.
+        name: string, defaults to None. The name of the layer.
         **kwargs: other keyword arguments.
 
     Examples:
@@ -74,9 +73,9 @@ class TransformerEncoder(keras.layers.Layer):
         dropout=0,
         activation="relu",
         layer_norm_epsilon=1e-05,
-        name=None,
         kernel_initializer=None,
         bias_initializer=None,
+        name=None,
         **kwargs
     ):
         super().__init__(name=name, **kwargs)
@@ -176,8 +175,8 @@ class TransformerEncoder(keras.layers.Layer):
                 "dropout": self.dropout,
                 "activation": self.activation,
                 "layer_norm_epsilon": self.layer_norm_epsilon,
-                "kernel_initializer": initializers.serialize(self.kernel_initializer),
-                "bias_initializer": initializers.serialize(self.bias_initializer),
+                "kernel_initializer": keras.initializers.serialize(self.kernel_initializer),
+                "bias_initializer": keras.initializers.serialize(self.bias_initializer),
             }
         )
         return config

--- a/keras_nlp/layers/transformer_encoder.py
+++ b/keras_nlp/layers/transformer_encoder.py
@@ -183,7 +183,9 @@ class TransformerEncoder(keras.layers.Layer):
                 "kernel_initializer": keras.initializers.serialize(
                     self.kernel_initializer
                 ),
-                "bias_initializer": keras.initializers.serialize(self.bias_initializer),
+                "bias_initializer": keras.initializers.serialize(
+                    self.bias_initializer
+                ),
             }
         )
         return config

--- a/keras_nlp/layers/transformer_encoder.py
+++ b/keras_nlp/layers/transformer_encoder.py
@@ -37,10 +37,12 @@ class TransformerEncoder(keras.layers.Layer):
             activation function of feedforward network.
         layer_norm_epsilon: float, defaults to 1e-5. The epsilon value in layer
             normalization components.
-        kernel_initializer: tf.keras.initializers initializer, defaults to "glorot_uniform".
-            The kernel initializer for the dense and multiheaded attention layers.
-        bias_initializer: tf.keras.initializers initializer, defaults to "zeros".
-            The bias initializer for the dense and multiheaded attention layers.
+        kernel_initializer: string or tf.keras.initializers initializer,
+            defaults to "glorot_uniform". The kernel initializer for
+            the dense and multiheaded attention layers.
+        bias_initializer: string or tf.keras.initializers initializer,
+            defaults to "zeros". The bias initializer for
+            the dense and multiheaded attention layers.
         name: string, defaults to None. The name of the layer.
         **kwargs: other keyword arguments.
 
@@ -48,7 +50,7 @@ class TransformerEncoder(keras.layers.Layer):
 
     ```python
     # Create a single transformer encoder layer.
-    encoder = keras_nlp.layer.TransformerEncoder(
+    encoder = keras_nlp.layers.TransformerEncoder(
         intermediate_dim=64, num_heads=8)
 
     # Create a simple model containing the encoder.

--- a/keras_nlp/layers/transformer_encoder.py
+++ b/keras_nlp/layers/transformer_encoder.py
@@ -176,8 +176,8 @@ class TransformerEncoder(keras.layers.Layer):
                 "dropout": self.dropout,
                 "activation": self.activation,
                 "layer_norm_epsilon": self.layer_norm_epsilon,
-                "kernel_initializer": self.kernel_initializer,
-                "bias_initializer": self.bias_initializer,
+                "kernel_initializer": initializers.serialize(self.kernel_initializer),
+                "bias_initializer": initializers.serialize(self.bias_initializer),
             }
         )
         return config

--- a/keras_nlp/layers/transformer_encoder.py
+++ b/keras_nlp/layers/transformer_encoder.py
@@ -84,9 +84,9 @@ class TransformerEncoder(keras.layers.Layer):
         self.dropout = dropout
         self.activation = keras.activations.get(activation)
         self.layer_norm_epsilon = layer_norm_epsilon
-        self._built = False
         self.kernel_initializer = keras.initializers.get(kernel_initializer)
         self.bias_initializer = keras.initializers.get(bias_initializer)
+        self._built = False
 
     def _build(self, input_shape):
         # Create layers based on input shape.

--- a/keras_nlp/layers/transformer_encoder.py
+++ b/keras_nlp/layers/transformer_encoder.py
@@ -178,7 +178,7 @@ class TransformerEncoder(keras.layers.Layer):
                 "intermediate_dim": self.intermediate_dim,
                 "num_heads": self.num_heads,
                 "dropout": self.dropout,
-                "activation": self.activation,
+                "activation": keras.activations.serialize(self.activation),
                 "layer_norm_epsilon": self.layer_norm_epsilon,
                 "kernel_initializer": keras.initializers.serialize(
                     self.kernel_initializer

--- a/keras_nlp/layers/transformer_encoder.py
+++ b/keras_nlp/layers/transformer_encoder.py
@@ -15,6 +15,7 @@
 """Transformer encoder block implementation based on `keras.layers.Layer`."""
 
 from tensorflow import keras
+from keras import initializers
 
 from keras_nlp.layers.transformer_layer_utils import (  # isort:skip
     merge_padding_and_attention_mask,
@@ -38,6 +39,10 @@ class TransformerEncoder(keras.layers.Layer):
         layer_norm_epsilon: float, defaults to 1e-5. The epsilon value in layer
             normalization components.
         name: string, defaults to None. The name of the layer.
+        kernel_initializer: tf.keras.initializers initializer, defaults to None. Sets the
+            kernel initializer for the dense and multiheaded attention layers
+        bias_initializer: tf.keras.initializers initializer, defaults to None. Sets the
+            bias initializer for the dense and multiheaded attention layers
         **kwargs: other keyword arguments.
 
     Examples:
@@ -70,6 +75,8 @@ class TransformerEncoder(keras.layers.Layer):
         activation="relu",
         layer_norm_epsilon=1e-05,
         name=None,
+        kernel_initializer=None,
+        bias_initializer=None,
         **kwargs
     ):
         super().__init__(name=name, **kwargs)
@@ -79,6 +86,8 @@ class TransformerEncoder(keras.layers.Layer):
         self.activation = activation
         self.layer_norm_epsilon = layer_norm_epsilon
         self._built = False
+        self.kernel_initializer = kernel_initializer
+        self.bias_initializer = bias_initializer
 
     def _build(self, input_shape):
         # Create layers based on input shape.
@@ -90,6 +99,8 @@ class TransformerEncoder(keras.layers.Layer):
             key_dim=self._attention_head_size,
             value_dim=self._attention_head_size,
             dropout=self.dropout,
+            kernel_initializer=self.kernel_initializer,
+            bias_initializer=self.bias_initializer,
         )
 
         self._attention_layernorm = keras.layers.LayerNormalization()
@@ -98,9 +109,11 @@ class TransformerEncoder(keras.layers.Layer):
         self._attentiondropout = keras.layers.Dropout(rate=self.dropout)
 
         self._intermediate_dense = keras.layers.Dense(
-            self.intermediate_dim, activation=self.activation
+            self.intermediate_dim, activation=self.activation,
+            kernel_initializer=self.kernel_initializer, bias_initializer=self.bias_initializer,
         )
-        self._output_dense = keras.layers.Dense(feature_size)
+        self._output_dense = keras.layers.Dense(feature_size,
+        kernel_initializer=self.kernel_initializer, bias_initializer=self.bias_initializer,)
         self._outputdropout = keras.layers.Dropout(rate=self.dropout)
 
     def _add_and_norm(self, input1, input2, norm_layer):
@@ -163,6 +176,8 @@ class TransformerEncoder(keras.layers.Layer):
                 "dropout": self.dropout,
                 "activation": self.activation,
                 "layer_norm_epsilon": self.layer_norm_epsilon,
+                "kernel_initializer": self.kernel_initializer,
+                "bias_initializer": self.bias_initializer,
             }
         )
         return config

--- a/keras_nlp/layers/transformer_encoder.py
+++ b/keras_nlp/layers/transformer_encoder.py
@@ -82,7 +82,7 @@ class TransformerEncoder(keras.layers.Layer):
         self.intermediate_dim = intermediate_dim
         self.num_heads = num_heads
         self.dropout = dropout
-        self.activation = activation
+        self.activation = keras.activations.get(activation)
         self.layer_norm_epsilon = layer_norm_epsilon
         self._built = False
         self.kernel_initializer = keras.initializers.get(kernel_initializer)

--- a/keras_nlp/layers/transformer_encoder.py
+++ b/keras_nlp/layers/transformer_encoder.py
@@ -37,9 +37,9 @@ class TransformerEncoder(keras.layers.Layer):
             activation function of feedforward network.
         layer_norm_epsilon: float, defaults to 1e-5. The epsilon value in layer
             normalization components.
-        kernel_initializer: tf.keras.initializers initializer, defaults to None. 
+        kernel_initializer: tf.keras.initializers initializer, defaults to "glorot_uniform". 
             The kernel initializer for the dense and multiheaded attention layers.
-        bias_initializer: tf.keras.initializers initializer, defaults to None. 
+        bias_initializer: tf.keras.initializers initializer, defaults to "zeros". 
             The bias initializer for the dense and multiheaded attention layers.
         name: string, defaults to None. The name of the layer.
         **kwargs: other keyword arguments.
@@ -73,8 +73,8 @@ class TransformerEncoder(keras.layers.Layer):
         dropout=0,
         activation="relu",
         layer_norm_epsilon=1e-05,
-        kernel_initializer=None,
-        bias_initializer=None,
+        kernel_initializer="glorot_uniform",
+        bias_initializer="zeros",
         name=None,
         **kwargs
     ):
@@ -85,8 +85,8 @@ class TransformerEncoder(keras.layers.Layer):
         self.activation = activation
         self.layer_norm_epsilon = layer_norm_epsilon
         self._built = False
-        self.kernel_initializer = kernel_initializer
-        self.bias_initializer = bias_initializer
+        self.kernel_initializer = keras.initializers.get(kernel_initializer)
+        self.bias_initializer = keras.initializers.get(bias_initializer)
 
     def _build(self, input_shape):
         # Create layers based on input shape.

--- a/keras_nlp/layers/transformer_encoder.py
+++ b/keras_nlp/layers/transformer_encoder.py
@@ -37,9 +37,9 @@ class TransformerEncoder(keras.layers.Layer):
             activation function of feedforward network.
         layer_norm_epsilon: float, defaults to 1e-5. The epsilon value in layer
             normalization components.
-        kernel_initializer: tf.keras.initializers initializer, defaults to "glorot_uniform". 
+        kernel_initializer: tf.keras.initializers initializer, defaults to "glorot_uniform".
             The kernel initializer for the dense and multiheaded attention layers.
-        bias_initializer: tf.keras.initializers initializer, defaults to "zeros". 
+        bias_initializer: tf.keras.initializers initializer, defaults to "zeros".
             The bias initializer for the dense and multiheaded attention layers.
         name: string, defaults to None. The name of the layer.
         **kwargs: other keyword arguments.
@@ -108,11 +108,16 @@ class TransformerEncoder(keras.layers.Layer):
         self._attentiondropout = keras.layers.Dropout(rate=self.dropout)
 
         self._intermediate_dense = keras.layers.Dense(
-            self.intermediate_dim, activation=self.activation,
-            kernel_initializer=self.kernel_initializer, bias_initializer=self.bias_initializer,
+            self.intermediate_dim,
+            activation=self.activation,
+            kernel_initializer=self.kernel_initializer,
+            bias_initializer=self.bias_initializer,
         )
-        self._output_dense = keras.layers.Dense(feature_size,
-        kernel_initializer=self.kernel_initializer, bias_initializer=self.bias_initializer,)
+        self._output_dense = keras.layers.Dense(
+            feature_size,
+            kernel_initializer=self.kernel_initializer,
+            bias_initializer=self.bias_initializer,
+        )
         self._outputdropout = keras.layers.Dropout(rate=self.dropout)
 
     def _add_and_norm(self, input1, input2, norm_layer):
@@ -175,7 +180,9 @@ class TransformerEncoder(keras.layers.Layer):
                 "dropout": self.dropout,
                 "activation": self.activation,
                 "layer_norm_epsilon": self.layer_norm_epsilon,
-                "kernel_initializer": keras.initializers.serialize(self.kernel_initializer),
+                "kernel_initializer": keras.initializers.serialize(
+                    self.kernel_initializer
+                ),
                 "bias_initializer": keras.initializers.serialize(self.bias_initializer),
             }
         )

--- a/keras_nlp/layers/transformer_encoder_test.py
+++ b/keras_nlp/layers/transformer_encoder_test.py
@@ -79,14 +79,14 @@ class TransformerEncoderTest(tf.test.TestCase):
             restored_encoder.get_config(), {**config, **expected_config_subset}
         )
 
-        self.assertRaises(
-            ValueError,
-            transformer_encoder.TransformerEncoder,
-            intermediate_dim=4,
-            num_heads=2,
-            dropout=0.5,
-            kernel_initializer="Invalid",
-        )
+    def test_value_error_when_invalid_kernel_inititalizer(self):
+        with self.assertRaises(ValueError):
+            transformer_encoder.TransformerEncoder(
+                intermediate_dim=4,
+                num_heads=2,
+                dropout=0.5,
+                kernel_initializer="Invalid",
+            )
 
     def test_one_training_step_of_transformer_encoder(self):
         encoder = transformer_encoder.TransformerEncoder(

--- a/keras_nlp/layers/transformer_encoder_test.py
+++ b/keras_nlp/layers/transformer_encoder_test.py
@@ -17,7 +17,6 @@ import os
 
 import tensorflow as tf
 from tensorflow import keras
-from keras import initializers
 from keras_nlp.layers import transformer_encoder
 
 
@@ -50,8 +49,8 @@ class TransformerEncoderTest(tf.test.TestCase):
         encoder = transformer_encoder.TransformerDecoder(
             intermediate_dim=4,
             num_heads=2,
-            kernel_initializer=initializers.HeNormal(),
-            bias_initializer=initializers.Constant(value=2)
+            kernel_initializer=keras.initializers.HeNormal(),
+            bias_initializer=keras.initializers.Constant(value=2)
         )
 
         config = encoder.get_config()
@@ -62,8 +61,8 @@ class TransformerEncoderTest(tf.test.TestCase):
             "dropout": 0,
             "activation": "relu",
             "layer_norm_epsilon": 1e-05,
-            "kernel_initializer": initializers.serialize(initializers.HeNormal()),
-            "bias_initializer": initializers.serialize(initializers.Constant(value=2)),
+            "kernel_initializer": keras.initializers.serialize(keras.initializers.HeNormal()),
+            "bias_initializer": keras.initializers.serialize(keras.initializers.Constant(value=2)),
         }
 
         self.assertEqual(config, {**config, **expected_config_subset})

--- a/keras_nlp/layers/transformer_encoder_test.py
+++ b/keras_nlp/layers/transformer_encoder_test.py
@@ -58,6 +58,8 @@ class TransformerEncoderTest(tf.test.TestCase):
             "dropout": 0,
             "activation": "relu",
             "layer_norm_epsilon": 1e-05,
+            "kernel_initializer": None,
+            "bias_initializer": None,
         }
         self.assertEqual(config, {**config, **expected_config_subset})
 

--- a/keras_nlp/layers/transformer_encoder_test.py
+++ b/keras_nlp/layers/transformer_encoder_test.py
@@ -50,7 +50,7 @@ class TransformerEncoderTest(tf.test.TestCase):
             intermediate_dim=4,
             num_heads=2,
             kernel_initializer=keras.initializers.HeNormal(),
-            bias_initializer=keras.initializers.Constant(value=2)
+            bias_initializer=keras.initializers.Constant(value=2),
         )
 
         config = encoder.get_config()
@@ -61,13 +61,17 @@ class TransformerEncoderTest(tf.test.TestCase):
             "dropout": 0,
             "activation": "relu",
             "layer_norm_epsilon": 1e-05,
-            "kernel_initializer": keras.initializers.serialize(keras.initializers.HeNormal()),
-            "bias_initializer": keras.initializers.serialize(keras.initializers.Constant(value=2)),
+            "kernel_initializer": keras.initializers.serialize(
+                keras.initializers.HeNormal()
+            ),
+            "bias_initializer": keras.initializers.serialize(
+                keras.initializers.Constant(value=2)
+            ),
         }
 
         self.assertEqual(config, {**config, **expected_config_subset})
 
-        restored_encoder= transformer_encoder.TransformerEncoder.from_config(
+        restored_encoder = transformer_encoder.TransformerEncoder.from_config(
             config,
         )
 

--- a/keras_nlp/layers/transformer_encoder_test.py
+++ b/keras_nlp/layers/transformer_encoder_test.py
@@ -46,11 +46,11 @@ class TransformerEncoderTest(tf.test.TestCase):
         encoder(input, mask)
 
     def test_get_config_and_from_config(self):
-        encoder = transformer_encoder.TransformerDecoder(
+        encoder = transformer_encoder.TransformerEncoder(
             intermediate_dim=4,
             num_heads=2,
-            kernel_initializer=keras.initializers.HeNormal(),
-            bias_initializer=keras.initializers.Constant(value=2),
+            kernel_initializer="HeNormal",
+            bias_initializer="Zeros",
         )
 
         config = encoder.get_config()
@@ -65,7 +65,7 @@ class TransformerEncoderTest(tf.test.TestCase):
                 keras.initializers.HeNormal()
             ),
             "bias_initializer": keras.initializers.serialize(
-                keras.initializers.Constant(value=2)
+                keras.initializers.Zeros()
             ),
         }
 

--- a/keras_nlp/layers/transformer_encoder_test.py
+++ b/keras_nlp/layers/transformer_encoder_test.py
@@ -17,6 +17,7 @@ import os
 
 import tensorflow as tf
 from tensorflow import keras
+
 from keras_nlp.layers import transformer_encoder
 
 

--- a/keras_nlp/layers/transformer_encoder_test.py
+++ b/keras_nlp/layers/transformer_encoder_test.py
@@ -47,30 +47,16 @@ class TransformerEncoderTest(tf.test.TestCase):
         encoder(input, mask)
 
     def test_get_config_and_from_config(self):
-        encoder1 = transformer_encoder.TransformerEncoder(
-            intermediate_dim=4,
-            num_heads=2,
-        )
-        encoder2 = transformer_encoder.TransformerDecoder(
+        encoder = transformer_encoder.TransformerDecoder(
             intermediate_dim=4,
             num_heads=2,
             kernel_initializer=initializers.HeNormal(),
             bias_initializer=initializers.Constant(value=2)
         )
 
-        config1 = encoder1.get_config()
-        config2 = encoder2.get_config()
+        config = encoder.get_config()
 
-        expected_config_subset1 = {
-            "intermediate_dim": 4,
-            "num_heads": 2,
-            "dropout": 0,
-            "activation": "relu",
-            "layer_norm_epsilon": 1e-05,
-            "kernel_initializer": None,
-            "bias_initializer": None,
-        }
-        expected_config_subset1 = {
+        expected_config_subset = {
             "intermediate_dim": 4,
             "num_heads": 2,
             "dropout": 0,
@@ -80,21 +66,14 @@ class TransformerEncoderTest(tf.test.TestCase):
             "bias_initializer": initializers.serialize(initializers.Constant(value=2)),
         }
 
-        self.assertEqual(config1, {**config1, **expected_config_subset1})
-        self.assertEqual(config2, {**config2, **expected_config_subset1})
+        self.assertEqual(config, {**config, **expected_config_subset})
 
-        restored_encoder1 = transformer_encoder.TransformerEncoder.from_config(
-            config1,
-        )
-        restored_encoder2 = transformer_encoder.TransformerEncoder.from_config(
-            config2,
+        restored_encoder= transformer_encoder.TransformerEncoder.from_config(
+            config,
         )
 
         self.assertEqual(
-            restored_encoder1.get_config(), {**config1, **expected_config_subset1}
-        )
-        self.assertEqual(
-            restored_encoder2.get_config(), {**config2, **expected_config_subset1}
+            restored_encoder.get_config(), {**config, **expected_config_subset}
         )
 
     def test_one_training_step_of_transformer_encoder(self):

--- a/keras_nlp/layers/transformer_encoder_test.py
+++ b/keras_nlp/layers/transformer_encoder_test.py
@@ -79,6 +79,15 @@ class TransformerEncoderTest(tf.test.TestCase):
             restored_encoder.get_config(), {**config, **expected_config_subset}
         )
 
+        self.assertRaises(
+            ValueError,
+            transformer_encoder.TransformerEncoder,
+            intermediate_dim=4,
+            num_heads=2,
+            dropout=0.5,
+            kernel_initializer="Invalid",
+        )
+
     def test_one_training_step_of_transformer_encoder(self):
         encoder = transformer_encoder.TransformerEncoder(
             intermediate_dim=4,


### PR DESCRIPTION
Fixes - #48 
I've added the required parameters for the encoder and decoder and also added 2 new tests to check the config files generated. I've also added relevant docstrings in the encoder and decoder files