### PR TITLE
Add docstring testing

### DIFF
--- a/keras_nlp/tests/__init__.py
+++ b/keras_nlp/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/keras_nlp/tests/docstring_lib.py
+++ b/keras_nlp/tests/docstring_lib.py
@@ -1,0 +1,221 @@
+# Copyright 2022 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Doctests lib for KerasNLP."""
+
+import doctest
+import re
+import textwrap
+
+import numpy as np
+
+
+class _FloatExtractor(object):
+    """Class for extracting floats from a string.
+
+    For example:
+
+    >>> text_parts, floats = _FloatExtractor()("Text 1.0 Text")
+    >>> text_parts
+    ['Text ', ' Text']
+    >>> floats
+    array([1.])
+    """
+
+    # Note: non-capturing groups "(?" are not returned in matched groups, or by
+    # re.split.
+    _FLOAT_RE = re.compile(
+        r"""
+        (                          # Captures the float value.
+            (?:
+            [-+]|                 # Start with a sign is okay anywhere.
+            (?:                   # Otherwise:
+                ^|                # Start after the start of string
+                (?<=[^\w.])       # Not after a word char, or a .
+            )
+            )
+            (?:                      # Digits and exponent - something like:
+            {digits_dot_maybe_digits}{exponent}?|   # "1.0" "1." "1.0e3", "1.e3"
+            {dot_digits}{exponent}?|                # ".1" ".1e3"
+            {digits}{exponent}|                     # "1e3"
+            {digits}(?=j)                           # "300j"
+            )
+        )
+        j?                         # Optional j for cplx numbers, not captured.
+        (?=                        # Only accept the match if
+            $|                       # * At the end of the string, or
+            [^\w.]                   # * Next char is not a word char or "."
+        )
+        """.format(
+            # Digits, a "." and optional more digits: "1.1".
+            digits_dot_maybe_digits=r"(?:[0-9]+\.(?:[0-9]*))",
+            # A "." with trailing digits ".23"
+            dot_digits=r"(?:\.[0-9]+)",
+            # digits: "12"
+            digits=r"(?:[0-9]+)",
+            # The exponent: An "e" or "E", optional sign, and at least one
+            # digit. "e-123", "E+12", "e12"
+            exponent=r"(?:[eE][-+]?[0-9]+)",
+        ),
+        re.VERBOSE,
+    )
+
+    def __call__(self, string):
+        """Extracts floats from a string.
+
+        >>> text_parts, floats = _FloatExtractor()("Text 1.0 Text")
+        >>> text_parts
+        ['Text ', ' Text']
+        >>> floats
+        array([1.])
+
+        Args:
+            string: the string to extract floats from.
+
+        Returns:
+            A (string, array) pair, where `string` has each float replaced by
+            "..." and `array` is a `float32` `numpy.array` containing the
+            extracted floats.
+        """
+        texts = []
+        floats = []
+        for i, part in enumerate(self._FLOAT_RE.split(string)):
+            if i % 2 == 0:
+                texts.append(part)
+            else:
+                floats.append(float(part))
+
+        return texts, np.array(floats)
+
+
+class DoctestOutputChecker(doctest.OutputChecker, object):
+    """Customizes how `want` and `got` are compared, see `check_output`."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.extract_floats = _FloatExtractor()
+        self.text_good = None
+        self.float_size_good = None
+
+    _ADDRESS_RE = re.compile(r"\bat 0x[0-9a-f]*?>")
+    # TODO(yashkatariya): Add other tensor's string substitutions too.
+    # tf.RaggedTensor doesn't need one.
+    _NUMPY_OUTPUT_RE = re.compile(r"<tf.Tensor.*?numpy=(.*?)>", re.DOTALL)
+
+    def _allclose(self, want, got, rtol=1e-3, atol=1e-3):
+        return np.allclose(want, got, rtol=rtol, atol=atol)
+
+    def _tf_tensor_numpy_output(self, string):
+        modified_string = self._NUMPY_OUTPUT_RE.sub(r"\1", string)
+        return modified_string, modified_string != string
+
+    MESSAGE = textwrap.dedent(
+        """\n
+        #############################################################
+        Check the documentation on how to write testable docstrings.
+        https://www.tensorflow.org/community/contribute/docs_ref
+        #############################################################"""
+    )
+
+    def check_output(self, want, got, optionflags):
+        """Compares the docstring output to the output from running the code.
+
+        Python addresses in the output are replaced with wildcards.
+
+        Float values in the output compared as using `np.allclose`:
+
+            * Float values are extracted from the text and replaced with
+              wildcards.
+            * The wildcard text is compared to the actual output.
+            * The float values are compared using `np.allclose`.
+
+        The method returns `True` if both the text comparison and the numeric
+        comparison are successful.
+
+        The numeric comparison will fail if either:
+
+            * The wrong number of floats are found.
+            * The float values are not within tolerence.
+
+        Args:
+            want: The output in the docstring.
+            got: The output generated after running the snippet.
+            optionflags: Flags passed to the doctest.
+
+        Returns:
+            A bool, indicating if the check was successful or not.
+        """
+
+        # If the docstring's output is empty and there is some output generated
+        # after running the snippet, return True. This is because if the user
+        # doesn't want to display output, respect that over what the doctest
+        # wants.
+        if got and not want:
+            return True
+
+        if want is None:
+            want = ""
+
+        # Replace python's addresses with ellipsis (`...`) since it can change
+        # on each execution.
+        want = self._ADDRESS_RE.sub("at ...>", want)
+
+        # Replace tf.Tensor strings with only their numpy field values.
+        want, want_changed = self._tf_tensor_numpy_output(want)
+        if want_changed:
+            got, _ = self._tf_tensor_numpy_output(got)
+
+        # Separate out the floats, and replace `want` with the wild-card version
+        # "result=7.0" => "result=..."
+        want_text_parts, self.want_floats = self.extract_floats(want)
+        want_text_wild = "...".join(want_text_parts)
+
+        # Find the floats in the string returned by the test
+        _, self.got_floats = self.extract_floats(got)
+
+        self.text_good = super().check_output(
+            want=want_text_wild, got=got, optionflags=optionflags
+        )
+        if not self.text_good:
+            return False
+
+        if self.want_floats.size == 0:
+            # If there are no floats in the "want" string, ignore all the floats
+            # in the result. "np.array([ ... ])" matches
+            # "np.array([ 1.0, 2.0 ])"
+            return True
+
+        self.float_size_good = self.want_floats.size == self.got_floats.size
+
+        if self.float_size_good:
+            return self._allclose(self.want_floats, self.got_floats)
+        else:
+            return False
+
+    def output_difference(self, example, got, optionflags):
+        got = [got]
+
+        # If the some of the float output is hidden with `...`,
+        # `float_size_good` will be False. This is because the floats extracted
+        # from the string is converted into a 1-D numpy array. Hence hidding
+        # floats is not allowed anymore.
+        if self.text_good:
+            if not self.float_size_good:
+                got.append(
+                    "\n\nCAUTION: tf_doctest doesn't work if *some* of the "
+                    '*float output* is hidden with a "...".'
+                )
+
+        got.append(self.MESSAGE)
+        got = "\n".join(got)
+        return super().output_difference(example, got, optionflags)

--- a/keras_nlp/tests/docstring_test.py
+++ b/keras_nlp/tests/docstring_test.py
@@ -1,0 +1,71 @@
+# Copyright 2022 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import doctest
+import os
+import sys
+import unittest
+
+import numpy as np
+import tensorflow as tf
+from tensorflow import keras
+
+import keras_nlp
+from keras_nlp.tests import docstring_lib
+
+PACKAGE = "keras_nlp."
+
+
+def find_modules():
+    keras_nlp_modules = []
+    for name, module in sys.modules.items():
+        if name.startswith(PACKAGE):
+            keras_nlp_modules.append(module)
+
+    return keras_nlp_modules
+
+
+def test_docstrings():
+    keras_nlp_modules = find_modules()
+    # As of this writing, it doesn't seem like pytest support load_tests
+    # protocol for unittest:
+    #     https://docs.pytest.org/en/7.1.x/how-to/unittest.html
+    # So we run the unittest.TestSuite manually and report the results back.
+    runner = unittest.TextTestRunner()
+    suite = unittest.TestSuite()
+    for module in keras_nlp_modules:
+        suite.addTest(
+            doctest.DocTestSuite(
+                module,
+                test_finder=doctest.DocTestFinder(exclude_empty=False),
+                extraglobs={
+                    "tf": tf,
+                    "np": np,
+                    "os": os,
+                    "keras": keras,
+                    "keras_nlp": keras_nlp,
+                },
+                checker=docstring_lib.DoctestOutputChecker(),
+                optionflags=(
+                    doctest.ELLIPSIS
+                    | doctest.NORMALIZE_WHITESPACE
+                    | doctest.IGNORE_EXCEPTION_DETAIL
+                    | doctest.DONT_ACCEPT_BLANKLINE
+                ),
+            )
+        )
+    result = runner.run(suite)
+    if not result.wasSuccessful():
+        print(result)
+    assert result.wasSuccessful()

--- a/keras_nlp/tests/docstring_test.py
+++ b/keras_nlp/tests/docstring_test.py
@@ -18,6 +18,7 @@ import sys
 import unittest
 
 import numpy as np
+import pytest
 import tensorflow as tf
 from tensorflow import keras
 
@@ -36,6 +37,9 @@ def find_modules():
     return keras_nlp_modules
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Numpy prints differently on windows"
+)
 def test_docstrings():
     keras_nlp_modules = find_modules()
     # As of this writing, it doesn't seem like pytest support load_tests

--- a/keras_nlp/tokenizers/byte_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_tokenizer.py
@@ -86,8 +86,8 @@ class ByteTokenizer(tokenizer.Tokenizer):
     >>> inputs = tf.constant(["hello"])
     >>> tokenizer = keras_nlp.tokenizers.ByteTokenizer(sequence_length=8)
     >>> tokenizer(inputs)
-    <tf.Tensor: shape=(1, 8), dtype=int32,
-                numpy=array([[104, 101, 108, 108, 111,   0,   0,   0]])>
+    <tf.Tensor: shape=(1, 8), dtype=int32, numpy=
+    array([[104, 101, 108, 108, 111,   0,   0,   0]], dtype=int32)>
 
     Tokenize first, then batch the dataset up.
     >>> tokenizer = keras_nlp.tokenizers.ByteTokenizer()
@@ -112,7 +112,7 @@ class ByteTokenizer(tokenizer.Tokenizer):
     >>> ds.take(1).get_single_element()
     <tf.Tensor: shape=(2, 5), dtype=int32, numpy=
     array([[104, 101, 108, 108, 111],
-        [102, 117, 110,   0,   0]])>
+           [102, 117, 110,   0,   0]], dtype=int32)>
 
     Batch up the inputs and then tokenize (`sequence_length` provided).
     >>> tokenizer = keras_nlp.tokenizers.ByteTokenizer(sequence_length=5)
@@ -121,7 +121,7 @@ class ByteTokenizer(tokenizer.Tokenizer):
     >>> ds.take(1).get_single_element()
     <tf.Tensor: shape=(2, 5), dtype=int32, numpy=
     array([[104, 101, 108, 108, 111],
-        [102, 117, 110,   0,   0]])>
+           [102, 117, 110,   0,   0]], dtype=int32)>
 
     Detokenization.
     >>> inputs = tf.constant([104, 101, 108, 108, 111], dtype=tf.int32)

--- a/keras_nlp/tokenizers/word_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer.py
@@ -132,8 +132,8 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
     >>> tokenizer = keras_nlp.tokenizers.WordPieceTokenizer(
     ...     vocabulary=vocab, sequence_length=10)
     >>> tokenizer(inputs)
-    <tf.Tensor: shape=(1, 10), dtype=int32,
-        numpy=array([[1, 2, 3, 4, 5, 6, 7, 0, 0, 0]]>
+    <tf.Tensor: shape=(1, 10), dtype=int32, numpy=
+    array([[1, 2, 3, 4, 5, 6, 7, 0, 0, 0]], dtype=int32)>
 
     String output.
     >>> vocab = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox", "."]
@@ -145,16 +145,15 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
 
     Detokenization.
     >>> vocab = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox", "."]
-    >>> inputs = ["The quick brown fox."]
+    >>> inputs = "The quick brown fox."
     >>> tokenizer = keras_nlp.tokenizers.WordPieceTokenizer(vocabulary=vocab)
-    >>> tokenizer.detokenize(tokenizer.tokenize(inputs))
-    <tf.Tensor: shape=(1,), dtype=string,
-        numpy=array([b"the quick brown fox ."], dtype=object)>
+    >>> tokenizer.detokenize(tokenizer.tokenize(inputs)).numpy().decode('utf-8')
+    'the quick brown fox .'
 
     Custom splitting.
     >>> vocab = ["[UNK]", "fox", ","]
     >>> inputs = ["fox,,fox,fox"]
-    >>> tokenizer = keras_nlp.tokenizers.WordPieceTokenizer(vocabulary=vocab,
+    >>> keras_nlp.tokenizers.WordPieceTokenizer(vocabulary=vocab,
     ...     split_pattern=",", keep_pattern=",", dtype='string')(inputs)
     <tf.RaggedTensor [[b'fox', b',', b',', b'fox', b',', b'fox']]>
     >>> keras_nlp.tokenizers.WordPieceTokenizer(vocabulary=vocab,


### PR DESCRIPTION
We will use the same docstring checker as Tensorflow and Keras. We may want to introduce a canonical tensorflow or keras version of this we can rely on. But in the interest of getting these tests up sooner rather than later, we will just duplicate it for now.

Fixes https://github.com/keras-team/keras-nlp/issues/82