### PR TITLE
Whitelisted formatting and lint check targets

### DIFF
--- a/shell/format.sh
+++ b/shell/format.sh
@@ -4,7 +4,6 @@ base_dir=$(dirname $(dirname $0))
 targets="${base_dir}/*.py ${base_dir}/examples/ ${base_dir}/keras_nlp/"
 
 isort --sp "${base_dir}/setup.cfg" --sl ${targets}
-echo "isort done"
 black --line-length 80 ${targets}
 
 for i in $(find ${targets} -name '*.py'); do

--- a/shell/format.sh
+++ b/shell/format.sh
@@ -1,15 +1,17 @@
 #!/bin/bash -e
 
 base_dir=$(dirname $(dirname $0))
+targets="${base_dir}/*.py ${base_dir}/examples/ ${base_dir}/keras_nlp/"
 
-isort --sl ${base_dir}
-black --line-length 80 ${base_dir}
+isort --sp "${base_dir}/setup.cfg" --sl ${targets}
+echo "isort done"
+black --line-length 80 ${targets}
 
-for i in $(find ${base_dir} -name '*.py'); do
+for i in $(find ${targets} -name '*.py'); do
   if ! grep -q Copyright $i; then
     echo $i
     cat shell/copyright.txt $i >$i.new && mv $i.new $i
   fi
 done
 
-flake8 ${base_dir}
+flake8 --config "${base_dir}/setup.cfg" ${targets}

--- a/shell/lint.sh
+++ b/shell/lint.sh
@@ -1,23 +1,26 @@
 #!/bin/bash -e
 
 base_dir=$(dirname $(dirname $0))
+targets="${base_dir}/*.py ${base_dir}/examples/ ${base_dir}/keras_nlp/"
 
-isort --sl -c "${base_dir}"
+isort --sp "${base_dir}/setup.cfg" --sl -c ${targets}
 if ! [ $? -eq 0 ]; then
   echo "Please run \"./shell/format.sh\" to format the code."
   exit 1
 fi
-flake8 "${base_dir}"
+
+flake8 --config "${base_dir}/setup.cfg" ${targets}
 if ! [ $? -eq 0 ]; then
   echo "Please fix the code style issue."
   exit 1
 fi
-black --check --line-length 80 "${base_dir}"
+
+black --check --line-length 80 ${targets}
 if ! [ $? -eq 0 ]; then
   echo "Please run \"./shell/format.sh\" to format the code."
     exit 1
 fi
-for i in $(find "${base_dir}" -name '*.py'); do
+for i in $(find ${targets} -name '*.py'); do
   if ! grep -q Copyright $i; then
     echo "Please run \"./shell/format.sh\" to format the code."
     exit 1


### PR DESCRIPTION
Resolves #104.

The proposed solution intends to whitelist directories/files that are supposed to be formatted and lint checked.
From current scenario it looks that the bash scripts don't perform really well with PowerShell, so WSL is recommended for project development on Windows platform.

Other than that, `lint.sh` continues to fail with error "Broken 1 Paths" while the input argument are same as in `format.sh`. This is discussed in above  issue.

- [X] `format.sh` fixed
- [X] `lint.sh` fixed

---
The above issue was resolved by switching from `"${targets}"` to `${targets}`.