### PR TITLE
Add `build` directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ keras_nlp.egg-info/
 .coverage
 .coverage.*
 
+# Windows-specific build files
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ keras_nlp.egg-info/
 
 .coverage
 .coverage.*
+
+build/


### PR DESCRIPTION
When I run `pip install ".[tests]"` on Windows, a new folder is created:

![image](https://user-images.githubusercontent.com/31360468/159401867-ce68cb85-e0ec-48e1-a973-f3175c8d0afd.png)


Hence, I've added it to `.gitignore`.

Note: This does not occur on Colab (so, possibly, this is a Windows-specific thing, and doesn't happen on Linux).