### PR TITLE
Set default name of `Bert` instance to `"backbone"`

### DIFF
--- a/keras_nlp/models/bert/bert_models.py
+++ b/keras_nlp/models/bert/bert_models.py
@@ -98,6 +98,7 @@ class Bert(keras.Model):
         dropout=0.1,
         max_sequence_length=512,
         num_segments=2,
+        name="encoder",
         **kwargs,
     ):
 
@@ -183,6 +184,7 @@ class Bert(keras.Model):
                 "sequence_output": sequence_output,
                 "pooled_output": pooled_output,
             },
+            name=name,
             **kwargs,
         )
         # All references to `self` below this line

--- a/keras_nlp/models/bert/bert_models.py
+++ b/keras_nlp/models/bert/bert_models.py
@@ -82,7 +82,6 @@ class Bert(keras.Model):
         hidden_dim=768,
         intermediate_dim=3072,
         max_sequence_length=12,
-        name="encoder",
     )
     output = model(input_data)
     ```
@@ -98,7 +97,6 @@ class Bert(keras.Model):
         dropout=0.1,
         max_sequence_length=512,
         num_segments=2,
-        name="backbone",
         **kwargs,
     ):
 
@@ -173,6 +171,10 @@ class Bert(keras.Model):
             name="pooled_dense",
         )(x[:, cls_token_index, :])
 
+        # Set default for `name` if none given
+        if "name" not in kwargs:
+            kwargs["name"] = "backbone"
+
         # Instantiate using Functional API Model constructor
         super().__init__(
             inputs={
@@ -184,7 +186,6 @@ class Bert(keras.Model):
                 "sequence_output": sequence_output,
                 "pooled_output": pooled_output,
             },
-            name=name,
             **kwargs,
         )
         # All references to `self` below this line

--- a/keras_nlp/models/bert/bert_models.py
+++ b/keras_nlp/models/bert/bert_models.py
@@ -98,7 +98,7 @@ class Bert(keras.Model):
         dropout=0.1,
         max_sequence_length=512,
         num_segments=2,
-        name="encoder",
+        name="backbone",
         **kwargs,
     ):
 

--- a/keras_nlp/models/bert/bert_models_test.py
+++ b/keras_nlp/models/bert/bert_models_test.py
@@ -52,7 +52,7 @@ class BertTest(tf.test.TestCase, parameterized.TestCase):
     def test_valid_call_bert(self):
         self.model(self.input_batch)
         # Check default name passed through
-        self.assertEqual(self.model.name, "encoder")
+        self.assertEqual(self.model.name, "backbone")
 
     def test_variable_sequence_length_call_bert(self):
         for seq_length in (25, 50, 75):

--- a/keras_nlp/models/bert/bert_models_test.py
+++ b/keras_nlp/models/bert/bert_models_test.py
@@ -31,7 +31,6 @@ class BertTest(tf.test.TestCase, parameterized.TestCase):
             hidden_dim=64,
             intermediate_dim=128,
             max_sequence_length=128,
-            name="encoder",
         )
         self.batch_size = 8
         self.input_batch = {
@@ -52,6 +51,7 @@ class BertTest(tf.test.TestCase, parameterized.TestCase):
 
     def test_valid_call_bert(self):
         self.model(self.input_batch)
+        # Check default name passed through
         self.assertEqual(self.model.name, "encoder")
 
     def test_variable_sequence_length_call_bert(self):
@@ -95,7 +95,6 @@ class BertTest(tf.test.TestCase, parameterized.TestCase):
             Bert.from_preset(
                 "bert_base_uncased_clowntown",
                 load_weights=False,
-                name="encoder",
             )
 
     def test_preset_mutability(self):


### PR DESCRIPTION
Current default name is `"bert"`, which looks pretty funny in the layers of a task model (see below).

Having `"bert_classifier"` as the default for a `BertClassifier` looks pretty good though.

```python
classifier = keras_nlp.models.BertClassifier(
    "bert_tiny_uncased_en",
    num_classes=2,
)
classifier.summary()
```
```
>>>
Model: "bert_classifier"
__________________________________________________________________________________________________
 Layer (type)                   Output Shape         Param #     Connected to                     
==================================================================================================
 padding_mask (InputLayer)      [(None, None)]       0           []                               
                                                                                                  
 segment_ids (InputLayer)       [(None, None)]       0           []                               
                                                                                                  
 token_ids (InputLayer)         [(None, None)]       0           []                               
                                                                                                  
 bert (Bert)                    {'sequence_output':  4385920     ['padding_mask[0][0]',           
                                 (None, None, 128),               'segment_ids[0][0]',            
                                 'pooled_output': (               'token_ids[0][0]']              
                                None, 128)}                                                       
                                                                                                  
 logits (Dense)                 (None, 2)            258         ['bert[0][0]']                   
                                                                                                  
==================================================================================================
Total params: 4,386,178
Trainable params: 4,386,178
Non-trainable params: 0
```
