### PR TITLE
[WIP] Add ROUGE Metric

### DIFF
--- a/keras_nlp/metrics/__init__.py
+++ b/keras_nlp/metrics/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2022 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from keras_nlp.metrics.rouge import RougeL
+from keras_nlp.metrics.rouge import RougeN

--- a/keras_nlp/metrics/rouge.py
+++ b/keras_nlp/metrics/rouge.py
@@ -76,31 +76,6 @@ class RougeN(keras.metrics.Metric):
 
     def update_state(self, y_true, y_pred, sample_weight=None):
         # y_true shape: (bsz, seq_len), y_pred shape: (bsz, seq_len)
-        if tf.rank(y_true) != 2:
-            raise ValueError(
-                f"`y_true` must have rank 2. Found rank {tf.rank(y_true)}"
-            )
-        if tf.rank(y_pred) != 2:
-            raise ValueError(
-                f"`y_pred` must have rank 2. Found rank {tf.rank(y_pred)}"
-            )
-
-        if (
-            tf.reduce_sum(
-                tf.cast(
-                    tf.equal(tf.shape(y_true), tf.shape(y_pred)),
-                    tf.int32,
-                )
-            )
-            != 2
-        ):
-            raise ValueError(
-                f"`y_true` and `y_pred` must have the same shape. Full shape "
-                f"received for `y_true`: {tf.shape(y_true)}. Full shape "
-                f"received for `y_pred`: {tf.shape(y_pred)}"
-            )
-
-        # Typecast the tensors to self._dtype.
         y_true = tf.cast(y_true, self._dtype)
         y_pred = tf.cast(y_pred, self._dtype)
 

--- a/keras_nlp/metrics/rouge.py
+++ b/keras_nlp/metrics/rouge.py
@@ -1,0 +1,154 @@
+# Copyright 2022 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ROUGE-N metric implementation based on `keras.metrics.Metric`."""
+
+import tensorflow as tf
+from tensorflow import keras
+
+from keras_nlp.metrics.utils import get_intersection_of_ngrams
+from keras_nlp.metrics.utils import get_ngrams
+
+
+class RougeN(keras.metrics.Metric):
+    """ROUGE-N metric.
+    This class implements the Rouge-N metric, as described in the paper
+    "ROUGE: A Package for Automatic Evaluation of Summaries"
+    (https://aclanthology.org/W04-1013/).
+
+    Args:
+        name: string. Name of the metric instance.
+        dtype: string or tf.dtypes.Dtype. Precision for the computation of the
+            metric. If not specified, it defaults to tf.float32.
+        ids_to_be_masked: [int]. Token IDs of the tokens to be masked. If
+            provided, the mask is computed by this class. For example, token ID
+            of the padding token can be provided here.
+        order: int. Defaults to 2. The n-gram order. For example, if the order
+            is 2, then bigrams are considered.
+        epsilon: float. Defaults to 1e-8. Small value to avoid division by zero
+            during F1 Score computation.
+        **kwargs: Other keyword arguments.
+    """
+
+    def __init__(
+        self,
+        name="rouge_n",
+        dtype=None,
+        ids_to_be_masked=None,
+        order=2,
+        epsilon=1e-8,
+        **kwargs,
+    ):
+        super(RougeN, self).__init__(name=name, dtype=dtype, **kwargs)
+        self._dtype = dtype if dtype else tf.float32
+
+        self.ids_to_be_masked = ids_to_be_masked
+
+        self.order = order
+        self.epsilon = epsilon
+
+        self.rouge_n = self.add_weight(name="rouge_n", initializer="zeros")
+        self.number_of_samples = self.add_weight(
+            name="number_of_samples", initializer="zeros"
+        )
+
+    def _get_f1_score(self, y_true_count, y_pred_count, overlap_count):
+        if y_pred_count == 0:
+            precision = 0.0
+        else:
+            precision = tf.cast(overlap_count / y_pred_count, tf.float32)
+        if y_true_count == 0:
+            recall = 0.0
+        else:
+            recall = tf.cast(overlap_count / y_true_count, tf.float32)
+        return (2 * precision * recall) / (precision + recall + self.epsilon)
+
+    def update_state(self, y_true, y_pred, sample_weight=None):
+        # y_true shape: (bsz, seq_len), y_pred shape: (bsz, seq_len)
+        if tf.rank(y_true) != 2:
+            raise ValueError(
+                f"`y_true` must have rank 2. Found rank {tf.rank(y_true)}"
+            )
+        if tf.rank(y_pred) != 2:
+            raise ValueError(
+                f"`y_pred` must have rank 2. Found rank {tf.rank(y_pred)}"
+            )
+
+        if (
+            tf.reduce_sum(
+                tf.cast(
+                    tf.equal(tf.shape(y_true), tf.shape(y_pred)),
+                    tf.int32,
+                )
+            )
+            != 2
+        ):
+            raise ValueError(
+                f"`y_true` and `y_pred` must have the same shape. Full shape "
+                f"received for `y_true`: {tf.shape(y_true)}. Full shape "
+                f"received for `y_pred`: {tf.shape(y_pred)}"
+            )
+
+        # Typecast the tensors to self._dtype.
+        y_true = tf.cast(y_true, self._dtype)
+        y_pred = tf.cast(y_pred, self._dtype)
+
+        total_rouge_score = 0.0
+        bsz = tf.shape(y_true)[0]
+        for batch_dim in range(bsz):
+            _batch_y_true = y_true[batch_dim]
+            _batch_y_pred = y_pred[batch_dim]
+
+            if self.ids_to_be_masked:
+                for mask_id in self.ids_to_be_masked:
+                    _mask_batch_y_true = tf.math.not_equal(
+                        _batch_y_true, mask_id
+                    )
+                    _batch_y_true = tf.boolean_mask(
+                        _batch_y_true, _mask_batch_y_true
+                    )
+
+                    _mask_batch_y_pred = tf.math.not_equal(
+                        _batch_y_pred, mask_id
+                    )
+                    _batch_y_pred = tf.boolean_mask(
+                        _batch_y_pred, _mask_batch_y_pred
+                    )
+
+            _batch_y_true_ngrams, y_true_count = get_ngrams(
+                _batch_y_true, self.order
+            )
+            _batch_y_pred_ngrams, y_pred_count = get_ngrams(
+                _batch_y_pred, self.order
+            )
+            _, _overlap_ct = get_intersection_of_ngrams(
+                _batch_y_true_ngrams,
+                y_true_count,
+                _batch_y_pred_ngrams,
+                y_pred_count,
+            )
+            total_rouge_score += self._get_f1_score(
+                y_true_count, y_pred_count, _overlap_ct
+            )
+        self.rouge_n.assign_add(total_rouge_score)
+        self.number_of_samples.assign_add(tf.cast(bsz, tf.float32))
+
+    def result(self):
+        if self.number_of_samples == 0:
+            return 0.0
+        return self.rouge_n / self.number_of_samples
+
+    def reset_state(self):
+        self.rouge_n.assign(0.0)
+        self.number_of_samples.assign(0.0)

--- a/keras_nlp/metrics/utils.py
+++ b/keras_nlp/metrics/utils.py
@@ -1,0 +1,96 @@
+# Copyright 2022 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility functions used by metrics classes."""
+
+import tensorflow as tf
+
+
+def get_ngrams(segment, order):
+    """Given a tensor of tokens, finds n-grams.
+
+    Args:
+        segment: tf.Tensor. A one-dimensional tensor of token IDs.
+        order: int. The order of the n-grams. For example, if the order is 2,
+            we find bigrams.
+
+    Returns:
+        (ngrams, max_idx): (tf.Tensor, int). A two-dimensional tensor of n-grams
+            , along with the number of n-grams.
+    """
+    dtype = segment.dtype
+
+    def _found(ngrams, ngram, max_idx):
+        """Inner function to check whether `ngrams` has the ngram `ngram`."""
+        found_flag = 0
+        for idx in tf.range(max_idx):  # iterate over the existing ngrams
+            if (
+                tf.reduce_sum(
+                    tf.cast(tf.equal(ngrams.read(idx), ngram), tf.int32)
+                )
+                == tf.shape(ngram)[0]
+            ):
+                # tensorflow graph ops don't support break statements.
+                found_flag = 1
+        if found_flag == 1:
+            return True
+        return False
+
+    max_idx = 0
+    ngrams = tf.TensorArray(
+        dtype=dtype, size=0, dynamic_size=True, clear_after_read=False
+    )
+    for i in range(tf.shape(segment)[0] - order + 1):
+        formed_ngram = segment[i : i + order]
+        if max_idx == 0:
+            ngrams = ngrams.write(0, formed_ngram)
+            max_idx += 1
+        else:
+            found_flag = _found(ngrams, formed_ngram, max_idx)
+            if not (found_flag):
+                ngrams = ngrams.write(max_idx, formed_ngram)
+                max_idx += 1
+    return ngrams.stack(), max_idx
+
+
+def get_intersection_of_ngrams(ngrams1, len1, ngrams2, len2):
+    """Given two tensors having ngrams, find common ngrams.
+
+    Args:
+        ngrams1: tf.Tensor. A two-dimensional tensor of n-grams.
+        len1: int. The number of n-grams in ngrams1.
+        ngrams2: tf.Tensor. A two-dimensional tensor of n-grams.
+        len2: int. The number of n-grams in ngrams2.
+
+    Returns:
+        (ngrams, max_idx): (tf.Tensor, int). A two-dimensional tensor of n-grams
+            common to `ngram1` and `ngram2`. Also, returns the number of n-grams
+            common to `ngram1` and `ngram2`.
+    """
+    dtype = ngrams1.dtype
+    max_idx = 0
+    common_ngrams = tf.TensorArray(
+        dtype=dtype, size=0, dynamic_size=True, clear_after_read=False
+    )
+    for i in tf.range(len1):
+        for j in tf.range(len2):
+            ngram1 = ngrams1[i]
+            ngram2 = ngrams2[j]
+            if (
+                tf.reduce_sum(tf.cast(tf.equal(ngram1, ngram2), tf.int32))
+                == tf.shape(ngram1)[0]
+            ):
+                common_ngrams = common_ngrams.write(max_idx, ngram1)
+                max_idx += 1
+    return common_ngrams, max_idx


### PR DESCRIPTION
Resolves #67 

- [x] ROUGE-N
- [ ] ROUGE-L

**Important**: @mattdangerw, @chenmoneygithub, the ROUGE-N implementation is very inefficient. I could not find a data structure in TensorFlow which can store tensors (ngrams) as keys (or hash them in a set). So, I have to use `TensorArray` and push an ngram if it does not already belong to the `TensorArray`. Hence,  the push operation is O(n), as opposed to O(1) if we have a set/dictionary data structure in TensorFlow. Please let me know if there is a more efficient way. Currently, ROUGE-N computation makes training very slow. Thank you!

Note: [MutableHashTable](https://www.tensorflow.org/api_docs/python/tf/lookup/experimental/MutableHashTable) does not accept tensors as keys.

Edit: Even ROUGE-L is slow. Is it because I'm looping over the batches during metric computation?


ROUGE-N Notebook: https://colab.research.google.com/drive/1wiNN5KZaClr7qufAu3vzZtx6YECqsTrX?usp=sharing
ROUGE-L Notebook: https://colab.research.google.com/drive/1xchVi4DsG_2gfi8FmO-g9GZS6-7CIFnz?usp=sharing