### PR TITLE
Return a single tensor from roberta

### DIFF
--- a/keras_nlp/models/roberta.py
+++ b/keras_nlp/models/roberta.py
@@ -138,9 +138,7 @@ class RobertaCustom(keras.Model):
                 "token_ids": token_id_input,
                 "padding_mask": padding_mask,
             },
-            outputs={
-                "sequence_output": x,
-            },
+            outputs=x,
             name=name,
             trainable=trainable,
         )
@@ -220,9 +218,7 @@ class RobertaClassifier(keras.Model):
         if hidden_dim is None:
             hidden_dim = base_model.hidden_dim
 
-        x = base_model(inputs)["sequence_output"][
-            :, base_model.cls_token_index, :
-        ]
+        x = base_model(inputs)[:, base_model.cls_token_index, :]
         x = keras.layers.Dropout(dropout, name="pooled_dropout")(x)
         x = keras.layers.Dense(
             hidden_dim, activation="tanh", name="pooled_dense"

--- a/keras_nlp/models/roberta_test.py
+++ b/keras_nlp/models/roberta_test.py
@@ -75,7 +75,7 @@ class RobertaTest(tf.test.TestCase):
             }
             output = self.model(input_data)
             self.assertAllEqual(
-                tf.shape(output["sequence_output"]),
+                tf.shape(output),
                 [self.batch_size, seq_length, self.model.hidden_dim],
             )
 
@@ -88,6 +88,6 @@ class RobertaTest(tf.test.TestCase):
 
         restored_output = restored_model.predict(self.input_data)
         self.assertAllClose(
-            model_output["sequence_output"],
-            restored_output["sequence_output"],
+            model_output,
+            restored_output,
         )


### PR DESCRIPTION
I think as an overall policy, it makes sense to return a single tensor
as a tensor not as a dictionary.

We could consider a dict to allow for future modifications to the output
to support more types. But I feel like that would be incorrect in this
case. Different "heads" for this base graph might define different
outputs, and this graph could be sliced to grab intermediate outputs,
but there will only ever be a single output from the RoBERTa core graph.