### PR TITLE
Move network_tests into keras_nlp/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,14 +126,14 @@ pytest keras_nlp/keras_nlp/integration_tests/import_test.py -k="import"
 
 ### Run all tests
 
-You can run all the testing we run continuously for the repository with:
+You can run the testing we run continuously for the repository with:
 
 ```shell
 pytest
 ```
 
 Some slow integration tests (e.g. tests that download large files) are
-disabled by default. You can run these by running:
+disabled by default. You can include these by running:
 
 ```shell
 pytest --runslow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ pytest keras_nlp/keras_nlp/integration_tests/import_test.py -k="import"
 
 ### Run all tests
 
-You can run the testing we run continuously for the repository with:
+You can run the full testing suite by simply invoking pytest:
 
 ```shell
 pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ Once the pull request is approved, a team member will take care of merging.
 Python 3.7 or later is required.
 
 Setting up your KerasNLP development environment requires you to fork the
-KerasNLP repository, clone the repository, create a virtual environment, and 
+KerasNLP repository, clone the repository, create a virtual environment, and
 install dependencies.
 
 You can achieve this by running the following commands:
@@ -126,10 +126,17 @@ pytest keras_nlp/keras_nlp/integration_tests/import_test.py -k="import"
 
 ### Run all tests
 
-You can run the unit tests for KerasNLP by running:
+You can run all the testing we run continuously for the repository with:
 
 ```shell
-pytest keras_nlp/
+pytest
+```
+
+Some slow integration tests (e.g. tests that download large files) are
+disabled by default. You can run these by running:
+
+```shell
+pytest --runslow
 ```
 
 ## Formatting Code

--- a/keras_nlp/conftest.py
+++ b/keras_nlp/conftest.py
@@ -1,0 +1,34 @@
+# Copyright 2022 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)

--- a/keras_nlp/network_tests/test_load_ckpts.py
+++ b/keras_nlp/network_tests/test_load_ckpts.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 """Tests for loading pretrained model checkpoints."""
 
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 
 import keras_nlp
 
 
+@pytest.mark.slow
 class BertCkptTest(tf.test.TestCase, parameterized.TestCase):
     @parameterized.named_parameters(
         ("uncased_en", "uncased_en"),

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,8 +10,8 @@ filterwarnings =
 
 addopts=-vv
 
-# Do not run tests in the `build` or `network_tests` folders
-norecursedirs = build network_tests
+# Do not run tests in the `build` folders
+norecursedirs = build
 
 [isort]
 known_first_party = keras_nlp,tests

--- a/shell/format.sh
+++ b/shell/format.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 base_dir=$(dirname $(dirname $0))
-targets="${base_dir}/*.py ${base_dir}/examples/ ${base_dir}/keras_nlp/ ${base_dir}/network_tests/"
+targets="${base_dir}/*.py ${base_dir}/examples/ ${base_dir}/keras_nlp/"
 
 isort --sp "${base_dir}/setup.cfg" --sl ${targets}
 black --line-length 80 ${targets}


### PR DESCRIPTION
This defines a [flag for pytest](https://docs.pytest.org/en/7.1.x/example/simple.html#control-skipping-of-tests-according-to-command-line-option) we can use to gate slow running tests,
without needing to keep them out of tree.

I think this will be a good way for us to collocate our, integration, network, and benchmarking tests, with a fine grained tool for deciding what to run.

