### PR TITLE
Remove type annotations for complex types

### DIFF
--- a/keras_nlp/tokenizers/byte_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_tokenizer.py
@@ -14,9 +14,6 @@
 
 """Byte Tokenizer."""
 
-from typing import Any
-from typing import Dict
-
 import numpy as np
 import tensorflow as tf
 import tensorflow_text as tf_text
@@ -248,7 +245,7 @@ class ByteTokenizer(tokenizer.Tokenizer):
         )
         return decoded
 
-    def get_config(self) -> Dict[str, Any]:
+    def get_config(self):
         config = super().get_config()
         config.update(
             {

--- a/keras_nlp/tokenizers/unicode_character_tokenizer.py
+++ b/keras_nlp/tokenizers/unicode_character_tokenizer.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
-from typing import Dict
-
 import tensorflow as tf
 import tensorflow_text as tf_text
 
@@ -247,7 +244,7 @@ class UnicodeCharacterTokenizer(tokenizer.Tokenizer):
         self.output_encoding = output_encoding
         self.vocabulary_size = vocabulary_size
 
-    def get_config(self) -> Dict[str, Any]:
+    def get_config(self):
         config = super().get_config()
         config.update(
             {

--- a/keras_nlp/tokenizers/word_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer.py
@@ -12,11 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
-from typing import Dict
 from typing import Iterable
 from typing import List
-from typing import Union
 
 import tensorflow as tf
 import tensorflow_text as tf_text
@@ -175,7 +172,7 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
 
     def __init__(
         self,
-        vocabulary: Union[Iterable[str], str] = None,
+        vocabulary=None,
         sequence_length: int = None,
         lowercase: bool = True,
         strip_accents: bool = True,
@@ -262,11 +259,11 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
     def token_to_id(self, token: str) -> int:
         """Convert a string token to an integer id."""
         # This will be slow, but keep memory usage down compared to building a
-        # dict. Assuming the main use case is looking up a few special tokens
+        # . Assuming the main use case is looking up a few special tokens
         # early in the vocab, this should be fine.
         return self.vocabulary.index(token)
 
-    def get_config(self) -> Dict[str, Any]:
+    def get_config(self):
         config = super().get_config()
         config.update(
             {


### PR DESCRIPTION
We discussed as a group a while ago avoiding the complex union type hints for now. They clutter up the docs a little too.

Let's remove them.