### PR TITLE
Add a test for variable sequence length inputs

### DIFF
--- a/keras_nlp/models/bert_test.py
+++ b/keras_nlp/models/bert_test.py
@@ -46,7 +46,7 @@ class BertTest(tf.test.TestCase):
         model(input_data)
 
     def test_variable_sequence_length_call_bert(self):
-        model = bert.Bert(
+        model = bert.BertCustom(
             vocabulary_size=30522,
             num_layers=12,
             num_heads=12,
@@ -55,7 +55,7 @@ class BertTest(tf.test.TestCase):
             max_sequence_length=100,
             name="encoder",
         )
-        for seq_length in (25, 50, 100):
+        for seq_length in (25, 50, 75):
             input_data = {
                 "input_ids": tf.ones((8, seq_length), dtype="int32"),
                 "segment_ids": tf.ones((8, seq_length), dtype="int32"),

--- a/keras_nlp/models/bert_test.py
+++ b/keras_nlp/models/bert_test.py
@@ -45,6 +45,24 @@ class BertTest(tf.test.TestCase):
         }
         model(input_data)
 
+    def test_variable_sequence_length_call_bert(self):
+        model = bert.Bert(
+            vocabulary_size=30522,
+            num_layers=12,
+            num_heads=12,
+            hidden_dim=768,
+            intermediate_dim=3072,
+            max_sequence_length=100,
+            name="encoder",
+        )
+        for seq_length in (25, 50, 100):
+            input_data = {
+                "input_ids": tf.ones((8, seq_length), dtype="int32"),
+                "segment_ids": tf.ones((8, seq_length), dtype="int32"),
+                "input_mask": tf.ones((8, seq_length), dtype="int32"),
+            }
+            model(input_data)
+
     def test_valid_call_classifier(self):
         model = bert.BertCustom(
             vocabulary_size=30522,


### PR DESCRIPTION
As discussed on a long thread here, we want to make sure our models
support variable sequence lengths.
https://github.com/keras-team/keras-nlp/pull/304#pullrequestreview-1086162750

This works today, but perhaps a bit incidentally. Let's add a unit test.