### PR TITLE
Split the Bert tokenizer to a separate class

### DIFF
--- a/keras_nlp/models/__init__.py
+++ b/keras_nlp/models/__init__.py
@@ -14,6 +14,7 @@
 
 from keras_nlp.models.bert.bert_models import Bert
 from keras_nlp.models.bert.bert_preprocessing import BertPreprocessor
+from keras_nlp.models.bert.bert_preprocessing import BertTokenizer
 from keras_nlp.models.bert.bert_tasks import BertClassifier
 from keras_nlp.models.distilbert.distilbert_models import DistilBert
 from keras_nlp.models.distilbert.distilbert_preprocessing import (

--- a/keras_nlp/models/bert/bert_preprocessing.py
+++ b/keras_nlp/models/bert/bert_preprocessing.py
@@ -25,13 +25,163 @@ from keras_nlp.tokenizers.word_piece_tokenizer import WordPieceTokenizer
 
 
 @keras.utils.register_keras_serializable(package="keras_nlp")
+class BertTokenizer(WordPieceTokenizer):
+    """A BERT tokenizer using WordPiece subword segmentation.
+
+    This tokenizer class will tokenize raw strings into integer sequences, and
+    is based on `keras_nlp.tokenizers.WordPieceTokenizer`. Unlike the
+    underlying tokenizer, it will check for all special tokens needed by BERT
+    models, and provides a `from_preset()` method to automatically download
+    a matching vocabulary for a BERT preset.
+
+    This tokenizer will not do any truncation or padding of inputs by default.
+    It can be used with a `keras_nlp.models.BertPreprocessor` layer for common
+    input packing, or used directly with a standalone step to combine sequences
+    with any truncation, padding, and special token packing desired.
+
+    If input is a batch of strings (rank > 0), the layer will output a
+    `tf.RaggedTensor` where the last dimension of the output is ragged.
+
+    If input is a scalar string (rank == 0), the layer will output a dense
+    `tf.Tensor` with static shape `[None]`.
+
+    Args:
+        vocabulary: A list of strings or a string filename path. If
+            passing a list, each element of the list should be a single word
+            piece token string. If passing a filename, the file should be a
+            plain text file containing a single word piece token per line.
+        lowercase: If true, the input text will be first lowered before
+            tokenization.
+
+    Examples:
+
+
+    Batched input.
+    >>> vocab = ["[UNK]", "[CLS]", "[SEP]", "[PAD]"]
+    >>> vocab += ["The", "qu", "##ick", "brown", "fox", "."]
+    >>> inputs = ["The quick brown fox.", "The fox."]
+    >>> tokenizer = keras_nlp.models.BertTokenizer(vocabulary=vocab)
+    >>> tokenizer(inputs)
+    <tf.RaggedTensor [[4, 5, 6, 7, 8, 9], [4, 8, 9]]>
+
+    Unbatched input.
+    >>> vocab = ["[UNK]", "[CLS]", "[SEP]", "[PAD]"]
+    >>> vocab += ["The", "qu", "##ick", "brown", "fox", "."]
+    >>> inputs = "The fox."
+    >>> tokenizer = keras_nlp.models.BertTokenizer(vocabulary=vocab)
+    >>> tokenizer(inputs)
+    <tf.Tensor: shape=(3,), dtype=int32, numpy=array([4, 8, 9], dtype=int32)>
+
+    Detokenization.
+    >>> vocab = ["[UNK]", "[CLS]", "[SEP]", "[PAD]"]
+    >>> vocab += ["The", "qu", "##ick", "brown", "fox", "."]
+    >>> inputs = "The quick brown fox."
+    >>> tokenizer = keras_nlp.models.BertTokenizer(vocabulary=vocab)
+    >>> tokenizer.detokenize(tokenizer.tokenize(inputs)).numpy().decode('utf-8')
+    'The quick brown fox .'
+    """
+
+    def __init__(
+        self,
+        vocabulary,
+        lowercase=False,
+        **kwargs,
+    ):
+        super().__init__(
+            vocabulary=vocabulary,
+            lowercase=lowercase,
+            **kwargs,
+        )
+
+        # Check for necessary special tokens.
+        cls_token = "[CLS]"
+        sep_token = "[SEP]"
+        pad_token = "[PAD]"
+        for token in [cls_token, pad_token, sep_token]:
+            if token not in self.get_vocabulary():
+                raise ValueError(
+                    f"Cannot find token `'{token}'` in the provided "
+                    f"`vocabulary`. Please provide `'{token}'` in your "
+                    "`vocabulary` or use a pretrained `vocabulary` name."
+                )
+
+        self.cls_token_id = self.token_to_id(cls_token)
+        self.sep_token_id = self.token_to_id(sep_token)
+        self.pad_token_id = self.token_to_id(pad_token)
+
+    @classproperty
+    def presets(cls):
+        return copy.deepcopy(backbone_presets)
+
+    @classmethod
+    def from_preset(
+        cls,
+        preset,
+        **kwargs,
+    ):
+        if preset not in cls.presets:
+            raise ValueError(
+                "`preset` must be one of "
+                f"""{", ".join(cls.presets)}. Received: {preset}."""
+            )
+        metadata = cls.presets[preset]
+
+        vocabulary = keras.utils.get_file(
+            "vocab.txt",
+            metadata["vocabulary_url"],
+            cache_subdir=os.path.join("models", preset),
+            file_hash=metadata["vocabulary_hash"],
+        )
+
+        config = metadata["preprocessor_config"]
+        config.update(
+            {
+                "vocabulary": vocabulary,
+            },
+        )
+
+        return cls.from_config({**config, **kwargs})
+
+
+FROM_PRESET_DOCSTRING = """Instantiate a BERT tokenizer from preset vocabulary.
+
+    Args:
+        preset: string. Must be one of {names}.
+
+    Examples:
+    ```python
+    tokenizer = keras_nlp.models.BertTokenizer.from_preset(
+        "bert_base_uncased_en",
+    )
+
+    # Tokenize a single sentence directly.
+    tokenizer("The quick brown fox tripped.")
+
+    # Tokenize a batch of sentences directly.
+    tokenizer([
+        "The quick brown fox tripped.",
+        "Call me Ishmael.",
+    ])
+
+    # Detokenize a sequence of ints to a single string.
+    tokenizer.detokenize([5, 6, 7, 8, 9])
+    ```
+    """
+
+setattr(
+    BertTokenizer.from_preset.__func__,
+    "__doc__",
+    FROM_PRESET_DOCSTRING.format(names=", ".join(BertTokenizer.presets)),
+)
+
+
+@keras.utils.register_keras_serializable(package="keras_nlp")
 class BertPreprocessor(keras.layers.Layer):
-    """BERT preprocessing layer.
+    """A BERT preprocessing layer which tokenizes and packs inputs.
 
     This preprocessing layer will do three things:
 
-     - Tokenize any number of inputs using a
-       `keras_nlp.tokenizers.WordPieceTokenizer`.
+     - Tokenize any number of inputs using the `tokenizer`.
      - Pack the inputs together using a `keras_nlp.layers.MultiSegmentPacker`.
        with the appropriate `"[CLS]"`, `"[SEP]"` and `"[PAD]"` tokens.
      - Construct a dictionary of with keys `"token_ids"`, `"segment_ids"`,
@@ -41,14 +191,8 @@ class BertPreprocessor(keras.layers.Layer):
     single input tensor. If a single tensor is passed, it will be packed
     equivalently to a tuple with a single element.
 
-    The `WordPieceTokenizer` can be accessed via the `tokenizer` property on
-    this layer, and can be used directly for custom packing on inputs.
-
     Args:
-        vocabulary: A list of vocabulary terms or a vocabulary filename.
-        lowercase: If `True`, input will be lowercase before tokenization. If
-            `vocabulary` is set to a pretrained vocabulary, this parameter will
-            be inferred.
+        tokenizer: A `keras_nlp.models.BertTokenizer` instance.
         sequence_length: The length of the packed inputs.
         truncate: string. The algorithm to truncate a list of batched segments
             to fit within `sequence_length`. The value can be either
@@ -64,11 +208,12 @@ class BertPreprocessor(keras.layers.Layer):
     Examples:
     ```python
     vocab = ["[PAD]", "[UNK]", "[CLS]", "[SEP]"]
-    vocab += ["the", "qu", "##ick", "br", "##own", "fox", "tripped"]
-    vocab += ["call", "me", "ish", "##mael", "."]
-    vocab += ["oh", "look", "a", "whale"]
-    vocab += ["i", "forgot", "my", "home", "##work"]
-    preprocessor = keras_nlp.models.BertPreprocessor(vocabulary=vocab)
+    vocab += ["The", "qu", "##ick", "br", "##own", "fox", "tripped"]
+    vocab += ["Call", "me", "Ish", "##mael", "."]
+    vocab += ["Oh", "look", "a", "whale"]
+    vocab += ["I", "forgot", "my", "home", "##work"]
+    tokenizer = keras_nlp.models.BertTokenizer(vocabulary=vocab)
+    preprocessor = keras_nlp.models.BertPreprocessor(tokenizer)
 
     # Tokenize and pack a single sentence directly.
     preprocessor("The quick brown fox jumped.")
@@ -97,61 +242,47 @@ class BertPreprocessor(keras.layers.Layer):
     ds = ds.map(
         lambda x, y: (preprocessor(x), y),
         num_parallel_calls=tf.data.AUTOTUNE,
-    )
-    ```
+    )    ```
     """
 
     def __init__(
         self,
-        vocabulary,
-        lowercase=False,
+        tokenizer="bert_base_uncased_en",
         sequence_length=512,
         truncate="round_robin",
         **kwargs,
     ):
         super().__init__(**kwargs)
-
-        self.tokenizer = WordPieceTokenizer(
-            vocabulary=vocabulary,
-            lowercase=lowercase,
-        )
-
-        # Check for necessary special tokens.
-        cls_token = "[CLS]"
-        sep_token = "[SEP]"
-        pad_token = "[PAD]"
-        for token in [cls_token, pad_token, sep_token]:
-            if token not in self.tokenizer.get_vocabulary():
-                raise ValueError(
-                    f"Cannot find token `'{token}'` in the provided "
-                    f"`vocabulary`. Please provide `'{token}'` in your "
-                    "`vocabulary` or use a pretrained `vocabulary` name."
-                )
-
-        self.pad_token_id = self.tokenizer.token_to_id(pad_token)
+        self._tokenizer = tokenizer
         self.packer = MultiSegmentPacker(
-            start_value=self.tokenizer.token_to_id(cls_token),
-            end_value=self.tokenizer.token_to_id(sep_token),
-            pad_value=self.pad_token_id,
+            start_value=self.tokenizer.cls_token_id,
+            end_value=self.tokenizer.sep_token_id,
+            pad_value=self.tokenizer.pad_token_id,
             truncate=truncate,
             sequence_length=sequence_length,
         )
 
-    def vocabulary_size(self):
-        """Returns the vocabulary size of the tokenizer."""
-        return self.tokenizer.vocabulary_size()
+    @property
+    def tokenizer(self):
+        """The `keras_nlp.models.BertTokenizer` used to tokenize strings."""
+        return self._tokenizer
 
     def get_config(self):
         config = super().get_config()
         config.update(
             {
-                "vocabulary": self.tokenizer.vocabulary,
-                "lowercase": self.tokenizer.lowercase,
+                "tokenizer": keras.layers.serialize(self.tokenizer),
                 "sequence_length": self.packer.sequence_length,
                 "truncate": self.packer.truncate,
             }
         )
         return config
+
+    @classmethod
+    def from_config(cls, config):
+        if "tokenizer" in config:
+            config["tokenizer"] = keras.layers.deserialize(config["tokenizer"])
+        return cls(**config)
 
     def call(self, inputs):
         if not isinstance(inputs, (list, tuple)):
@@ -162,7 +293,7 @@ class BertPreprocessor(keras.layers.Layer):
         return {
             "token_ids": token_ids,
             "segment_ids": segment_ids,
-            "padding_mask": token_ids != self.pad_token_id,
+            "padding_mask": token_ids != self.tokenizer.pad_token_id,
         }
 
     @classproperty
@@ -182,18 +313,12 @@ class BertPreprocessor(keras.layers.Layer):
                 "`preset` must be one of "
                 f"""{", ".join(cls.presets)}. Received: {preset}."""
             )
-        metadata = cls.presets[preset]
 
-        vocabulary = keras.utils.get_file(
-            "vocab.txt",
-            metadata["vocabulary_url"],
-            cache_subdir=os.path.join("models", preset),
-            file_hash=metadata["vocabulary_hash"],
-        )
+        tokenizer = BertTokenizer.from_preset(preset)
 
-        config = metadata["preprocessor_config"]
         # Use model's `max_sequence_length` if `sequence_length` unspecified;
         # otherwise check that `sequence_length` not too long.
+        metadata = cls.presets[preset]
         max_sequence_length = metadata["config"]["max_sequence_length"]
         if sequence_length is not None:
             if sequence_length > max_sequence_length:
@@ -205,15 +330,12 @@ class BertPreprocessor(keras.layers.Layer):
         else:
             sequence_length = max_sequence_length
 
-        config.update(
-            {
-                "sequence_length": sequence_length,
-                "vocabulary": vocabulary,
-                "truncate": truncate,
-            },
+        return cls(
+            tokenizer=tokenizer,
+            sequence_length=sequence_length,
+            truncate=truncate,
+            **kwargs,
         )
-
-        return cls.from_config({**config, **kwargs})
 
 
 FROM_PRESET_DOCSTRING = """Instantiate BERT preprocessor from preset architecture.
@@ -238,11 +360,13 @@ FROM_PRESET_DOCSTRING = """Instantiate BERT preprocessor from preset architectur
     Examples:
     ```python
     # Load preprocessor from preset
-    preprocessor = BertPreprocessor.from_preset("bert_base_uncased_en")
+    preprocessor = keras_nlp.models.BertPreprocessor.from_preset(
+        "bert_base_uncased_en",
+    )
     preprocessor("The quick brown fox jumped.")
 
     # Override sequence_length
-    preprocessor = BertPreprocessor.from_preset(
+    preprocessor = keras_nlp.models.BertPreprocessor.from_preset(
         "bert_base_uncased_en"
         sequence_length=64
     )

--- a/keras_nlp/models/bert/bert_preprocessing.py
+++ b/keras_nlp/models/bert/bert_preprocessing.py
@@ -28,16 +28,14 @@ from keras_nlp.tokenizers.word_piece_tokenizer import WordPieceTokenizer
 class BertTokenizer(WordPieceTokenizer):
     """A BERT tokenizer using WordPiece subword segmentation.
 
-    This tokenizer class will tokenize raw strings into integer sequences, and
+    This tokenizer class will tokenize raw strings into integer sequences and
     is based on `keras_nlp.tokenizers.WordPieceTokenizer`. Unlike the
     underlying tokenizer, it will check for all special tokens needed by BERT
-    models, and provides a `from_preset()` method to automatically download
+    models and provides a `from_preset()` method to automatically download
     a matching vocabulary for a BERT preset.
 
-    This tokenizer will not do any truncation or padding of inputs by default.
-    It can be used with a `keras_nlp.models.BertPreprocessor` layer for common
-    input packing, or used directly with a standalone step to combine sequences
-    with any truncation, padding, and special token packing desired.
+    This tokenizer does not provide truncation or padding of inputs. It can be
+    combined with a `keras_nlp.models.BertPreprocessor` layer for input packing.
 
     If input is a batch of strings (rank > 0), the layer will output a
     `tf.RaggedTensor` where the last dimension of the output is ragged.
@@ -54,7 +52,6 @@ class BertTokenizer(WordPieceTokenizer):
             tokenization.
 
     Examples:
-
 
     Batched input.
     >>> vocab = ["[UNK]", "[CLS]", "[SEP]", "[PAD]"]
@@ -150,20 +147,15 @@ FROM_PRESET_DOCSTRING = """Instantiate a BERT tokenizer from preset vocabulary.
 
     Examples:
     ```python
+    # Load a preset tokenizer.
     tokenizer = keras_nlp.models.BertTokenizer.from_preset(
         "bert_base_uncased_en",
     )
 
-    # Tokenize a single sentence directly.
+    # Tokenize some input.
     tokenizer("The quick brown fox tripped.")
 
-    # Tokenize a batch of sentences directly.
-    tokenizer([
-        "The quick brown fox tripped.",
-        "Call me Ishmael.",
-    ])
-
-    # Detokenize a sequence of ints to a single string.
+    # Detokenize some input.
     tokenizer.detokenize([5, 6, 7, 8, 9])
     ```
     """
@@ -247,7 +239,7 @@ class BertPreprocessor(keras.layers.Layer):
 
     def __init__(
         self,
-        tokenizer="bert_base_uncased_en",
+        tokenizer,
         sequence_length=512,
         truncate="round_robin",
         **kwargs,

--- a/keras_nlp/models/bert/bert_preprocessing_test.py
+++ b/keras_nlp/models/bert/bert_preprocessing_test.py
@@ -21,6 +21,74 @@ from absl.testing import parameterized
 from tensorflow import keras
 
 from keras_nlp.models.bert.bert_preprocessing import BertPreprocessor
+from keras_nlp.models.bert.bert_preprocessing import BertTokenizer
+
+
+class BertTokenizerTest(tf.test.TestCase, parameterized.TestCase):
+    def setUp(self):
+        self.vocab = ["[PAD]", "[UNK]", "[CLS]", "[SEP]", "[MASK]"]
+        self.vocab += ["THE", "QUICK", "BROWN", "FOX"]
+        self.vocab += ["the", "quick", "brown", "fox"]
+
+    def test_tokenize(self):
+        input_data = "THE QUICK BROWN FOX."
+        tokenizer = BertTokenizer(vocabulary=self.vocab)
+        output = tokenizer(input_data)
+        self.assertAllEqual(output, [5, 6, 7, 8, 1])
+
+    def test_tokenize_batch(self):
+        input_data = tf.constant(["THE QUICK BROWN FOX.", "THE FOX."])
+        tokenizer = BertTokenizer(vocabulary=self.vocab)
+        output = tokenizer(input_data)
+        self.assertAllEqual(output, [[5, 6, 7, 8, 1], [5, 8, 1]])
+
+    def test_lowercase(self):
+        input_data = "THE QUICK BROWN FOX."
+        tokenizer = BertTokenizer(vocabulary=self.vocab, lowercase=True)
+        output = tokenizer(input_data)
+        self.assertAllEqual(output, [9, 10, 11, 12, 1])
+
+    def test_detokenize(self):
+        input_tokens = [[5, 6, 7, 8]]
+        tokenizer = BertTokenizer(vocabulary=self.vocab)
+        output = tokenizer.detokenize(input_tokens)
+        self.assertAllEqual(output, ["THE QUICK BROWN FOX"])
+
+    def test_vocabulary_size(self):
+        tokenizer = BertTokenizer(vocabulary=self.vocab)
+        self.assertEqual(tokenizer.vocabulary_size(), 13)
+
+    def test_unknown_preset_error(self):
+        # Not a preset name
+        with self.assertRaises(ValueError):
+            BertPreprocessor.from_preset("bert_base_uncased_clowntown")
+
+    @unittest.mock.patch("tensorflow.keras.utils.get_file")
+    def test_valid_call_presets(self, get_file_mock):
+        """Ensure presets have necessary structure, but no RCPs."""
+        input_data = ["THE QUICK BROWN FOX."]
+        get_file_mock.return_value = self.vocab
+        for preset in BertTokenizer.presets:
+            tokenizer = BertTokenizer.from_preset(preset)
+            tokenizer(input_data)
+        self.assertEqual(get_file_mock.call_count, len(BertTokenizer.presets))
+
+    @parameterized.named_parameters(
+        ("save_format_tf", "tf"), ("save_format_h5", "h5")
+    )
+    def test_saving_model(self, save_format):
+        input_data = tf.constant(["THE QUICK BROWN FOX."])
+        tokenizer = BertTokenizer(vocabulary=self.vocab)
+        inputs = keras.Input(dtype="string", shape=())
+        outputs = tokenizer(inputs)
+        model = keras.Model(inputs, outputs)
+        path = os.path.join(self.get_temp_dir(), "model")
+        model.save(path, save_format=save_format)
+        restored_model = keras.models.load_model(path)
+        self.assertAllEqual(
+            model(input_data),
+            restored_model(input_data),
+        )
 
 
 class BertPreprocessorTest(tf.test.TestCase, parameterized.TestCase):
@@ -32,7 +100,7 @@ class BertPreprocessorTest(tf.test.TestCase, parameterized.TestCase):
     def test_tokenize(self):
         input_data = ["THE QUICK BROWN FOX."]
         preprocessor = BertPreprocessor(
-            vocabulary=self.vocab,
+            BertTokenizer(vocabulary=self.vocab),
             sequence_length=8,
         )
         output = preprocessor(input_data)
@@ -50,7 +118,7 @@ class BertPreprocessorTest(tf.test.TestCase, parameterized.TestCase):
             ]
         )
         preprocessor = BertPreprocessor(
-            vocabulary=self.vocab,
+            BertTokenizer(vocabulary=self.vocab),
             sequence_length=8,
         )
         output = preprocessor(input_data)
@@ -66,7 +134,7 @@ class BertPreprocessorTest(tf.test.TestCase, parameterized.TestCase):
         sentence_one = "THE QUICK"
         sentence_two = "BROWN FOX."
         preprocessor = BertPreprocessor(
-            vocabulary=self.vocab,
+            BertTokenizer(vocabulary=self.vocab),
             sequence_length=8,
         )
         # The first tuple or list is always interpreted as an enumeration of
@@ -94,7 +162,7 @@ class BertPreprocessorTest(tf.test.TestCase, parameterized.TestCase):
             ]
         )
         preprocessor = BertPreprocessor(
-            vocabulary=self.vocab,
+            BertTokenizer(vocabulary=self.vocab),
             sequence_length=8,
         )
         # The first tuple or list is always interpreted as an enumeration of
@@ -107,26 +175,6 @@ class BertPreprocessorTest(tf.test.TestCase, parameterized.TestCase):
         self.assertAllEqual(
             output["padding_mask"], [[1, 1, 1, 1, 1, 1, 1, 1]] * 4
         )
-
-    def test_lowercase(self):
-        input_data = ["THE QUICK BROWN FOX."]
-        preprocessor = BertPreprocessor(
-            vocabulary=self.vocab,
-            sequence_length=8,
-            lowercase=True,
-        )
-        output = preprocessor(input_data)
-        self.assertAllEqual(output["token_ids"], [2, 9, 10, 11, 12, 1, 3, 0])
-
-    def test_detokenize(self):
-        input_tokens = [[5, 6, 7, 8]]
-        preprocessor = BertPreprocessor(vocabulary=self.vocab)
-        output = preprocessor.tokenizer.detokenize(input_tokens)
-        self.assertAllEqual(output, ["THE QUICK BROWN FOX"])
-
-    def test_vocabulary_size(self):
-        preprocessor = BertPreprocessor(vocabulary=self.vocab)
-        self.assertEqual(preprocessor.vocabulary_size(), 13)
 
     def test_unknown_preset_error(self):
         # Not a preset name
@@ -173,7 +221,7 @@ class BertPreprocessorTest(tf.test.TestCase, parameterized.TestCase):
     def test_saving_model(self, save_format):
         input_data = tf.constant(["THE QUICK BROWN FOX."])
         preprocessor = BertPreprocessor(
-            vocabulary=self.vocab,
+            BertTokenizer(vocabulary=self.vocab),
             sequence_length=8,
         )
         inputs = keras.Input(dtype="string", shape=())

--- a/keras_nlp/models/bert/bert_preprocessing_test.py
+++ b/keras_nlp/models/bert/bert_preprocessing_test.py
@@ -65,7 +65,7 @@ class BertTokenizerTest(tf.test.TestCase, parameterized.TestCase):
 
     @unittest.mock.patch("tensorflow.keras.utils.get_file")
     def test_valid_call_presets(self, get_file_mock):
-        """Ensure presets have necessary structure, but no RCPs."""
+        """Ensure presets have necessary structure, but no RPCs."""
         input_data = ["THE QUICK BROWN FOX."]
         get_file_mock.return_value = self.vocab
         for preset in BertTokenizer.presets:
@@ -183,7 +183,7 @@ class BertPreprocessorTest(tf.test.TestCase, parameterized.TestCase):
 
     @unittest.mock.patch("tensorflow.keras.utils.get_file")
     def test_valid_call_presets(self, get_file_mock):
-        """Ensure presets have necessary structure, but no RCPs."""
+        """Ensure presets have necessary structure, but no RPCs."""
         input_data = ["THE QUICK BROWN FOX."]
         get_file_mock.return_value = self.vocab
         for preset in BertPreprocessor.presets:

--- a/keras_nlp/models/bert/bert_presets_test.py
+++ b/keras_nlp/models/bert/bert_presets_test.py
@@ -18,6 +18,7 @@ import tensorflow as tf
 
 from keras_nlp.models.bert.bert_models import Bert
 from keras_nlp.models.bert.bert_preprocessing import BertPreprocessor
+from keras_nlp.models.bert.bert_preprocessing import BertTokenizer
 from keras_nlp.models.bert.bert_tasks import BertClassifier
 
 
@@ -29,6 +30,14 @@ class BertPresetSmokeTest(tf.test.TestCase):
     This only tests the smallest weights we have available. Run with:
     `pytest keras_nlp/models/bert/bert_presets_test.py --run_large`
     """
+
+    def test_tokenizer_output(self):
+        tokenizer = BertTokenizer.from_preset(
+            "bert_tiny_uncased_en",
+        )
+        outputs = tokenizer("The quick brown fox.")
+        expected_outputs = [1996, 4248, 2829, 4419, 1012]
+        self.assertAllEqual(outputs, expected_outputs)
 
     def test_preprocessor_output(self):
         tokenizer = BertPreprocessor.from_preset(
@@ -110,6 +119,11 @@ class BertPresetTest(tf.test.TestCase):
                 "padding_mask": tf.constant([1] * 512, shape=(1, 512)),
             }
             classifier(input_data)
+
+    def test_load_tokenizers(self):
+        for preset in BertTokenizer.presets:
+            tokenizer = BertTokenizer.from_preset(preset)
+            tokenizer("The quick brown fox.")
 
     def test_load_preprocessors(self):
         for preset in BertPreprocessor.presets:


### PR DESCRIPTION
I will do the `(x, y, sample_weight)` pass through change as a follow up PR.