### PR TITLE
Stop running CI on Windows

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,10 +8,7 @@ on:
 jobs:
   build:
     name: Run tests
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.7

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,10 +9,7 @@ on:
 jobs:
   build:
     name: Run tests
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.7


### PR DESCRIPTION
Windows nightlies have been broken for a few days now.

Probably related, core Tensorflow is dropping native Windows support for anything but tensorflow-cpu (which we don't install by default) as of the upcoming tf release (2.11).

Both core tensorflow and our development guide recommend WSL2.

I think the simplest solution here is to stop running windows CI and continue recommending WSL2 for running on windows.