### PR TITLE
Run keras tuner from a temp directory

### DIFF
--- a/examples/bert/bert_finetune_glue.py
+++ b/examples/bert/bert_finetune_glue.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Run finetuning on a GLUE task."""
 
+import tempfile
+
 import datasets
 import keras_tuner
 import tensorflow as tf
@@ -251,6 +253,7 @@ def main(_):
         max_trials=4,
         overwrite=True,
         project_name="hyperparameter_tuner_results",
+        directory=tempfile.mkdtemp(),
     )
 
     tuner.search(


### PR DESCRIPTION
Otherwise the temporary saved models will always be in your current
working directory. I don't think we need to make this configurable, as
you can already specify the output directory for the best saved model.