### PR TITLE
Register the BertPreprocessor as serializable

### DIFF
--- a/keras_nlp/models/bert/bert_preprocessing.py
+++ b/keras_nlp/models/bert/bert_preprocessing.py
@@ -24,6 +24,7 @@ from keras_nlp.models.utils import classproperty
 from keras_nlp.tokenizers.word_piece_tokenizer import WordPieceTokenizer
 
 
+@keras.utils.register_keras_serializable(package="keras_nlp")
 class BertPreprocessor(keras.layers.Layer):
     """BERT preprocessing layer.
 


### PR DESCRIPTION
One last missing spot for registering our objects. We had not registered BertPreprocessing for serialization.