### PR TITLE
Add normalize_first arg to Transformer Layers

### DIFF
--- a/keras_nlp/layers/transformer_decoder.py
+++ b/keras_nlp/layers/transformer_decoder.py
@@ -63,10 +63,10 @@ class TransformerDecoder(keras.layers.Layer):
         bias_initializer: string or `keras.initializers` initializer,
             defaults to "zeros". The bias initializer for
             the dense and multiheaded attention layers.
-        normalize_first: bool. If True, the inputs to the attention layer(s) and
-            the intermediate dense layer are normalized (similar to GPT-2). If
-            set to False, outputs of attention layer and intermediate dense
-            layer are normalized (similar to BERT). Defaults to False.
+        normalize_first: bool. Defaults to False. If True, the inputs to the
+            attention layer(s) and the intermediate dense layer are normalized
+            (similar to GPT-2). If set to False, outputs of attention layer and
+            intermediate dense layer are normalized (similar to BERT).
         name: string, defaults to None. The name of the layer.
         **kwargs: other keyword arguments.
 
@@ -197,7 +197,7 @@ class TransformerDecoder(keras.layers.Layer):
         )
         self._output_dropout = keras.layers.Dropout(rate=self.dropout)
 
-    def _feed_forward(self, input):
+    def _feedforward(self, input):
         x = self._intermediate_dense(input)
         x = self._output_dense(x)
         return self._output_dropout(x)
@@ -317,13 +317,11 @@ class TransformerDecoder(keras.layers.Layer):
         if self.normalize_first:
             attention_output = self._feedforward_layernorm(attention_output)
         # Feedforward.
-        feed_forward_output = self._feed_forward(attention_output)
-        feed_forward_output = residual_attention_output + feed_forward_output
+        feedforward_output = self._feedforward(attention_output)
+        feedforward_output = residual_attention_output + feedforward_output
         if not self.normalize_first:
-            feed_forward_output = self._feedforward_layernorm(
-                feed_forward_output
-            )
-        return feed_forward_output
+            feedforward_output = self._feedforward_layernorm(feedforward_output)
+        return feedforward_output
 
     def get_config(self):
         config = super().get_config()

--- a/keras_nlp/layers/transformer_decoder_test.py
+++ b/keras_nlp/layers/transformer_decoder_test.py
@@ -23,12 +23,17 @@ from keras_nlp.layers import transformer_decoder
 
 
 class TransformerDecoderTest(tf.test.TestCase, parameterized.TestCase):
-    def test_valid_call(self):
+    @parameterized.named_parameters(
+        ("without_norm_first", False),
+        ("with_norm_first", True),
+    )
+    def test_valid_call(self, normalize_first):
         encoder_input = keras.Input(shape=[4, 6])
         decoder_input = keras.Input(shape=[4, 6])
         decoder = transformer_decoder.TransformerDecoder(
             intermediate_dim=4,
             num_heads=2,
+            normalize_first=normalize_first,
         )
         output = decoder(decoder_input, encoder_input)
         model = keras.Model(
@@ -39,11 +44,16 @@ class TransformerDecoderTest(tf.test.TestCase, parameterized.TestCase):
         decoder_sequence = tf.random.uniform(shape=[2, 4, 6])
         model([decoder_sequence, encoder_sequence])
 
-    def test_valid_call_without_cross_attention(self):
+    @parameterized.named_parameters(
+        ("without_norm_first", False),
+        ("with_norm_first", True),
+    )
+    def test_valid_call_without_cross_attention(self, normalize_first):
         decoder_input = keras.Input(shape=[4, 6])
         decoder = transformer_decoder.TransformerDecoder(
             intermediate_dim=4,
             num_heads=2,
+            normalize_first=normalize_first,
         )
         output = decoder(decoder_input)
         model = keras.Model(

--- a/keras_nlp/layers/transformer_decoder_test.py
+++ b/keras_nlp/layers/transformer_decoder_test.py
@@ -93,6 +93,7 @@ class TransformerDecoderTest(tf.test.TestCase, parameterized.TestCase):
             num_heads=2,
             kernel_initializer="HeNormal",
             bias_initializer="Zeros",
+            normalize_first=True,
         )
 
         config = decoder.get_config()
@@ -108,6 +109,7 @@ class TransformerDecoderTest(tf.test.TestCase, parameterized.TestCase):
             "bias_initializer": keras.initializers.serialize(
                 keras.initializers.Zeros()
             ),
+            "normalize_first": True,
         }
         self.assertEqual(config, {**config, **expected_config_subset})
         self.assertEqual(config, {**config, **expected_config_subset})
@@ -274,6 +276,7 @@ class TransformerDecoderTest(tf.test.TestCase, parameterized.TestCase):
         decoder = transformer_decoder.TransformerDecoder(
             intermediate_dim=4,
             num_heads=2,
+            normalize_first=True,
         )
         output = decoder(encoder_input, decoder_input)
         model = keras.Model(
@@ -297,6 +300,7 @@ class TransformerDecoderTest(tf.test.TestCase, parameterized.TestCase):
         decoder = transformer_decoder.TransformerDecoder(
             intermediate_dim=4,
             num_heads=2,
+            normalize_first=True,
         )
         output = decoder(decoder_input)
         model = keras.Model(

--- a/keras_nlp/layers/transformer_encoder.py
+++ b/keras_nlp/layers/transformer_encoder.py
@@ -51,10 +51,10 @@ class TransformerEncoder(keras.layers.Layer):
         bias_initializer: string or `keras.initializers` initializer,
             defaults to "zeros". The bias initializer for
             the dense and multiheaded attention layers.
-        normalize_first: bool. If True, the inputs to the attention layer and
-            the intermediate dense layer  are normalized (similar to GPT-2). If
-            set to False, outputs of attention layer and intermediate dense
-            layer are normalized (similar to BERT). Defaults to False.
+        normalize_first: bool. Defaults to False. If True, the inputs to the
+            attention layer and the intermediate dense layer  are normalized
+            (similar to GPT-2). If set to False, outputs of attention layer and
+            intermediate dense layer are normalized (similar to BERT).
         name: string, defaults to None. The name of the layer.
         **kwargs: other keyword arguments.
 
@@ -150,7 +150,7 @@ class TransformerEncoder(keras.layers.Layer):
         )
         self._output_dropout = keras.layers.Dropout(rate=self.dropout)
 
-    def _feed_forward(self, input):
+    def _feedforward(self, input):
         x = self._intermediate_dense(input)
         x = self._output_dense(x)
         return self._output_dropout(x)
@@ -198,13 +198,11 @@ class TransformerEncoder(keras.layers.Layer):
         if self.normalize_first:
             attended = self._feedforward_layernorm(attended)
         # Feedforward.
-        feed_forward_output = self._feed_forward(attended)
-        feed_forward_output = residual_attended + feed_forward_output
+        feedforward_output = self._feedforward(attended)
+        feedforward_output = residual_attended + feedforward_output
         if not self.normalize_first:
-            feed_forward_output = self._feedforward_layernorm(
-                feed_forward_output
-            )
-        return feed_forward_output
+            feedforward_output = self._feedforward_layernorm(feedforward_output)
+        return feedforward_output
 
     def get_config(self):
         config = super().get_config()

--- a/keras_nlp/layers/transformer_encoder_test.py
+++ b/keras_nlp/layers/transformer_encoder_test.py
@@ -58,6 +58,7 @@ class TransformerEncoderTest(tf.test.TestCase, parameterized.TestCase):
             num_heads=2,
             kernel_initializer="HeNormal",
             bias_initializer="Zeros",
+            normalize_first=True,
         )
 
         config = encoder.get_config()
@@ -74,6 +75,7 @@ class TransformerEncoderTest(tf.test.TestCase, parameterized.TestCase):
             "bias_initializer": keras.initializers.serialize(
                 keras.initializers.Zeros()
             ),
+            "normalize_first": True,
         }
 
         self.assertEqual(config, {**config, **expected_config_subset})
@@ -166,6 +168,7 @@ class TransformerEncoderTest(tf.test.TestCase, parameterized.TestCase):
                 transformer_encoder.TransformerEncoder(
                     intermediate_dim=4,
                     num_heads=2,
+                    normalize_first=True,
                 ),
             ]
         )

--- a/keras_nlp/layers/transformer_encoder_test.py
+++ b/keras_nlp/layers/transformer_encoder_test.py
@@ -23,10 +23,15 @@ from keras_nlp.layers import transformer_encoder
 
 
 class TransformerEncoderTest(tf.test.TestCase, parameterized.TestCase):
-    def test_valid_call(self):
+    @parameterized.named_parameters(
+        ("without_norm_first", False),
+        ("with_norm_first", True),
+    )
+    def test_valid_call(self, normalize_first):
         encoder = transformer_encoder.TransformerEncoder(
             intermediate_dim=4,
             num_heads=2,
+            normalize_first=normalize_first,
         )
         model = keras.Sequential(
             [


### PR DESCRIPTION
Partially resolves #337 

For the `TransformerDecoder` layer, I went ahead and normalized the input to the cross-attention layer as well (other than self-attention and feedforward layers). Considering `normalize_first` for the self-attention layer and feedforward layer and not considering it for the cross-attention layer seemed incomplete.

Some references for the above:

- https://fossies.org/linux/tensorflow-official-models/official/projects/detr/modeling/transformer.py (LN 818-819)
- PyTorch (check `class TransformerDecoderLayer`): https://pytorch.org/docs/stable/_modules/torch/nn/modules/transformer.html#TransformerDecoderLayer
```
        if self.norm_first:
            x = x + self._sa_block(self.norm1(x), tgt_mask, tgt_key_padding_mask)
            x = x + self._mha_block(self.norm2(x), memory, memory_mask, memory_key_padding_mask)
```
- https://github.com/seetaresearch/dragon/blob/494774d3a545f807d483fd9e6e4563cedec6dda5/torch/core/nn/modules/transformer.py#L183-L184