### PR TITLE
Empty Input for Utils

### DIFF
--- a/keras_nlp/utils/text_generation.py
+++ b/keras_nlp/utils/text_generation.py
@@ -27,7 +27,7 @@ def validate_prompt(prompt):
             "provide `prompt` as a list or Tensor."
         )
     if not isinstance(prompt, tf.Tensor):
-        prompt = tf.convert_to_tensor(prompt)
+        prompt = tf.convert_to_tensor(prompt, dtype=tf.int32)
     return prompt
 
 

--- a/keras_nlp/utils/text_generation.py
+++ b/keras_nlp/utils/text_generation.py
@@ -28,10 +28,6 @@ def validate_prompt(prompt):
         )
     if not isinstance(prompt, tf.Tensor):
         prompt = tf.convert_to_tensor(prompt)
-    if prompt.shape[-1] == 0:
-        raise ValueError(
-            "Length of `prompt` is 0, please provide a non-empty `prompt`."
-        )
     return prompt
 
 

--- a/keras_nlp/utils/text_generation_test.py
+++ b/keras_nlp/utils/text_generation_test.py
@@ -50,14 +50,6 @@ class GreedySearchTextGenerationTest(tf.test.TestCase):
 
         self.token_probability_fn = token_probability_fn
 
-    def test_generate_with_empty_prompt(self):
-        inputs = tf.constant([])
-        with self.assertRaises(ValueError):
-            greedy_search(self.token_probability_fn, inputs, max_length=5)
-        inputs = tf.constant([[]])
-        with self.assertRaises(ValueError):
-            greedy_search(self.token_probability_fn, inputs, max_length=5)
-
     def test_generate_with_1d_prompt(self):
         inputs = tf.constant([1])
         outputs = greedy_search(self.token_probability_fn, inputs, max_length=5)
@@ -137,18 +129,6 @@ class BeamSearchTextGenerationTest(tf.test.TestCase):
             return model(inputs)[:, -1, :]
 
         self.token_probability_fn = token_probability_fn
-
-    def test_generate_with_empty_prompt(self):
-        inputs = tf.constant([])
-        with self.assertRaises(ValueError):
-            beam_search(
-                self.token_probability_fn, inputs, max_length=5, num_beams=5
-            )
-        inputs = tf.constant([[]])
-        with self.assertRaises(ValueError):
-            beam_search(
-                self.token_probability_fn, inputs, max_length=5, num_beams=5
-            )
 
     def test_generate_with_1d_prompt(self):
         inputs = tf.constant([1])
@@ -311,14 +291,6 @@ class RandomSearchTextGenerationTest(tf.test.TestCase):
 
         self.token_probability_fn = token_probability_fn
 
-    def test_generate_with_empty_prompt(self):
-        inputs = tf.constant([])
-        with self.assertRaises(ValueError):
-            random_search(self.token_probability_fn, inputs, max_length=5)
-        inputs = tf.constant([[]])
-        with self.assertRaises(ValueError):
-            random_search(self.token_probability_fn, inputs, max_length=5)
-
     def test_generate_with_1d_prompt(self):
         inputs = tf.constant([1])
         outputs = random_search(self.token_probability_fn, inputs, max_length=5)
@@ -443,14 +415,6 @@ class TopKSearchTextGenerationTest(tf.test.TestCase):
             return model(inputs)[:, -1, :]
 
         self.token_probability_fn = token_probability_fn
-
-    def test_generate_with_empty_prompt(self):
-        inputs = tf.constant([])
-        with self.assertRaises(ValueError):
-            top_k_search(self.token_probability_fn, inputs, max_length=5, k=2)
-        inputs = tf.constant([[]])
-        with self.assertRaises(ValueError):
-            top_k_search(self.token_probability_fn, inputs, max_length=5, k=2)
 
     def test_generate_with_1d_prompt(self):
         inputs = tf.constant([1])
@@ -618,14 +582,6 @@ class TopPSearchTextGenerationTest(tf.test.TestCase):
             return model(inputs)[:, -1, :]
 
         self.token_probability_fn = token_probability_fn
-
-    def test_generate_with_empty_prompt(self):
-        inputs = tf.constant([])
-        with self.assertRaises(ValueError):
-            top_p_search(self.token_probability_fn, inputs, max_length=5, p=0.8)
-        inputs = tf.constant([[]])
-        with self.assertRaises(ValueError):
-            top_p_search(self.token_probability_fn, inputs, max_length=5, p=0.8)
 
     def test_generate_with_1d_prompt(self):
         inputs = tf.constant([1])


### PR DESCRIPTION
Utility functions should be able to take in an empty input prompt. This is because whether it can take in an empty prompt or not is determined by whether there is packing of the input and what the model is in `token_probability_fn`. Hence, it is not the utility's responsibility to check whether it is an empty input.