### PR TITLE
Configure GKE-based accelerator testing

### DIFF
--- a/cloudbuild/Dockerfile
+++ b/cloudbuild/Dockerfile
@@ -1,0 +1,8 @@
+# Creates environment to run unit tests with current nightly image.
+FROM tensorflow/tensorflow:latest-gpu
+COPY . /kerasnlp
+WORKDIR /kerasnlp
+RUN apt-get -y update
+RUN apt-get -y install git
+RUN pip install -r cloudbuild/requirements.txt
+CMD ["./cloudbuild/quickstart.sh"]

--- a/cloudbuild/Dockerfile
+++ b/cloudbuild/Dockerfile
@@ -1,8 +1,7 @@
 # Creates environment to run unit tests with current nightly image.
-FROM tensorflow/tensorflow:latest-gpu
+FROM tensorflow/tensorflow:2.9.1-gpu
 COPY . /kerasnlp
 WORKDIR /kerasnlp
 RUN apt-get -y update
 RUN apt-get -y install git
 RUN pip install -r cloudbuild/requirements.txt
-CMD ["./cloudbuild/quickstart.sh"]

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -1,11 +1,16 @@
 substitutions:
   # GCS location to write temporary checkpoints and summaries.
-  _GCS_BUCKET: 'gs://chenmoney-gke-test'
+  # TODO(chenmoneygithub): Change the bucket to a stable one after GPU is 
+  # granted for keras-team-test.
+  _GCS_BUCKET: 'gs://keras-nlp-test'
   # Name of GKE cluster in which to run Job.
+  # TODO(chenmoneygithub): Change the cluster to a stable one after GPU is 
+  # granted for keras-team-test.
   _CLUSTER_NAME: 'tutorial-cluster'
   # Location of GKE cluster.
   _CLUSTER_ZONE: 'us-central1-b'
-  _TAG_NAME: '2022-07-08-3pm'
+  # Image name.
+  _IMAGE_NAME: 'us-central1-docker.pkg.dev/keras-team-gcp/keras-nlp-test/test-image'
 steps:
 - name: 'docker'
   id: build-image
@@ -13,13 +18,13 @@ steps:
     'build',
     '.',
     '-f', 'cloudbuild/Dockerfile',
-    '-t', 'us-central1-docker.pkg.dev/keras-team-gcp/keras-nlp-test/test-image:$_TAG_NAME',
+    '-t', '$_IMAGE_NAME:$BUILD_ID',
   ]
 - name: 'docker'
   id: push-image
   waitFor:
   - build-image
-  args: ['push', 'us-central1-docker.pkg.dev/keras-team-gcp/keras-nlp-test/test-image:$_TAG_NAME']
+  args: ['push', '$_IMAGE_NAME:$BUILD_ID']
 - name: 'golang'
   id: download-jsonnet
   waitFor: ['-']
@@ -46,8 +51,8 @@ steps:
     'cloudbuild/unit_test_jobs.jsonnet',
     '--string',
     '-J', 'ml-testing-accelerators',
-    '--ext-str', 'image=us-central1-docker.pkg.dev/keras-team-gcp/keras-nlp-test/test-image',
-    '--ext-str', 'tag_name=$_TAG_NAME',
+    '--ext-str', 'image=$_IMAGE_NAME',
+    '--ext-str', 'tag_name=$BUILD_ID',
     '--ext-str', 'gcs_bucket=$_GCS_BUCKET',
     '-o', 'output.yaml',
   ]

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -1,0 +1,78 @@
+substitutions:
+  # GCS location to write temporary checkpoints and summaries.
+  _GCS_BUCKET: 'gs://chenmoney-gke-test'
+  # Name of GKE cluster in which to run Job.
+  _CLUSTER_NAME: 'tutorial-cluster'
+  # Location of GKE cluster.
+  _CLUSTER_ZONE: 'us-central1-b'
+  _TAG_NAME: '2022-07-08-3pm'
+steps:
+- name: 'docker'
+  id: build-image
+  args: [
+    'build',
+    '.',
+    '-f', 'cloudbuild/Dockerfile',
+    '-t', 'us-central1-docker.pkg.dev/keras-team-gcp/keras-nlp-test/test-image:$_TAG_NAME',
+  ]
+- name: 'docker'
+  id: push-image
+  waitFor:
+  - build-image
+  args: ['push', 'us-central1-docker.pkg.dev/keras-team-gcp/keras-nlp-test/test-image:$_TAG_NAME']
+- name: 'golang'
+  id: download-jsonnet
+  waitFor: ['-']
+  entrypoint: 'go'
+  args: [
+    'install',
+    'github.com/google/go-jsonnet/cmd/jsonnet@latest',
+  ]
+- name: 'google/cloud-sdk'
+  id: clone-templates
+  waitFor: ['-']
+  entrypoint: 'git'
+  args: [
+    'clone',
+    'https://github.com/GoogleCloudPlatform/ml-testing-accelerators.git',
+  ]
+- name: 'golang'
+  id: build-templates
+  waitFor:
+  - download-jsonnet
+  - clone-templates
+  entrypoint: 'jsonnet'
+  args: [
+    'cloudbuild/unit_test_jobs.jsonnet',
+    '--string',
+    '-J', 'ml-testing-accelerators',
+    '--ext-str', 'image=us-central1-docker.pkg.dev/keras-team-gcp/keras-nlp-test/test-image',
+    '--ext-str', 'tag_name=$_TAG_NAME',
+    '--ext-str', 'gcs_bucket=$_GCS_BUCKET',
+    '-o', 'output.yaml',
+  ]
+- name: 'google/cloud-sdk'
+  id: create-job
+  waitFor:
+  - push-image
+  - build-templates
+  entrypoint: bash
+  args:
+  - -c
+  - |
+    set -u
+    set -e
+    set -x
+
+    gcloud container clusters get-credentials $_CLUSTER_NAME --zone $_CLUSTER_ZONE --project keras-team-gcp
+    job_name=$(kubectl create -f output.yaml -o name)
+    sleep 5
+    pod_name=$(kubectl wait --for condition=ready --timeout=10m pod -l job-name=${job_name#job.batch/} -o name)
+    kubectl logs -f $pod_name --container=train
+    sleep 5
+    exit $(kubectl get $pod_name -o jsonpath={.status.containerStatuses[0].state.terminated.exitCode})
+timeout: 1800s  # 30 minutes
+options:
+  volumes:
+  - name: go-modules
+    path: /go

--- a/cloudbuild/quickstart.sh
+++ b/cloudbuild/quickstart.sh
@@ -1,0 +1,1 @@
+echo "Hello, world! The time is $(date)."

--- a/cloudbuild/quickstart.sh
+++ b/cloudbuild/quickstart.sh
@@ -1,1 +1,1 @@
-echo "Hello, world! The time is $(date)."
+echo "Hello, worldddd! The time is $(date)."

--- a/cloudbuild/quickstart.sh
+++ b/cloudbuild/quickstart.sh
@@ -1,1 +1,0 @@
-echo "Hello, worldddd! The time is $(date)."

--- a/cloudbuild/unit_test_jobs.jsonnet
+++ b/cloudbuild/unit_test_jobs.jsonnet
@@ -6,13 +6,13 @@ local tagName = std.extVar('tag_name');
 local gcsBucket = std.extVar('gcs_bucket');
 
 local unittest = base.BaseTest {
-  // Configure job name
+  // Configure job name.
   frameworkPrefix: "tf",
   modelName: "keras-nlp",
   mode: "unit-tests",
   timeout: 3600, # 1 hour, in seconds
 
-  // Set up runtime environment
+  // Set up runtime environment.
   image: image,
   imageTag: tagName,
   accelerator: gpus.teslaV100,
@@ -22,14 +22,14 @@ local unittest = base.BaseTest {
     'bash',
     '-c',
     |||
-      # Run whatever is in `command` here
+      # Run whatever is in `command` here.
       cd keras-nlp
       ${@:0}
     |||
   ],
   command: [
     'pytest',
-    'keras_nlp/layers',
+    'keras_nlp',
   ],
 };
 

--- a/cloudbuild/unit_test_jobs.jsonnet
+++ b/cloudbuild/unit_test_jobs.jsonnet
@@ -1,0 +1,36 @@
+local base = import 'templates/base.libsonnet';
+local gpus = import 'templates/gpus.libsonnet';
+
+local image = std.extVar('image');
+local tagName = std.extVar('tag_name');
+local gcsBucket = std.extVar('gcs_bucket');
+
+local unittest = base.BaseTest {
+  // Configure job name
+  frameworkPrefix: "tf",
+  modelName: "keras-nlp",
+  mode: "unit-tests",
+  timeout: 3600, # 1 hour, in seconds
+
+  // Set up runtime environment
+  image: image,
+  imageTag: tagName,
+  accelerator: gpus.teslaV100,
+  outputBucket: gcsBucket,
+
+  entrypoint: [
+    'bash',
+    '-c',
+    |||
+      # Run whatever is in `command` here
+      cd keras-nlp
+      ${@:0}
+    |||
+  ],
+  command: [
+    'pytest',
+    'keras_nlp/layers',
+  ],
+};
+
+std.manifestYamlDoc(unittest.oneshotJob, quote_keys=false)


### PR DESCRIPTION
The test is based on [ml-accelerator-testing](https://github.com/GoogleCloudPlatform/ml-testing-accelerators), and it is now using GCP project keras-team-gcp.

This is under experiment and subject to quick iterations. After we are confident with our approach, we will migrate to GCP project keras-team-test, which is designed specifically for testing purposes (still waiting for resources). 