### PR TITLE
Add `backbone` as `property` for task models

### DIFF
--- a/keras_nlp/models/bert/bert_tasks.py
+++ b/keras_nlp/models/bert/bert_tasks.py
@@ -61,6 +61,9 @@ CLASSIFIER_DOCSTRING = """BERT encoder model with a classification head.
         "bert_base_uncased_en", 4, name="classifier"
     )
     logits = classifier(input_data)
+
+    # Access backbone programatically (e.g., to change `trainable`)
+    classifier.backbone.trainable = False
     ```
 """
 

--- a/keras_nlp/models/bert/bert_tasks.py
+++ b/keras_nlp/models/bert/bert_tasks.py
@@ -100,8 +100,13 @@ class BertClassifier(keras.Model):
             inputs=inputs, outputs=outputs, name=name, trainable=trainable
         )
         # All references to `self` below this line
-        self.backbone = backbone
+        self._backbone = backbone
         self.num_classes = num_classes
+
+    @property
+    def backbone(self):
+        """A `keras_nlp.models.Bert` instance providing the encoder submodel."""
+        return self._backbone
 
     def get_config(self):
         return {


### PR DESCRIPTION
The `backbone` in our first task model is accessible programatically with `classifier.backbone`, but we do nothing to advertise this fact. Adding a note in the docstring. 