### PR TITLE
Fix bert preprocessing docstring so it is runnable

### DIFF
--- a/keras_nlp/models/bert/bert_preprocessing.py
+++ b/keras_nlp/models/bert/bert_preprocessing.py
@@ -63,7 +63,8 @@ class BertPreprocessor(keras.layers.Layer):
 
     Examples:
     ```python
-    vocab = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox", "tripped"]
+    vocab = ["[PAD]", "[UNK]", "[CLS]", "[SEP]"]
+    vocab += ["the", "qu", "##ick", "br", "##own", "fox", "tripped"]
     vocab += ["call", "me", "ish", "##mael", "."]
     vocab += ["oh", "look", "a", "whale"]
     vocab += ["i", "forgot", "my", "home", "##work"]


### PR DESCRIPTION
This fixes a small bug introduced in https://github.com/keras-team/keras-nlp/pull/390, where our code block immediately errors out because our vocabulary does not have the correct special tokens.