### PR TITLE
Streamline and speed up tests

### DIFF
--- a/keras_nlp/models/bert_test.py
+++ b/keras_nlp/models/bert_test.py
@@ -32,10 +32,17 @@ class BertTest(tf.test.TestCase):
             max_sequence_length=128,
             name="encoder",
         )
+        self.batch_size = 8
         self.input_data = {
-            "input_ids": tf.ones((8, 128), dtype="int32"),
-            "segment_ids": tf.ones((8, 128), dtype="int32"),
-            "input_mask": tf.ones((8, 128), dtype="int32"),
+            "input_ids": tf.ones(
+                (self.batch_size, self.model.max_sequence_length), dtype="int32"
+            ),
+            "segment_ids": tf.ones(
+                (self.batch_size, self.model.max_sequence_length), dtype="int32"
+            ),
+            "input_mask": tf.ones(
+                (self.batch_size, self.model.max_sequence_length), dtype="int32"
+            ),
         }
 
     def test_valid_call_bert(self):
@@ -44,9 +51,15 @@ class BertTest(tf.test.TestCase):
     def test_variable_sequence_length_call_bert(self):
         for seq_length in (25, 50, 75):
             input_data = {
-                "input_ids": tf.ones((8, seq_length), dtype="int32"),
-                "segment_ids": tf.ones((8, seq_length), dtype="int32"),
-                "input_mask": tf.ones((8, seq_length), dtype="int32"),
+                "input_ids": tf.ones(
+                    (self.batch_size, seq_length), dtype="int32"
+                ),
+                "segment_ids": tf.ones(
+                    (self.batch_size, seq_length), dtype="int32"
+                ),
+                "input_mask": tf.ones(
+                    (self.batch_size, seq_length), dtype="int32"
+                ),
             }
             self.model(input_data)
 
@@ -58,13 +71,13 @@ class BertTest(tf.test.TestCase):
         model = bert.BertBase(vocabulary_size=1000, name="encoder")
         input_data = {
             "input_ids": tf.ones(
-                (8, self.model.max_sequence_length), dtype="int32"
+                (self.batch_size, self.model.max_sequence_length), dtype="int32"
             ),
             "segment_ids": tf.ones(
-                (8, self.model.max_sequence_length), dtype="int32"
+                (self.batch_size, self.model.max_sequence_length), dtype="int32"
             ),
             "input_mask": tf.ones(
-                (8, self.model.max_sequence_length), dtype="int32"
+                (self.batch_size, self.model.max_sequence_length), dtype="int32"
             ),
         }
         model(input_data)
@@ -78,7 +91,7 @@ class BertTest(tf.test.TestCase):
         with self.assertRaises(ValueError):
             bert.BertBase(
                 weights="bert_base_uncased",
-                vocabulary_size=10000,
+                vocabulary_size=1000,
                 name="encoder",
             )
 

--- a/keras_nlp/models/bert_test.py
+++ b/keras_nlp/models/bert_test.py
@@ -22,79 +22,50 @@ from keras_nlp.models import bert
 
 
 class BertTest(tf.test.TestCase):
-    def test_valid_call_bert(self):
-        model = bert.BertCustom(
-            vocabulary_size=30522,
-            num_layers=12,
-            num_heads=12,
-            hidden_dim=768,
-            intermediate_dim=3072,
-            max_sequence_length=12,
+    def setUp(self):
+        self.model = bert.BertCustom(
+            vocabulary_size=1000,
+            num_layers=2,
+            num_heads=2,
+            hidden_dim=64,
+            intermediate_dim=128,
+            max_sequence_length=128,
             name="encoder",
         )
-        input_data = {
-            "input_ids": tf.random.uniform(
-                shape=(1, 12), dtype=tf.int64, maxval=model.vocabulary_size
-            ),
-            "segment_ids": tf.constant(
-                [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
-            ),
-            "input_mask": tf.constant(
-                [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
-            ),
+        self.input_data = {
+            "input_ids": tf.ones((8, 128), dtype="int32"),
+            "segment_ids": tf.ones((8, 128), dtype="int32"),
+            "input_mask": tf.ones((8, 128), dtype="int32"),
         }
-        model(input_data)
+
+    def test_valid_call_bert(self):
+        self.model(self.input_data)
 
     def test_variable_sequence_length_call_bert(self):
-        model = bert.BertCustom(
-            vocabulary_size=30522,
-            num_layers=12,
-            num_heads=12,
-            hidden_dim=768,
-            intermediate_dim=3072,
-            max_sequence_length=100,
-            name="encoder",
-        )
         for seq_length in (25, 50, 75):
             input_data = {
                 "input_ids": tf.ones((8, seq_length), dtype="int32"),
                 "segment_ids": tf.ones((8, seq_length), dtype="int32"),
                 "input_mask": tf.ones((8, seq_length), dtype="int32"),
             }
-            model(input_data)
+            self.model(input_data)
 
     def test_valid_call_classifier(self):
-        model = bert.BertCustom(
-            vocabulary_size=30522,
-            num_layers=12,
-            num_heads=12,
-            hidden_dim=768,
-            intermediate_dim=3072,
-            max_sequence_length=12,
-            name="encoder",
-        )
-        input_data = {
-            "input_ids": tf.random.uniform(
-                shape=(1, 12), dtype=tf.int64, maxval=30522
-            ),
-            "segment_ids": tf.constant(
-                [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
-            ),
-            "input_mask": tf.constant(
-                [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
-            ),
-        }
-        classifier = bert.BertClassifier(model, 4, name="classifier")
-        classifier(input_data)
+        classifier = bert.BertClassifier(self.model, 4, name="classifier")
+        classifier(self.input_data)
 
     def test_valid_call_bert_base(self):
-        model = bert.BertBase(vocabulary_size=10000, name="encoder")
+        model = bert.BertBase(vocabulary_size=1000, name="encoder")
         input_data = {
-            "input_ids": tf.random.uniform(
-                shape=(1, 512), dtype=tf.int64, maxval=model.vocabulary_size
+            "input_ids": tf.ones(
+                (8, self.model.max_sequence_length), dtype="int32"
             ),
-            "segment_ids": tf.constant([0] * 200 + [1] * 312, shape=(1, 512)),
-            "input_mask": tf.constant([1] * 512, shape=(1, 512)),
+            "segment_ids": tf.ones(
+                (8, self.model.max_sequence_length), dtype="int32"
+            ),
+            "input_mask": tf.ones(
+                (8, self.model.max_sequence_length), dtype="int32"
+            ),
         }
         model(input_data)
 
@@ -119,32 +90,12 @@ class BertTest(tf.test.TestCase):
             )
 
     def test_saving_model(self):
-        model = bert.BertCustom(
-            vocabulary_size=30522,
-            num_layers=12,
-            num_heads=12,
-            hidden_dim=768,
-            intermediate_dim=3072,
-            max_sequence_length=12,
-            name="encoder",
-        )
-        input_data = {
-            "input_ids": tf.random.uniform(
-                shape=(1, 12), dtype=tf.int64, maxval=model.vocabulary_size
-            ),
-            "segment_ids": tf.constant(
-                [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
-            ),
-            "input_mask": tf.constant(
-                [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
-            ),
-        }
-        model_output = model(input_data)
+        model_output = self.model(self.input_data)
         save_path = os.path.join(self.get_temp_dir(), "model")
-        model.save(save_path)
+        self.model.save(save_path)
         restored_model = keras.models.load_model(save_path)
 
-        restored_output = restored_model(input_data)
+        restored_output = restored_model(self.input_data)
         self.assertAllClose(
             model_output["pooled_output"], restored_output["pooled_output"]
         )

--- a/keras_nlp/models/roberta_test.py
+++ b/keras_nlp/models/roberta_test.py
@@ -32,9 +32,14 @@ class RobertaTest(tf.test.TestCase):
             max_sequence_length=128,
             name="encoder",
         )
+        self.batch_size = 8
         self.input_data = {
-            "input_ids": tf.ones((8, 128), dtype="int32"),
-            "input_mask": tf.ones((8, 128), dtype="int32"),
+            "input_ids": tf.ones(
+                (self.batch_size, self.model.max_sequence_length), dtype="int32"
+            ),
+            "input_mask": tf.ones(
+                (self.batch_size, self.model.max_sequence_length), dtype="int32"
+            ),
         }
 
     def test_valid_call_roberta(self):
@@ -42,7 +47,7 @@ class RobertaTest(tf.test.TestCase):
 
     def test_valid_call_classifier(self):
         classifier = roberta.RobertaClassifier(
-            self.model, 4, 768, name="classifier"
+            self.model, 4, 128, name="classifier"
         )
         classifier(self.input_data)
 
@@ -50,10 +55,10 @@ class RobertaTest(tf.test.TestCase):
         model = roberta.RobertaBase(vocabulary_size=1000, name="encoder")
         input_data = {
             "input_ids": tf.ones(
-                (8, self.model.max_sequence_length), dtype="int32"
+                (self.batch_size, model.max_sequence_length), dtype="int32"
             ),
             "input_mask": tf.ones(
-                (8, self.model.max_sequence_length), dtype="int32"
+                (self.batch_size, model.max_sequence_length), dtype="int32"
             ),
         }
         model(input_data)
@@ -61,13 +66,17 @@ class RobertaTest(tf.test.TestCase):
     def test_variable_sequence_length_call_roberta(self):
         for seq_length in (25, 50, 75):
             input_data = {
-                "input_ids": tf.ones((8, seq_length), dtype="int32"),
-                "input_mask": tf.ones((8, seq_length), dtype="int32"),
+                "input_ids": tf.ones(
+                    (self.batch_size, seq_length), dtype="int32"
+                ),
+                "input_mask": tf.ones(
+                    (self.batch_size, seq_length), dtype="int32"
+                ),
             }
             output = self.model(input_data)
             self.assertAllEqual(
                 tf.shape(output["sequence_output"]),
-                [8, seq_length, self.model.hidden_dim],
+                [self.batch_size, seq_length, self.model.hidden_dim],
             )
 
     def test_saving_model(self):

--- a/keras_nlp/models/roberta_test.py
+++ b/keras_nlp/models/roberta_test.py
@@ -22,102 +22,62 @@ from keras_nlp.models import roberta
 
 
 class RobertaTest(tf.test.TestCase):
-    def test_valid_call_roberta(self):
-        model = roberta.RobertaCustom(
-            vocabulary_size=50265,
-            num_layers=12,
-            num_heads=12,
-            hidden_dim=768,
-            intermediate_dim=3072,
-            max_sequence_length=12,
+    def setUp(self):
+        self.model = roberta.RobertaCustom(
+            vocabulary_size=1000,
+            num_layers=2,
+            num_heads=2,
+            hidden_dim=64,
+            intermediate_dim=128,
+            max_sequence_length=128,
             name="encoder",
         )
-        input_data = {
-            "input_ids": tf.random.uniform(
-                shape=(1, 12), dtype=tf.int64, maxval=model.vocabulary_size
-            ),
-            "input_mask": tf.constant(
-                [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
-            ),
+        self.input_data = {
+            "input_ids": tf.ones((8, 128), dtype="int32"),
+            "input_mask": tf.ones((8, 128), dtype="int32"),
         }
-        model(input_data)
+
+    def test_valid_call_roberta(self):
+        self.model(self.input_data)
 
     def test_valid_call_classifier(self):
-        model = roberta.RobertaCustom(
-            vocabulary_size=50265,
-            num_layers=12,
-            num_heads=12,
-            hidden_dim=768,
-            intermediate_dim=3072,
-            max_sequence_length=12,
-            name="encoder",
+        classifier = roberta.RobertaClassifier(
+            self.model, 4, 768, name="classifier"
         )
-        input_data = {
-            "input_ids": tf.random.uniform(
-                shape=(1, 12), dtype=tf.int64, maxval=model.vocabulary_size
-            ),
-            "input_mask": tf.constant(
-                [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
-            ),
-        }
-        classifier = roberta.RobertaClassifier(model, 4, 768, name="classifier")
-        classifier(input_data)
+        classifier(self.input_data)
 
     def test_valid_call_roberta_base(self):
-        model = roberta.RobertaBase(vocabulary_size=10000, name="encoder")
+        model = roberta.RobertaBase(vocabulary_size=1000, name="encoder")
         input_data = {
-            "input_ids": tf.random.uniform(
-                shape=(1, 512), dtype=tf.int64, maxval=model.vocabulary_size
+            "input_ids": tf.ones(
+                (8, self.model.max_sequence_length), dtype="int32"
             ),
-            "input_mask": tf.constant([1] * 512, shape=(1, 512)),
+            "input_mask": tf.ones(
+                (8, self.model.max_sequence_length), dtype="int32"
+            ),
         }
         model(input_data)
 
     def test_variable_sequence_length_call_roberta(self):
-        model = roberta.RobertaCustom(
-            vocabulary_size=50265,
-            num_layers=12,
-            num_heads=12,
-            hidden_dim=768,
-            intermediate_dim=3072,
-            max_sequence_length=100,
-            name="encoder",
-        )
         for seq_length in (25, 50, 75):
             input_data = {
                 "input_ids": tf.ones((8, seq_length), dtype="int32"),
                 "input_mask": tf.ones((8, seq_length), dtype="int32"),
             }
-            output = model(input_data)
+            output = self.model(input_data)
             self.assertAllEqual(
-                tf.shape(output["sequence_output"]), [8, seq_length, 768]
+                tf.shape(output["sequence_output"]),
+                [8, seq_length, self.model.hidden_dim],
             )
 
     def test_saving_model(self):
-        model = roberta.RobertaCustom(
-            vocabulary_size=50265,
-            num_layers=12,
-            num_heads=12,
-            hidden_dim=768,
-            intermediate_dim=3072,
-            max_sequence_length=12,
-            name="encoder",
-        )
-        input_data = {
-            "input_ids": tf.random.uniform(
-                shape=(1, 12), dtype=tf.int64, maxval=model.vocabulary_size
-            ),
-            "input_mask": tf.constant(
-                [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
-            ),
-        }
-        model_output = model.predict(input_data)
+        model_output = self.model.predict(self.input_data)
 
         save_path = os.path.join(self.get_temp_dir(), "model")
-        model.save(save_path)
+        self.model.save(save_path)
         restored_model = keras.models.load_model(save_path)
 
-        restored_output = restored_model.predict(input_data)
+        restored_output = restored_model.predict(self.input_data)
         self.assertAllClose(
             model_output["sequence_output"],
             restored_output["sequence_output"],

--- a/keras_nlp/utils/text_generation_test.py
+++ b/keras_nlp/utils/text_generation_test.py
@@ -415,7 +415,7 @@ class RandomSearchTextGenerationTest(tf.test.TestCase, parameterized.TestCase):
 
         outputs_count = np.array([0, 0, 0, 0])
         tf.random.set_seed(42)
-        for i in range(500):
+        for i in range(64):
             outputs = random_search(
                 token_probability_fn, inputs, max_length=max_length, seed=42
             )
@@ -629,7 +629,7 @@ class TopKSearchTextGenerationTest(tf.test.TestCase, parameterized.TestCase):
 
         outputs_count = np.array([0, 0, 0, 0])
         tf.random.set_seed(42)
-        for i in range(500):
+        for _ in range(64):
             outputs = top_k_search(
                 token_probability_fn,
                 inputs,
@@ -859,7 +859,7 @@ class TopPSearchTextGenerationTest(tf.test.TestCase, parameterized.TestCase):
 
         outputs_count = np.array([0, 0, 0, 0])
         tf.random.set_seed(42)
-        for i in range(500):
+        for i in range(64):
             outputs = top_p_search(
                 token_probability_fn,
                 inputs,


### PR DESCRIPTION
Our test suite current takes over 200s to run on my cloudtop. Additionally test code for the new `Bert` and `Roberta` models has a lot of boilerplate.

Fixes:
* Create `setUp` function with smaller architectures for `Bert` and `Roberta`.
* Reference `setUp` model arch in tests to reduce brittleness.
* Reduce number of steps in `test_assert_probability_distribution_generation_is_correct` functions.

Result: ~2x speedup in test runtime (106s) and more maintainable test suites (-75 lines)