### PR TITLE
Add requirements.txt for cloud build

### DIFF
--- a/cloudbuild/requirements.txt
+++ b/cloudbuild/requirements.txt
@@ -1,0 +1,12 @@
+absl-py
+numpy
+packaging
+tensorflow
+tensorflow-text
+black
+flake8
+isort
+pytest
+pytest-cov
+rouge-score
+sentencepiece


### PR DESCRIPTION
Add requirements.txt for cloud build, this file is required for building the docker image. 