### PR TITLE
Fix the issue that MLMMaskGenerator does not work in graph mode

### DIFF
--- a/keras_nlp/layers/preprocessing/mlm_mask_generator.py
+++ b/keras_nlp/layers/preprocessing/mlm_mask_generator.py
@@ -129,7 +129,7 @@ class MLMMaskGenerator(keras.layers.Layer):
 
     def call(self, inputs):
         input_is_ragged = isinstance(inputs, tf.RaggedTensor)
-        input_is_1d = tf.rank(inputs) == 1
+        input_is_1d = inputs.shape.rank == 1
         if input_is_1d:
             # If inputs is of rank 1, we manually add the batch axis.
             inputs = inputs[tf.newaxis, :]
@@ -137,6 +137,7 @@ class MLMMaskGenerator(keras.layers.Layer):
             # `tf_text.mask_language_model` requires a ragged tensor, so
             # convert dense to ragged.
             inputs = tf.RaggedTensor.from_tensor(inputs)
+
         (tokens, mask_positions, mask_ids,) = tf_text.mask_language_model(
             inputs,
             item_selector=self._random_selector,

--- a/keras_nlp/layers/preprocessing/mlm_mask_generator_test.py
+++ b/keras_nlp/layers/preprocessing/mlm_mask_generator_test.py
@@ -202,7 +202,7 @@ class MLMMaskGeneratorTest(tf.test.TestCase):
             mask_token_rate=1,
             random_token_rate=0,
         )
-        inputs = [unselectable_token_ids]
+        inputs = tf.convert_to_tensor([unselectable_token_ids])
         outputs = mlm_masker(inputs)
         # Verify that no token is masked out.
         self.assertEqual(tf.reduce_sum(outputs["mask_positions"]), 0)
@@ -232,3 +232,36 @@ class MLMMaskGeneratorTest(tf.test.TestCase):
             [[0, 1, 2], [0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4]]
         )
         cloned_mlm_masker(inputs)
+
+    def test_graph_mode_execution(self):
+        mlm_masker = MLMMaskGenerator(
+            vocabulary_size=self.vocabulary_size,
+            mask_selection_rate=0.5,
+            mask_token_id=self.mask_token_id,
+            mask_selection_length=5,
+        )
+
+        @tf.function
+        def masker(inputs):
+            return mlm_masker(inputs)
+
+        masker(tf.constant([1, 2, 3]))
+        masker(tf.constant([[1, 2, 3], [1, 2, 3]]))
+        masker(tf.ragged.constant([[3, 5, 7, 7], [4, 6, 7, 5]]))
+
+    def test_with_tf_data(self):
+        ds = tf.data.Dataset.from_tensor_slices(
+            tf.ones((100, 10), dtype="int32")
+        )
+        mlm_masker = MLMMaskGenerator(
+            vocabulary_size=self.vocabulary_size,
+            mask_selection_rate=0.5,
+            mask_token_id=self.mask_token_id,
+            mask_selection_length=5,
+        )
+        batch_first = ds.batch(8).map(mlm_masker)
+        batch_second = ds.map(mlm_masker).batch(8)
+        self.assertEqual(
+            batch_first.take(1).get_single_element()["tokens"].shape,
+            batch_second.take(1).get_single_element()["tokens"].shape,
+        )


### PR DESCRIPTION
The problem is caused by `tf.rank() == 1` check, which in graph mode generates a subgraph for things under if condition. Thus, the input shape became undetermined after the if branch, which crashed our downstream calls to shape.

Fix #128 