### PR TITLE
Change gpt2 to GPT2

### DIFF
--- a/keras_nlp/models/__init__.py
+++ b/keras_nlp/models/__init__.py
@@ -19,7 +19,7 @@ from keras_nlp.models.distilbert.distilbert_models import DistilBert
 from keras_nlp.models.distilbert.distilbert_preprocessing import (
     DistilBertPreprocessor,
 )
-from keras_nlp.models.gpt2.gpt2_models import Gpt2
+from keras_nlp.models.gpt2.gpt2_models import GPT2
 from keras_nlp.models.roberta.roberta_models import Roberta
 from keras_nlp.models.roberta.roberta_tasks import RobertaClassifier
 from keras_nlp.models.xlm_roberta.xlm_roberta_models import XLMRoberta

--- a/keras_nlp/models/gpt2/gpt2_models.py
+++ b/keras_nlp/models/gpt2/gpt2_models.py
@@ -26,7 +26,7 @@ def _gpt_2_kernel_initializer(stddev=0.02):
 
 
 @keras.utils.register_keras_serializable(package="keras_nlp")
-class Gpt2(keras.Model):
+class GPT2(keras.Model):
     """GPT-2 core network with hyperparameters.
 
     This network implements a Transformer-based decoder network,
@@ -65,7 +65,7 @@ class Gpt2(keras.Model):
     }
 
     # Randomly initialized GPT-2 decoder
-    model = keras_nlp.models.Gpt2(
+    model = keras_nlp.models.GPT2(
         vocabulary_size=50257,
         num_layers=12,
         num_heads=12,

--- a/keras_nlp/models/gpt2/gpt2_models_test.py
+++ b/keras_nlp/models/gpt2/gpt2_models_test.py
@@ -19,12 +19,12 @@ import tensorflow as tf
 from absl.testing import parameterized
 from tensorflow import keras
 
-from keras_nlp.models.gpt2.gpt2_models import Gpt2
+from keras_nlp.models.gpt2.gpt2_models import GPT2
 
 
-class Gpt2Test(tf.test.TestCase, parameterized.TestCase):
+class GPT2Test(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
-        self.model = Gpt2(
+        self.model = GPT2(
             vocabulary_size=1000,
             num_layers=2,
             num_heads=2,
@@ -88,7 +88,7 @@ class Gpt2Test(tf.test.TestCase, parameterized.TestCase):
         restored_model = keras.models.load_model(save_path)
 
         # Check we got the real object back.
-        self.assertIsInstance(restored_model, Gpt2)
+        self.assertIsInstance(restored_model, GPT2)
 
         # Check that output matches.
         restored_output = restored_model(self.input_batch)


### PR DESCRIPTION
Change `gpt2` model name to `GPT2` to be consistent with `XLM` and other Model Names

Resolves #416 