### PR TITLE
Never pass Raggeds to user function when generating text

### DIFF
--- a/keras_nlp/utils/text_generation.py
+++ b/keras_nlp/utils/text_generation.py
@@ -170,10 +170,10 @@ def greedy_search(
     if input_is_1d:
         prompt = prompt[tf.newaxis, :]
 
-    _validate_token_probability_fn(token_probability_fn, prompt)
-
     batch_size, length = _get_prompt_shape(prompt)
     prompt, mask = _pad_prompt(prompt, max_length)
+
+    _validate_token_probability_fn(token_probability_fn, prompt)
 
     def one_step(length, prompt):
         pred = token_probability_fn(prompt[:, :length])
@@ -484,10 +484,10 @@ def random_search(
     if input_is_1d:
         prompt = prompt[tf.newaxis, :]
 
-    _validate_token_probability_fn(token_probability_fn, prompt)
-
     batch_size, length = _get_prompt_shape(prompt)
     prompt, mask = _pad_prompt(prompt, max_length)
+
+    _validate_token_probability_fn(token_probability_fn, prompt)
 
     def one_step(length, prompt):
         pred = token_probability_fn(prompt[:, :length])
@@ -622,6 +622,9 @@ def top_k_search(
     if input_is_1d:
         prompt = prompt[tf.newaxis, :]
 
+    batch_size, length = _get_prompt_shape(prompt)
+    prompt, mask = _pad_prompt(prompt, max_length)
+
     _validate_token_probability_fn(token_probability_fn, prompt)
 
     # If k is greater than the vocabulary size, use the entire vocabulary.
@@ -632,9 +635,6 @@ def top_k_search(
             f"Setting `k` to vocabulary size. Received: `k={k}`."
         )
         k = pred.shape[1]
-
-    batch_size, length = _get_prompt_shape(prompt)
-    prompt, mask = _pad_prompt(prompt, max_length)
 
     def one_step(length, prompt):
         pred = token_probability_fn(prompt[:, :length])
@@ -777,10 +777,10 @@ def top_p_search(
     if input_is_1d:
         prompt = prompt[tf.newaxis, :]
 
-    _validate_token_probability_fn(token_probability_fn, prompt)
-
     batch_size, length = _get_prompt_shape(prompt)
     prompt, mask = _pad_prompt(prompt, max_length)
+
+    _validate_token_probability_fn(token_probability_fn, prompt)
 
     def one_step(length, prompt):
         pred = token_probability_fn(prompt[:, :length])

--- a/keras_nlp/utils/text_generation_test.py
+++ b/keras_nlp/utils/text_generation_test.py
@@ -68,7 +68,7 @@ class GreedySearchTextGenerationTest(tf.test.TestCase, parameterized.TestCase):
 
     def test_generate_with_ragged_prompt(self):
         def token_probability_fn(inputs):
-            # Assert that passed function is passed only dense tensors.
+            # Assert that user function is passed only dense tensors.
             self.assertIsInstance(inputs, tf.Tensor)
             prob = tf.constant([[0.0, 0.0, 0.0, 1.0]])
             return tf.repeat(prob, 2, axis=0)
@@ -262,7 +262,7 @@ class BeamSearchTextGenerationTest(tf.test.TestCase, parameterized.TestCase):
 
     def test_generate_with_ragged_prompt(self):
         def token_probability_fn(inputs):
-            # Assert that passed function is passed only dense tensors.
+            # Assert that user function is passed only dense tensors.
             self.assertIsInstance(inputs, tf.Tensor)
             repeat_times = tf.shape(inputs)[0]
             prob = tf.constant([[0.0, 0.0, 0.0, 1.0]])
@@ -450,7 +450,7 @@ class RandomSearchTextGenerationTest(tf.test.TestCase, parameterized.TestCase):
 
     def test_generate_with_ragged_prompt(self):
         def token_probability_fn(inputs):
-            # Assert that passed function is passed only dense tensors.
+            # Assert that user function is passed only dense tensors.
             self.assertIsInstance(inputs, tf.Tensor)
             prob = tf.constant([[0.0, 0.0, 0.0, 1.0]])
             return tf.repeat(prob, 2, axis=0)
@@ -673,7 +673,7 @@ class TopKSearchTextGenerationTest(tf.test.TestCase, parameterized.TestCase):
 
     def test_generate_with_ragged_prompt(self):
         def token_probability_fn(inputs):
-            # Assert that passed function is passed only dense tensors.
+            # Assert that user function is passed only dense tensors.
             self.assertIsInstance(inputs, tf.Tensor)
             prob = tf.constant([[0.0, 0.0, 0.0, 1.0]])
             return tf.repeat(prob, 2, axis=0)
@@ -914,7 +914,7 @@ class TopPSearchTextGenerationTest(tf.test.TestCase, parameterized.TestCase):
 
     def test_generate_with_ragged_prompt(self):
         def token_probability_fn(inputs):
-            # Assert that passed function is passed only dense tensors.
+            # Assert that user function is passed only dense tensors.
             self.assertIsInstance(inputs, tf.Tensor)
             prob = tf.constant([[0.0, 0.0, 0.0, 1.0]])
             return tf.repeat(prob, 2, axis=0)

--- a/keras_nlp/utils/text_generation_test.py
+++ b/keras_nlp/utils/text_generation_test.py
@@ -68,6 +68,8 @@ class GreedySearchTextGenerationTest(tf.test.TestCase, parameterized.TestCase):
 
     def test_generate_with_ragged_prompt(self):
         def token_probability_fn(inputs):
+            # Assert that passed function is passed only dense tensors.
+            self.assertIsInstance(inputs, tf.Tensor)
             prob = tf.constant([[0.0, 0.0, 0.0, 1.0]])
             return tf.repeat(prob, 2, axis=0)
 
@@ -260,6 +262,8 @@ class BeamSearchTextGenerationTest(tf.test.TestCase, parameterized.TestCase):
 
     def test_generate_with_ragged_prompt(self):
         def token_probability_fn(inputs):
+            # Assert that passed function is passed only dense tensors.
+            self.assertIsInstance(inputs, tf.Tensor)
             repeat_times = tf.shape(inputs)[0]
             prob = tf.constant([[0.0, 0.0, 0.0, 1.0]])
             return tf.repeat(prob, repeat_times, axis=0)
@@ -446,6 +450,8 @@ class RandomSearchTextGenerationTest(tf.test.TestCase, parameterized.TestCase):
 
     def test_generate_with_ragged_prompt(self):
         def token_probability_fn(inputs):
+            # Assert that passed function is passed only dense tensors.
+            self.assertIsInstance(inputs, tf.Tensor)
             prob = tf.constant([[0.0, 0.0, 0.0, 1.0]])
             return tf.repeat(prob, 2, axis=0)
 
@@ -667,6 +673,8 @@ class TopKSearchTextGenerationTest(tf.test.TestCase, parameterized.TestCase):
 
     def test_generate_with_ragged_prompt(self):
         def token_probability_fn(inputs):
+            # Assert that passed function is passed only dense tensors.
+            self.assertIsInstance(inputs, tf.Tensor)
             prob = tf.constant([[0.0, 0.0, 0.0, 1.0]])
             return tf.repeat(prob, 2, axis=0)
 
@@ -906,6 +914,8 @@ class TopPSearchTextGenerationTest(tf.test.TestCase, parameterized.TestCase):
 
     def test_generate_with_ragged_prompt(self):
         def token_probability_fn(inputs):
+            # Assert that passed function is passed only dense tensors.
+            self.assertIsInstance(inputs, tf.Tensor)
             prob = tf.constant([[0.0, 0.0, 0.0, 1.0]])
             return tf.repeat(prob, 2, axis=0)
 


### PR DESCRIPTION
When our text generation utils are passed a ragged tensor, we first convert to dense and use a mask to gate updates. However, we would attempt to first validate the user supplied function by passing the ragged inputs, meaning the user supplied function needed to handle both ragged and dense tensors.

We can greatly simplify end to end workflows by only validating our prompt function after we convert the prompt to a dense tensor.