### PR TITLE
Add a BertPreprocessor class

### DIFF
--- a/keras_nlp/layers/multi_segment_packer_test.py
+++ b/keras_nlp/layers/multi_segment_packer_test.py
@@ -43,7 +43,7 @@ class MultiSegmentPackerTest(tf.test.TestCase, parameterized.TestCase):
         seq1 = tf.constant(["a", "b", "c"])
         seq2 = tf.constant(["x", "y", "z"])
         packer = MultiSegmentPacker(
-            7, start_value="[CLS]", end_value="[SEP]", truncator="round_robin"
+            7, start_value="[CLS]", end_value="[SEP]", truncate="round_robin"
         )
         output = packer([seq1, seq2])
         self.assertAllEqual(
@@ -58,7 +58,7 @@ class MultiSegmentPackerTest(tf.test.TestCase, parameterized.TestCase):
         seq1 = tf.constant(["a", "b", "c"])
         seq2 = tf.constant(["x", "y", "z"])
         packer = MultiSegmentPacker(
-            7, start_value="[CLS]", end_value="[SEP]", truncator="waterfall"
+            7, start_value="[CLS]", end_value="[SEP]", truncate="waterfall"
         )
         output = packer([seq1, seq2])
         self.assertAllEqual(
@@ -73,7 +73,7 @@ class MultiSegmentPackerTest(tf.test.TestCase, parameterized.TestCase):
         seq1 = tf.constant([["a", "b", "c"], ["a", "b", "c"]])
         seq2 = tf.constant([["x", "y", "z"], ["x", "y", "z"]])
         packer = MultiSegmentPacker(
-            7, start_value="[CLS]", end_value="[SEP]", truncator="round_robin"
+            7, start_value="[CLS]", end_value="[SEP]", truncate="round_robin"
         )
         output = packer([seq1, seq2])
         self.assertAllEqual(
@@ -94,7 +94,7 @@ class MultiSegmentPackerTest(tf.test.TestCase, parameterized.TestCase):
         seq1 = tf.ragged.constant([["a", "b", "c"], ["a", "b"]])
         seq2 = tf.constant([["x", "y", "z"], ["x", "y", "z"]])
         packer = MultiSegmentPacker(
-            7, start_value="[CLS]", end_value="[SEP]", truncator="waterfall"
+            7, start_value="[CLS]", end_value="[SEP]", truncate="waterfall"
         )
         output = packer([seq1, seq2])
         self.assertAllEqual(
@@ -151,7 +151,7 @@ class MultiSegmentPackerTest(tf.test.TestCase, parameterized.TestCase):
         seq1 = tf.ragged.constant([["a", "b", "c"], ["a", "b"]])
         seq2 = tf.ragged.constant([["x", "y", "z"], ["x", "y", "z"]])
         original_packer = MultiSegmentPacker(
-            7, start_value="[CLS]", end_value="[SEP]", truncator="waterfall"
+            7, start_value="[CLS]", end_value="[SEP]", truncate="waterfall"
         )
         cloned_packer = MultiSegmentPacker.from_config(
             original_packer.get_config()
@@ -166,7 +166,7 @@ class MultiSegmentPackerTest(tf.test.TestCase, parameterized.TestCase):
         seq1 = tf.ragged.constant([["a", "b", "c"], ["a", "b"]])
         seq2 = tf.ragged.constant([["x", "y", "z"], ["x", "y", "z"]])
         packer = MultiSegmentPacker(
-            7, start_value="[CLS]", end_value="[SEP]", truncator="waterfall"
+            7, start_value="[CLS]", end_value="[SEP]", truncate="waterfall"
         )
         inputs = (
             keras.Input(dtype="string", ragged=True, shape=(None,)),

--- a/keras_nlp/models/__init__.py
+++ b/keras_nlp/models/__init__.py
@@ -17,6 +17,7 @@ from keras_nlp.models.bert import BertClassifier
 from keras_nlp.models.bert import BertCustom
 from keras_nlp.models.bert import BertLarge
 from keras_nlp.models.bert import BertMedium
+from keras_nlp.models.bert import BertPreprocessor
 from keras_nlp.models.bert import BertSmall
 from keras_nlp.models.bert import BertTiny
 from keras_nlp.models.roberta import RobertaBase

--- a/keras_nlp/models/bert_test.py
+++ b/keras_nlp/models/bert_test.py
@@ -55,6 +55,10 @@ class BertPreprocessorTest(tf.test.TestCase):
         output = preprocessor.tokenizer.detokenize(input_data)
         self.assertAllEqual(output, ["THE QUICK BROWN FOX"])
 
+    def test_vocabulary_size(self):
+        preprocessor = bert.BertPreprocessor(vocabulary=self.vocab)
+        self.assertEqual(preprocessor.vocabulary_size(), 13)
+
 
 class BertTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):

--- a/keras_nlp/models/bert_test.py
+++ b/keras_nlp/models/bert_test.py
@@ -22,6 +22,40 @@ from tensorflow import keras
 from keras_nlp.models import bert
 
 
+class BertPreprocessorTest(tf.test.TestCase):
+    def setUp(self):
+        self.vocab = ["[PAD]", "[UNK]", "[CLS]", "[SEP]", "[MASK]"]
+        self.vocab += ["THE", "QUICK", "BROWN", "FOX"]
+        self.vocab += ["the", "quick", "brown", "fox"]
+
+    def test_tokenize(self):
+        input_data = ["THE QUICK BROWN FOX."]
+        preprocessor = bert.BertPreprocessor(
+            vocabulary=self.vocab,
+            sequence_length=8,
+        )
+        output = preprocessor(input_data)
+        self.assertAllEqual(output["token_ids"], [2, 5, 6, 7, 8, 1, 3, 0])
+        self.assertAllEqual(output["segment_ids"], [0, 0, 0, 0, 0, 0, 0, 0])
+        self.assertAllEqual(output["padding_mask"], [1, 1, 1, 1, 1, 1, 1, 0])
+
+    def test_lowercase(self):
+        input_data = ["THE QUICK BROWN FOX."]
+        preprocessor = bert.BertPreprocessor(
+            vocabulary=self.vocab,
+            sequence_length=8,
+            lowercase=True,
+        )
+        output = preprocessor(input_data)
+        self.assertAllEqual(output["token_ids"], [2, 9, 10, 11, 12, 1, 3, 0])
+
+    def test_detokenize(self):
+        input_data = [[5, 6, 7, 8]]
+        preprocessor = bert.BertPreprocessor(vocabulary=self.vocab)
+        output = preprocessor.tokenizer.detokenize(input_data)
+        self.assertAllEqual(output, ["THE QUICK BROWN FOX"])
+
+
 class BertTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
         self.model = bert.BertCustom(

--- a/keras_nlp/network_tests/test_load_ckpts.py
+++ b/keras_nlp/network_tests/test_load_ckpts.py
@@ -43,3 +43,13 @@ class BertCkptTest(tf.test.TestCase, parameterized.TestCase):
             "padding_mask": tf.constant([1] * 512, shape=(1, 512)),
         }
         model(input_data)
+
+    @parameterized.named_parameters(
+        ("uncased_en", "uncased_en"),
+        ("cased_en", "cased_en"),
+        ("zh", "zh"),
+        ("multi_cased", "multi_cased"),
+    )
+    def test_load_vocabularies(self, vocabulary):
+        tokenizer = keras_nlp.models.BertPreprocessor(vocabulary=vocabulary)
+        tokenizer("The quick brown fox.")


### PR DESCRIPTION
This exposes a tokenizer for Bert, including a way to access pretrained vocabularies, as a standalone class. I am fairly confident we will want access to this standalone (though it may be a power user tool). You might want to prepreprocess your inputs outside of the training script, and, in that case, we should not require users to load a massive tf graph.

I think one of the major design considerations here is wether we want add a parameters for the size of the model we want the vocab for (e.g. `"base"` or `"large"`). For bert there is no difference for pretrained vocabularies across sizes. This is also true for gpt-2, roberta, and xlm-roberta. I think for most model tokenizers we can avoid a "model size" parameter, which possibly some exceptions (though I have no concrete examples).