### PR TITLE
Add backbone presets to task classes 

### DIFF
--- a/keras_nlp/models/bert/bert_presets_test.py
+++ b/keras_nlp/models/bert/bert_presets_test.py
@@ -62,7 +62,7 @@ class BertPresetSmokeTest(tf.test.TestCase):
             "segment_ids": tf.constant([[0, 0, 0, 0]]),
             "padding_mask": tf.constant([[1, 1, 1, 1]]),
         }
-        model = BertClassifier(
+        model = BertClassifier.from_preset(
             "bert_tiny_uncased_en",
         )
         # We don't assert output values, as the head weights are random.
@@ -110,19 +110,6 @@ class BertPresetTest(tf.test.TestCase):
                 "padding_mask": tf.constant([1] * 512, shape=(1, 512)),
             }
             classifier(input_data)
-
-    def test_classifier_default_args(self):
-        classifier = BertClassifier()
-        input_data = {
-            "token_ids": tf.random.uniform(
-                shape=(1, 512),
-                dtype=tf.int64,
-                maxval=classifier.backbone.vocabulary_size,
-            ),
-            "segment_ids": tf.constant([0] * 200 + [1] * 312, shape=(1, 512)),
-            "padding_mask": tf.constant([1] * 512, shape=(1, 512)),
-        }
-        classifier(input_data)
 
     def test_load_preprocessors(self):
         for preset in BertPreprocessor.presets:

--- a/keras_nlp/models/bert/bert_presets_test.py
+++ b/keras_nlp/models/bert/bert_presets_test.py
@@ -93,9 +93,11 @@ class BertPresetTest(tf.test.TestCase):
             }
             model(input_data)
 
-    def test_load_bert_backbone_string(self):
-        for preset in Bert.presets:
-            classifier = BertClassifier(preset, 4, name="classifier")
+    def test_load_bert_classifier(self):
+        for preset in BertClassifier.presets:
+            classifier = BertClassifier.from_preset(
+                preset, num_classes=4, name="classifier"
+            )
             input_data = {
                 "token_ids": tf.random.uniform(
                     shape=(1, 512),

--- a/keras_nlp/models/bert/bert_tasks.py
+++ b/keras_nlp/models/bert/bert_tasks.py
@@ -69,10 +69,6 @@ class BertClassifier(keras.Model):
         num_classes=2,
         **kwargs,
     ):
-        # Load backbone from string identifier
-        # TODO(jbischof): create util function when ready to load backbones in
-        # other task classes (e.g., load_backbone_from_string())
-
         inputs = backbone.input
         pooled = backbone(inputs)["pooled_output"]
         outputs = keras.layers.Dense(
@@ -156,7 +152,7 @@ FROM_PRESET_DOCSTRING = """Instantiate BERT classification model from preset arc
         ),
     }}
 
-    # Load architecture and weights from preset
+    # Load backbone architecture and weights from preset
     classifier = BertClassifier.from_preset(
         "bert_base_uncased_en",
         num_classes=4,

--- a/keras_nlp/models/bert/bert_tasks.py
+++ b/keras_nlp/models/bert/bert_tasks.py
@@ -167,7 +167,7 @@ FROM_PRESET_DOCSTRING = """Instantiate BERT classification model from preset arc
     """
 
 setattr(
-    Bert.from_preset.__func__,
+    BertClassifier.from_preset.__func__,
     "__doc__",
-    FROM_PRESET_DOCSTRING.format(names=", ".join(Bert.presets)),
+    FROM_PRESET_DOCSTRING.format(names=", ".join(BertClassifier.presets)),
 )

--- a/keras_nlp/models/bert/bert_tasks.py
+++ b/keras_nlp/models/bert/bert_tasks.py
@@ -13,23 +13,28 @@
 # limitations under the License.
 """BERT task specific models and heads."""
 
+import copy
+
 from tensorflow import keras
 
 from keras_nlp.models.bert.bert_models import Bert
 from keras_nlp.models.bert.bert_models import bert_kernel_initializer
+from keras_nlp.models.bert.bert_presets import backbone_presets
+from keras_nlp.models.utils import classproperty
 
-# TODO(jbischof): Find more scalable way to list checkpoints.
-CLASSIFIER_DOCSTRING = """BERT encoder model with a classification head.
+
+@keras.utils.register_keras_serializable(package="keras_nlp")
+class BertClassifier(keras.Model):
+    """BERT encoder model with a classification head.
 
     Args:
-        backbone: A string or `keras_nlp.models.Bert` instance. If a string,
-            should be one of {names}.
+        backbone: A `keras_nlp.models.Bert` instance.
         num_classes: int. Number of classes to predict.
 
     Examples:
     ```python
     # Randomly initialized BERT encoder
-    model = keras_nlp.models.BertCustom(
+    encoder = keras_nlp.models.Bert(
         vocabulary_size=30522,
         num_layers=12,
         num_heads=12,
@@ -50,39 +55,23 @@ CLASSIFIER_DOCSTRING = """BERT encoder model with a classification head.
             [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
         ),
     }}
-    classifier = keras_nlp.models.BertClassifier(model, 4, name="classifier")
-    logits = classifier(input_data)
-
-    # String backbone specification
-    classifier = keras_nlp.models.BertClassifier(
-        "bert_base_uncased_en", 4, name="classifier"
-    )
+    classifier = keras_nlp.models.BertClassifier(encoder, 4, name="classifier")
     logits = classifier(input_data)
 
     # Access backbone programatically (e.g., to change `trainable`)
     classifier.backbone.trainable = False
     ```
-"""
+    """
 
-
-@keras.utils.register_keras_serializable(package="keras_nlp")
-class BertClassifier(keras.Model):
     def __init__(
         self,
-        backbone="bert_base_uncased_en",
+        backbone,
         num_classes=2,
         **kwargs,
     ):
         # Load backbone from string identifier
         # TODO(jbischof): create util function when ready to load backbones in
         # other task classes (e.g., load_backbone_from_string())
-        if isinstance(backbone, str):
-            if backbone not in Bert.presets:
-                raise ValueError(
-                    "`backbone` must be one of "
-                    f"""{", ".join(Bert.presets)}. Received: {backbone}."""
-                )
-            backbone = Bert.from_preset(backbone)
 
         inputs = backbone.input
         pooled = backbone(inputs)["pooled_output"]
@@ -120,9 +109,65 @@ class BertClassifier(keras.Model):
             config["backbone"] = keras.layers.deserialize(config["backbone"])
         return cls(**config)
 
+    @classproperty
+    def presets(cls):
+        return copy.deepcopy(backbone_presets)
+
+    @classmethod
+    def from_preset(
+        cls,
+        preset,
+        load_weights=True,
+        **kwargs,
+    ):
+        # Check if preset is backbone-only model
+        if preset in Bert.presets:
+            backbone = Bert.from_preset(preset, load_weights)
+            return cls(backbone, **kwargs)
+
+        # Otherwise must be one of class presets
+        # Currently no classifier-level presets, so must throw.
+        if preset not in cls.presets:
+            raise ValueError(
+                "`preset` must be one of "
+                f"""{", ".join(cls.presets)}. Received: {preset}."""
+            )
+
+
+FROM_PRESET_DOCSTRING = """Instantiate BERT classification model from preset architecture and
+    weights.
+
+    Args:
+        preset: string. Must be one of {names}.
+        load_weights: Whether to load pre-trained weights into model. Defaults
+            to `True`.
+
+    Examples:
+    ```python
+    input_data = {{
+        "token_ids": tf.random.uniform(
+            shape=(1, 12), dtype=tf.int64, maxval=model.vocabulary_size
+        ),
+        "segment_ids": tf.constant(
+            [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
+        ),
+        "padding_mask": tf.constant(
+            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
+        ),
+    }}
+
+    # Load architecture and weights from preset
+    classifier = BertClassifier.from_preset("bert_base_uncased_en")
+    output = classifier(input_data)
+
+    # Load randomly initalized model from preset architecture
+    classifier = Bert.from_preset("bert_base_uncased_en", load_weights=False)
+    output = classifier(input_data)
+    ```
+    """
 
 setattr(
-    BertClassifier,
+    Bert.from_preset.__func__,
     "__doc__",
-    CLASSIFIER_DOCSTRING.format(names=", ".join(Bert.presets)),
+    FROM_PRESET_DOCSTRING.format(names=", ".join(Bert.presets)),
 )

--- a/keras_nlp/models/bert/bert_tasks.py
+++ b/keras_nlp/models/bert/bert_tasks.py
@@ -157,11 +157,18 @@ FROM_PRESET_DOCSTRING = """Instantiate BERT classification model from preset arc
     }}
 
     # Load architecture and weights from preset
-    classifier = BertClassifier.from_preset("bert_base_uncased_en")
+    classifier = BertClassifier.from_preset(
+        "bert_base_uncased_en",
+        num_classes=4,
+    )
     output = classifier(input_data)
 
     # Load randomly initalized model from preset architecture
-    classifier = Bert.from_preset("bert_base_uncased_en", load_weights=False)
+    classifier = BertClassifier.from_preset(
+        "bert_base_uncased_en",
+        load_weights=False,
+        num_classes=4,
+    )
     output = classifier(input_data)
     ```
     """

--- a/keras_nlp/models/bert/bert_tasks_test.py
+++ b/keras_nlp/models/bert/bert_tasks_test.py
@@ -58,9 +58,33 @@ class BertClassifierTest(tf.test.TestCase, parameterized.TestCase):
     def test_valid_call_classifier(self):
         self.classifier(self.input_batch)
 
-        # Not a checkpoint name
+    def test_valid_call_presets(self):
+        # Test preset loading without weights
+        for preset in BertClassifier.presets:
+            classifier = BertClassifier.from_preset(preset, load_weights=False)
+            input_data = {
+                "token_ids": tf.ones(
+                    (self.batch_size, self.backbone.max_sequence_length),
+                    dtype="int32",
+                ),
+                "segment_ids": tf.ones(
+                    (self.batch_size, self.backbone.max_sequence_length),
+                    dtype="int32",
+                ),
+                "padding_mask": tf.ones(
+                    (self.batch_size, self.backbone.max_sequence_length),
+                    dtype="int32",
+                ),
+            }
+            classifier(input_data)
+
+    def test_unknown_preset_error(self):
+        # Not a preset name
         with self.assertRaises(ValueError):
-            BertClassifier("bert_clowntown", 4, name="classifier")
+            BertClassifier.from_preset(
+                "bert_base_uncased_clowntown",
+                load_weights=False,
+            )
 
     @parameterized.named_parameters(
         ("jit_compile_false", False), ("jit_compile_true", True)


### PR DESCRIPTION
Use `from_preset` to load backbone-only checkpoints into task models rather than the default constructor.

This provides a more consistent user experience for loading presets.