### PR TITLE
Allow formatting our docstrings inline

### DIFF
--- a/keras_nlp/models/bert/bert_models.py
+++ b/keras_nlp/models/bert/bert_models.py
@@ -237,13 +237,13 @@ class Bert(keras.Model):
         """Instantiate BERT model from preset architecture and weights.
 
         Args:
-            preset: string. Must be one of {names}.
+            preset: string. Must be one of {{names}}.
             load_weights: Whether to load pre-trained weights into model.
                 Defaults to `True`.
 
         Examples:
         ```python
-        input_data = {{
+        input_data = {
             "token_ids": tf.random.uniform(
                 shape=(1, 12), dtype=tf.int64, maxval=model.vocabulary_size
             ),
@@ -253,7 +253,7 @@ class Bert(keras.Model):
             "padding_mask": tf.constant(
                 [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
             ),
-        }}
+        }
 
         # Load architecture and weights from preset
         model = Bert.from_preset("bert_base_uncased_en")

--- a/keras_nlp/models/bert/bert_models.py
+++ b/keras_nlp/models/bert/bert_models.py
@@ -23,7 +23,8 @@ from tensorflow import keras
 from keras_nlp.layers.position_embedding import PositionEmbedding
 from keras_nlp.layers.transformer_encoder import TransformerEncoder
 from keras_nlp.models.bert.bert_presets import backbone_presets
-from keras_nlp.models.utils import classproperty
+from keras_nlp.utils.python_utils import classproperty
+from keras_nlp.utils.python_utils import format_docstring
 
 
 def bert_kernel_initializer(stddev=0.02):
@@ -226,13 +227,43 @@ class Bert(keras.Model):
         return copy.deepcopy(backbone_presets)
 
     @classmethod
+    @format_docstring(names=", ".join(backbone_presets))
     def from_preset(
         cls,
         preset,
         load_weights=True,
         **kwargs,
     ):
+        """Instantiate BERT model from preset architecture and weights.
 
+        Args:
+            preset: string. Must be one of {names}.
+            load_weights: Whether to load pre-trained weights into model.
+                Defaults to `True`.
+
+        Examples:
+        ```python
+        input_data = {{
+            "token_ids": tf.random.uniform(
+                shape=(1, 12), dtype=tf.int64, maxval=model.vocabulary_size
+            ),
+            "segment_ids": tf.constant(
+                [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
+            ),
+            "padding_mask": tf.constant(
+                [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
+            ),
+        }}
+
+        # Load architecture and weights from preset
+        model = Bert.from_preset("bert_base_uncased_en")
+        output = model(input_data)
+
+        # Load randomly initalized model from preset architecture
+        model = Bert.from_preset("bert_base_uncased_en", load_weights=False)
+        output = model(input_data)
+        ```
+        """
         if preset not in cls.presets:
             raise ValueError(
                 "`preset` must be one of "
@@ -254,41 +285,3 @@ class Bert(keras.Model):
 
         model.load_weights(weights)
         return model
-
-
-FROM_PRESET_DOCSTRING = """Instantiate BERT model from preset architecture and weights.
-
-    Args:
-        preset: string. Must be one of {names}.
-        load_weights: Whether to load pre-trained weights into model. Defaults
-            to `True`.
-
-    Examples:
-    ```python
-    input_data = {{
-        "token_ids": tf.random.uniform(
-            shape=(1, 12), dtype=tf.int64, maxval=model.vocabulary_size
-        ),
-        "segment_ids": tf.constant(
-            [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
-        ),
-        "padding_mask": tf.constant(
-            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
-        ),
-    }}
-
-    # Load architecture and weights from preset
-    model = Bert.from_preset("bert_base_uncased_en")
-    output = model(input_data)
-
-    # Load randomly initalized model from preset architecture
-    model = Bert.from_preset("bert_base_uncased_en", load_weights=False)
-    output = model(input_data)
-    ```
-    """
-
-setattr(
-    Bert.from_preset.__func__,
-    "__doc__",
-    FROM_PRESET_DOCSTRING.format(names=", ".join(Bert.presets)),
-)

--- a/keras_nlp/models/bert/bert_models_test.py
+++ b/keras_nlp/models/bert/bert_models_test.py
@@ -117,6 +117,11 @@ class BertTest(tf.test.TestCase, parameterized.TestCase):
             Bert.presets[preset]["config"]["max_sequence_length"], 512
         )
 
+    def test_preset_docstring(self):
+        """Check we did our docstring formatting correctly."""
+        for name in Bert.presets:
+            self.assertRegex(Bert.from_preset.__doc__, name)
+
     @parameterized.named_parameters(
         ("jit_compile_false", False), ("jit_compile_true", True)
     )

--- a/keras_nlp/models/bert/bert_preprocessing.py
+++ b/keras_nlp/models/bert/bert_preprocessing.py
@@ -305,7 +305,7 @@ class BertPreprocessor(keras.layers.Layer):
         """Instantiate BERT preprocessor from preset architecture.
 
         Args:
-            preset: string. Must be one of {names}.
+            preset: string. Must be one of {{names}}.
             sequence_length: int, optional. The length of the packed inputs.
                 Must be equal to or smaller than the `max_sequence_length` of
                 the preset. If left as default, the `max_sequence_length` of

--- a/keras_nlp/models/bert/bert_preprocessing.py
+++ b/keras_nlp/models/bert/bert_preprocessing.py
@@ -112,11 +112,31 @@ class BertTokenizer(WordPieceTokenizer):
         return copy.deepcopy(backbone_presets)
 
     @classmethod
+    @format_docstring(names=", ".join(backbone_presets))
     def from_preset(
         cls,
         preset,
         **kwargs,
     ):
+        """Instantiate a BERT tokenizer from preset vocabulary.
+
+        Args:
+            preset: string. Must be one of {{names}}.
+
+        Examples:
+        ```python
+        # Load a preset tokenizer.
+        tokenizer = keras_nlp.models.BertTokenizer.from_preset(
+            "bert_base_uncased_en",
+        )
+
+        # Tokenize some input.
+        tokenizer("The quick brown fox tripped.")
+
+        # Detokenize some input.
+        tokenizer.detokenize([5, 6, 7, 8, 9])
+        ```
+        """
         if preset not in cls.presets:
             raise ValueError(
                 "`preset` must be one of "
@@ -139,33 +159,6 @@ class BertTokenizer(WordPieceTokenizer):
         )
 
         return cls.from_config({**config, **kwargs})
-
-
-FROM_PRESET_DOCSTRING = """Instantiate a BERT tokenizer from preset vocabulary.
-
-    Args:
-        preset: string. Must be one of {names}.
-
-    Examples:
-    ```python
-    # Load a preset tokenizer.
-    tokenizer = keras_nlp.models.BertTokenizer.from_preset(
-        "bert_base_uncased_en",
-    )
-
-    # Tokenize some input.
-    tokenizer("The quick brown fox tripped.")
-
-    # Detokenize some input.
-    tokenizer.detokenize([5, 6, 7, 8, 9])
-    ```
-    """
-
-setattr(
-    BertTokenizer.from_preset.__func__,
-    "__doc__",
-    FROM_PRESET_DOCSTRING.format(names=", ".join(BertTokenizer.presets)),
-)
 
 
 @keras.utils.register_keras_serializable(package="keras_nlp")

--- a/keras_nlp/models/bert/bert_preprocessing_test.py
+++ b/keras_nlp/models/bert/bert_preprocessing_test.py
@@ -215,6 +215,11 @@ class BertPreprocessorTest(tf.test.TestCase, parameterized.TestCase):
             )
         get_file_mock.assert_called_once()
 
+    def test_preset_docstring(self):
+        """Check we did our docstring formatting correctly."""
+        for name in BertPreprocessor.presets:
+            self.assertRegex(BertPreprocessor.from_preset.__doc__, name)
+
     @parameterized.named_parameters(
         ("save_format_tf", "tf"), ("save_format_h5", "h5")
     )

--- a/keras_nlp/models/bert/bert_preprocessing_test.py
+++ b/keras_nlp/models/bert/bert_preprocessing_test.py
@@ -63,6 +63,11 @@ class BertTokenizerTest(tf.test.TestCase, parameterized.TestCase):
         with self.assertRaises(ValueError):
             BertPreprocessor.from_preset("bert_base_uncased_clowntown")
 
+    def test_preset_docstring(self):
+        """Check we did our docstring formatting correctly."""
+        for name in BertPreprocessor.presets:
+            self.assertRegex(BertPreprocessor.from_preset.__doc__, name)
+
     @unittest.mock.patch("tensorflow.keras.utils.get_file")
     def test_valid_call_presets(self, get_file_mock):
         """Ensure presets have necessary structure, but no RPCs."""
@@ -181,6 +186,11 @@ class BertPreprocessorTest(tf.test.TestCase, parameterized.TestCase):
         with self.assertRaises(ValueError):
             BertPreprocessor.from_preset("bert_base_uncased_clowntown")
 
+    def test_preset_docstring(self):
+        """Check we did our docstring formatting correctly."""
+        for name in BertPreprocessor.presets:
+            self.assertRegex(BertPreprocessor.from_preset.__doc__, name)
+
     @unittest.mock.patch("tensorflow.keras.utils.get_file")
     def test_valid_call_presets(self, get_file_mock):
         """Ensure presets have necessary structure, but no RPCs."""
@@ -214,11 +224,6 @@ class BertPreprocessorTest(tf.test.TestCase, parameterized.TestCase):
                 sequence_length=1024,
             )
         get_file_mock.assert_called_once()
-
-    def test_preset_docstring(self):
-        """Check we did our docstring formatting correctly."""
-        for name in BertPreprocessor.presets:
-            self.assertRegex(BertPreprocessor.from_preset.__doc__, name)
 
     @parameterized.named_parameters(
         ("save_format_tf", "tf"), ("save_format_h5", "h5")

--- a/keras_nlp/models/bert/bert_tasks_test.py
+++ b/keras_nlp/models/bert/bert_tasks_test.py
@@ -86,6 +86,11 @@ class BertClassifierTest(tf.test.TestCase, parameterized.TestCase):
                 load_weights=False,
             )
 
+    def test_preset_docstring(self):
+        """Check we did our docstring formatting correctly."""
+        for name in BertClassifier.presets:
+            self.assertRegex(BertClassifier.from_preset.__doc__, name)
+
     @parameterized.named_parameters(
         ("jit_compile_false", False), ("jit_compile_true", True)
     )

--- a/keras_nlp/utils/python_utils.py
+++ b/keras_nlp/utils/python_utils.py
@@ -11,9 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Utilities for models and preprocessors."""
+"""Utilities with miscellaneous python extensions."""
 
 
 class classproperty(property):
+    """Define a class level property."""
+
     def __get__(self, _, owner_cls):
         return self.fget(owner_cls)
+
+
+def format_docstring(**replacements):
+    """Format a python docstring using a dictionary of replacements."""
+
+    def decorate(obj):
+        obj.__doc__ = obj.__doc__.format(**replacements)
+        return obj
+
+    return decorate

--- a/keras_nlp/utils/python_utils.py
+++ b/keras_nlp/utils/python_utils.py
@@ -22,10 +22,25 @@ class classproperty(property):
 
 
 def format_docstring(**replacements):
-    """Format a python docstring using a dictionary of replacements."""
+    """Format a python docstring using a dictionary of replacements.
+
+    This decorator can be placed on a function, class or method to format it's
+    docstring with python variables.
+
+    The decorator will replace any double bracketed variable with a kwargs
+    value passed to the decorator itself. For example
+    `@format_docstring(name="foo")` will replace any occurance of `{{name}}` in
+    the docstring with the string literal `foo`.
+    """
 
     def decorate(obj):
-        obj.__doc__ = obj.__doc__.format(**replacements)
+        doc = obj.__doc__
+        # We use `str.format()` to replace variables in the docstring, but use
+        # double brackets, e.g. {{var}}, to mark format strings. So we need to
+        # to swap all double and single brackets in the source docstring.
+        doc = "{".join(part.replace("{", "{{") for part in doc.split("{{"))
+        doc = "}".join(part.replace("}", "}}") for part in doc.split("}}"))
+        obj.__doc__ = doc.format(**replacements)
         return obj
 
     return decorate

--- a/keras_nlp/utils/python_utils_test.py
+++ b/keras_nlp/utils/python_utils_test.py
@@ -18,66 +18,67 @@ from keras_nlp.utils.python_utils import classproperty
 from keras_nlp.utils.python_utils import format_docstring
 
 
-class ClassWithClassProperty:
-    @classproperty
-    def foo(cls):
-        return "class property"
-
-
-@format_docstring(adjective="salubrious")
-def foo():
-    """It was a {{adjective}} November day."""
-    return "function"
-
-
-@format_docstring(adjective="smelly", name="Mortimer")
-class ClassWithDocstrings:
-    """I saw my {{adjective}} friend {{name}}."""
-
-    def __init__(self):
-        self.bar = "property"
-
-    @classmethod
-    @format_docstring(noun="cactus", bodypart="nostril")
-    def foo(cls):
-        """He was holding a {{noun}} in his {{bodypart}}."""
-        return "class method"
-
-
-@format_docstring(nickname="dumdum")
-def bar():
-    """Use `{}` to create a dictionary, {{nickname}}."""
-    return "function"
-
-
 class ClassPropertyTest(tf.test.TestCase):
     def test_class_property(self):
-        self.assertAllEqual(ClassWithClassProperty.foo, "class property")
+        class Foo:
+            @classproperty
+            def bar(cls):
+                return "class property"
+
+        self.assertAllEqual(Foo.bar, "class property")
 
 
 class FormatDocstringTest(tf.test.TestCase):
     def test_function(self):
+        @format_docstring(adjective="salubrious")
+        def foo():
+            """It was a {{adjective}} November day."""
+            return "function"
+
         self.assertAllEqual(foo(), "function")
         self.assertAllEqual(foo.__doc__, "It was a salubrious November day.")
 
     def test_class(self):
-        self.assertAllEqual(ClassWithDocstrings().bar, "property")
-        self.assertAllEqual(
-            ClassWithDocstrings.__doc__, "I saw my smelly friend Mortimer."
-        )
+        @format_docstring(adjective="smelly", name="Mortimer")
+        class Foo:
+            """I saw my {{adjective}} friend {{name}}."""
+
+            def __init__(self):
+                self.bar = "property"
+
+        self.assertAllEqual(Foo().bar, "property")
+        self.assertAllEqual(Foo.__doc__, "I saw my smelly friend Mortimer.")
 
     def test_class_method(self):
-        self.assertAllEqual(ClassWithDocstrings.foo(), "class method")
+        @format_docstring(adjective="smelly", name="Mortimer")
+        class Foo:
+            """I saw my {{adjective}} friend {{name}}."""
+
+            def __init__(self):
+                self.bar = "property"
+
+            @classmethod
+            @format_docstring(noun="cactus", bodypart="nostril")
+            def baz(cls):
+                """He was holding a {{noun}} in his {{bodypart}}."""
+                return "class method"
+
+        self.assertAllEqual(Foo.baz(), "class method")
         self.assertAllEqual(
-            ClassWithDocstrings.foo.__doc__,
+            Foo.baz.__doc__,
             "He was holding a cactus in his nostril.",
         )
         self.assertAllEqual(
-            ClassWithDocstrings.foo.__func__.__doc__,
+            Foo.baz.__func__.__doc__,
             "He was holding a cactus in his nostril.",
         )
 
     def test_brackets(self):
+        @format_docstring(nickname="dumdum")
+        def bar():
+            """Use `{}` to create a dictionary, {{nickname}}."""
+            return "function"
+
         self.assertAllEqual(bar(), "function")
         self.assertAllEqual(
             bar.__doc__, "Use `{}` to create a dictionary, dumdum."

--- a/keras_nlp/utils/python_utils_test.py
+++ b/keras_nlp/utils/python_utils_test.py
@@ -26,13 +26,13 @@ class ClassWithClassProperty:
 
 @format_docstring(adjective="salubrious")
 def foo():
-    """It was a {adjective} November day."""
+    """It was a {{adjective}} November day."""
     return "function"
 
 
 @format_docstring(adjective="smelly", name="Mortimer")
 class ClassWithDocstrings:
-    """I saw my {adjective} friend {name}."""
+    """I saw my {{adjective}} friend {{name}}."""
 
     def __init__(self):
         self.bar = "property"
@@ -40,8 +40,14 @@ class ClassWithDocstrings:
     @classmethod
     @format_docstring(noun="cactus", bodypart="nostril")
     def foo(cls):
-        """He was holding a {noun} in his {bodypart}."""
+        """He was holding a {{noun}} in his {{bodypart}}."""
         return "class method"
+
+
+@format_docstring(nickname="dumdum")
+def bar():
+    """Use `{}` to create a dictionary, {{nickname}}."""
+    return "function"
 
 
 class ClassPropertyTest(tf.test.TestCase):
@@ -69,4 +75,10 @@ class FormatDocstringTest(tf.test.TestCase):
         self.assertAllEqual(
             ClassWithDocstrings.foo.__func__.__doc__,
             "He was holding a cactus in his nostril.",
+        )
+
+    def test_brackets(self):
+        self.assertAllEqual(bar(), "function")
+        self.assertAllEqual(
+            bar.__doc__, "Use `{}` to create a dictionary, dumdum."
         )

--- a/keras_nlp/utils/python_utils_test.py
+++ b/keras_nlp/utils/python_utils_test.py
@@ -1,0 +1,72 @@
+# Copyright 2022 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+from keras_nlp.utils.python_utils import classproperty
+from keras_nlp.utils.python_utils import format_docstring
+
+
+class ClassWithClassProperty:
+    @classproperty
+    def foo(cls):
+        return "class property"
+
+
+@format_docstring(adjective="salubrious")
+def foo():
+    """It was a {adjective} November day."""
+    return "function"
+
+
+@format_docstring(adjective="smelly", name="Mortimer")
+class ClassWithDocstrings:
+    """I saw my {adjective} friend {name}."""
+
+    def __init__(self):
+        self.bar = "property"
+
+    @classmethod
+    @format_docstring(noun="cactus", bodypart="nostril")
+    def foo(cls):
+        """He was holding a {noun} in his {bodypart}."""
+        return "class method"
+
+
+class ClassPropertyTest(tf.test.TestCase):
+    def test_class_property(self):
+        self.assertAllEqual(ClassWithClassProperty.foo, "class property")
+
+
+class FormatDocstringTest(tf.test.TestCase):
+    def test_function(self):
+        self.assertAllEqual(foo(), "function")
+        self.assertAllEqual(foo.__doc__, "It was a salubrious November day.")
+
+    def test_class(self):
+        self.assertAllEqual(ClassWithDocstrings().bar, "property")
+        self.assertAllEqual(
+            ClassWithDocstrings.__doc__, "I saw my smelly friend Mortimer."
+        )
+
+    def test_class_method(self):
+        self.assertAllEqual(ClassWithDocstrings.foo(), "class method")
+        self.assertAllEqual(
+            ClassWithDocstrings.foo.__doc__,
+            "He was holding a cactus in his nostril.",
+        )
+        self.assertAllEqual(
+            ClassWithDocstrings.foo.__func__.__doc__,
+            "He was holding a cactus in his nostril.",
+        )


### PR DESCRIPTION
We keep changing which docstring we format, and it makes for these huge diffs.

We have even talked about switching this in the future to listing a url to a full list of presets. If we did that, we would need to move all our docstrings around again.

This adds a more general method for docstring formatting so we don't have to keep moving these massive blocks around.