### PR TITLE
Allow BertPreprocessor to map labeled datasets

### DIFF
--- a/keras_nlp/models/bert/bert_preprocessing.py
+++ b/keras_nlp/models/bert/bert_preprocessing.py
@@ -226,7 +226,7 @@ class BertPreprocessor(keras.layers.Layer):
     ds = tf.data.Dataset.from_tensor_slices((features, labels))
     ds = ds.map(preprocessor, num_parallel_calls=tf.data.AUTOTUNE)
 
-    # Map a dataset to preprocess a multiple sentences.
+    # Map a dataset to preprocess multiple sentence pairs.
     first_sentences = ["The quick brown fox jumped.", "Call me Ishmael."]
     second_sentences = ["The fox tripped.", "Oh look, a whale."]
     labels = [1, 1]
@@ -236,6 +236,17 @@ class BertPreprocessor(keras.layers.Layer):
         )
     )
     ds = ds.map(preprocessor, num_parallel_calls=tf.data.AUTOTUNE)
+
+    # Map a dataset to preprocess unlabeled sentence pairs.
+    first_sentences = ["The quick brown fox jumped.", "Call me Ishmael."]
+    second_sentences = ["The fox tripped.", "Oh look, a whale."]
+    ds = tf.data.Dataset.from_tensor_slices((first_sentences, second_sentences))
+    # Watch out for tf.data's default unpacking of tuples here!
+    # Best to invoke the `preprocessor` directly in this case.
+    ds = ds.map(
+        lambda s1, s2: preprocessor(x=(s1, s2)),
+        num_parallel_calls=tf.data.AUTOTUNE,
+    )
     ```
     """
 

--- a/keras_nlp/models/bert/bert_preprocessing.py
+++ b/keras_nlp/models/bert/bert_preprocessing.py
@@ -179,8 +179,8 @@ class BertPreprocessor(keras.layers.Layer):
     `keras.Model.fit`.
 
     The call method of this layer accepts three arguments, `x`, `y`, and
-    `sample_weights`. `x` should be either a (possible batched) string tensor,
-    or a tuple of (possible batched) string tensors. `y` and `sample_weights`
+    `sample_weights`. `x` should be either a (possibly batched) string tensor,
+    or a tuple of (possibly batched) string tensors. `y` and `sample_weights`
     are both optional, can have any format, and will be passed through
     unaltered.
 

--- a/keras_nlp/models/bert/bert_preprocessing.py
+++ b/keras_nlp/models/bert/bert_preprocessing.py
@@ -21,6 +21,7 @@ from tensorflow import keras
 from keras_nlp.layers.multi_segment_packer import MultiSegmentPacker
 from keras_nlp.models.bert.bert_presets import backbone_presets
 from keras_nlp.tokenizers.word_piece_tokenizer import WordPieceTokenizer
+from keras_nlp.utils.keras_utils import pack_x_y_sample_weight
 from keras_nlp.utils.python_utils import classproperty
 from keras_nlp.utils.python_utils import format_docstring
 
@@ -167,15 +168,27 @@ class BertPreprocessor(keras.layers.Layer):
 
     This preprocessing layer will do three things:
 
-     - Tokenize any number of inputs using the `tokenizer`.
+     - Tokenize any number of input segments using the `tokenizer`.
      - Pack the inputs together using a `keras_nlp.layers.MultiSegmentPacker`.
        with the appropriate `"[CLS]"`, `"[SEP]"` and `"[PAD]"` tokens.
      - Construct a dictionary of with keys `"token_ids"`, `"segment_ids"`,
        `"padding_mask"`, that can be passed directly to a BERT model.
 
-    This layer will accept either a tuple of (possibly batched) inputs, or a
-    single input tensor. If a single tensor is passed, it will be packed
-    equivalently to a tuple with a single element.
+    This layer can be used directly with `tf.data.Dataset.map` to preprocess
+    string data in the `(x, y, sample_weight)` format used by
+    `keras.Model.fit`.
+
+    The call method of this layer accepts three arguments, `x`, `y`, and
+    `sample_weights`. `x` should be either a (possible batched) string tensor,
+    or a tuple of (possible batched) string tensors. `y` and `sample_weights`
+    are both optional, can have any format, and will be passed through
+    unaltered.
+
+    Special care should be taken when using `tf.data` to map over an unlabeled
+    tuple of string segments. `tf.data` will unpack this tuple directly into the
+    call arguments of this layer, rather than forward all argument to `x`. To
+    handle this case, it is recommended to  explicitly call the layer, e.g.
+    `ds.map(lambda seg1, seg2: preprocessor(x=(seg1, seg2)))`.
 
     Args:
         tokenizer: A `keras_nlp.models.BertTokenizer` instance.
@@ -211,10 +224,7 @@ class BertPreprocessor(keras.layers.Layer):
     features = ["The quick brown fox jumped.", "I forgot my homework."]
     labels = [0, 1]
     ds = tf.data.Dataset.from_tensor_slices((features, labels))
-    ds = ds.map(
-        lambda x, y: (preprocessor(x), y),
-        num_parallel_calls=tf.data.AUTOTUNE,
-    )
+    ds = ds.map(preprocessor, num_parallel_calls=tf.data.AUTOTUNE)
 
     # Map a dataset to preprocess a multiple sentences.
     first_sentences = ["The quick brown fox jumped.", "Call me Ishmael."]
@@ -225,10 +235,8 @@ class BertPreprocessor(keras.layers.Layer):
             (first_sentences, second_sentences), labels
         )
     )
-    ds = ds.map(
-        lambda x, y: (preprocessor(x), y),
-        num_parallel_calls=tf.data.AUTOTUNE,
-    )    ```
+    ds = ds.map(preprocessor, num_parallel_calls=tf.data.AUTOTUNE)
+    ```
     """
 
     def __init__(
@@ -270,17 +278,18 @@ class BertPreprocessor(keras.layers.Layer):
             config["tokenizer"] = keras.layers.deserialize(config["tokenizer"])
         return cls(**config)
 
-    def call(self, inputs):
-        if not isinstance(inputs, (list, tuple)):
-            inputs = [inputs]
+    def call(self, x, y=None, sample_weight=None):
+        if not isinstance(x, (list, tuple)):
+            x = [x]
 
-        inputs = [self.tokenizer(x) for x in inputs]
-        token_ids, segment_ids = self.packer(inputs)
-        return {
+        x = [self.tokenizer(segment) for segment in x]
+        token_ids, segment_ids = self.packer(x)
+        x = {
             "token_ids": token_ids,
             "segment_ids": segment_ids,
             "padding_mask": token_ids != self.tokenizer.pad_token_id,
         }
+        return pack_x_y_sample_weight(x, y, sample_weight)
 
     @classproperty
     def presets(cls):

--- a/keras_nlp/models/bert/bert_preprocessing_test.py
+++ b/keras_nlp/models/bert/bert_preprocessing_test.py
@@ -114,14 +114,7 @@ class BertPreprocessorTest(tf.test.TestCase, parameterized.TestCase):
         self.assertAllEqual(output["padding_mask"], [1, 1, 1, 1, 1, 1, 1, 0])
 
     def test_tokenize_batch(self):
-        input_data = tf.constant(
-            [
-                "THE QUICK BROWN FOX.",
-                "THE QUICK BROWN FOX.",
-                "THE QUICK BROWN FOX.",
-                "THE QUICK BROWN FOX.",
-            ]
-        )
+        input_data = tf.constant(["THE QUICK BROWN FOX."] * 4)
         preprocessor = BertPreprocessor(
             BertTokenizer(vocabulary=self.vocab),
             sequence_length=8,
@@ -134,6 +127,46 @@ class BertPreprocessorTest(tf.test.TestCase, parameterized.TestCase):
         self.assertAllEqual(
             output["padding_mask"], [[1, 1, 1, 1, 1, 1, 1, 0]] * 4
         )
+
+    def test_tokenize_labeled_batch(self):
+        x = tf.constant(["THE QUICK BROWN FOX."] * 4)
+        y = tf.constant([1] * 4)
+        sw = tf.constant([1.0] * 4)
+        preprocessor = BertPreprocessor(
+            BertTokenizer(vocabulary=self.vocab),
+            sequence_length=8,
+        )
+        x_out, y_out, sw_out = preprocessor(x, y, sw)
+        self.assertAllEqual(x_out["token_ids"], [[2, 5, 6, 7, 8, 1, 3, 0]] * 4)
+        self.assertAllEqual(
+            x_out["segment_ids"], [[0, 0, 0, 0, 0, 0, 0, 0]] * 4
+        )
+        self.assertAllEqual(
+            x_out["padding_mask"], [[1, 1, 1, 1, 1, 1, 1, 0]] * 4
+        )
+        self.assertAllEqual(y_out, y)
+        self.assertAllEqual(sw_out, sw)
+
+    def test_tokenize_labeled_dataset(self):
+        x = tf.constant(["THE QUICK BROWN FOX."] * 4)
+        y = tf.constant([1] * 4)
+        sw = tf.constant([1.0] * 4)
+        ds = tf.data.Dataset.from_tensor_slices((x, y, sw))
+        preprocessor = BertPreprocessor(
+            BertTokenizer(vocabulary=self.vocab),
+            sequence_length=8,
+        )
+        ds = ds.map(preprocessor)
+        x_out, y_out, sw_out = ds.batch(4).take(1).get_single_element()
+        self.assertAllEqual(x_out["token_ids"], [[2, 5, 6, 7, 8, 1, 3, 0]] * 4)
+        self.assertAllEqual(
+            x_out["segment_ids"], [[0, 0, 0, 0, 0, 0, 0, 0]] * 4
+        )
+        self.assertAllEqual(
+            x_out["padding_mask"], [[1, 1, 1, 1, 1, 1, 1, 0]] * 4
+        )
+        self.assertAllEqual(y_out, y)
+        self.assertAllEqual(sw_out, sw)
 
     def test_tokenize_multiple_sentences(self):
         sentence_one = "THE QUICK"
@@ -150,22 +183,8 @@ class BertPreprocessorTest(tf.test.TestCase, parameterized.TestCase):
         self.assertAllEqual(output["padding_mask"], [1, 1, 1, 1, 1, 1, 1, 1])
 
     def test_tokenize_multiple_batched_sentences(self):
-        sentence_one = tf.constant(
-            [
-                "THE QUICK",
-                "THE QUICK",
-                "THE QUICK",
-                "THE QUICK",
-            ]
-        )
-        sentence_two = tf.constant(
-            [
-                "BROWN FOX.",
-                "BROWN FOX.",
-                "BROWN FOX.",
-                "BROWN FOX.",
-            ]
-        )
+        sentence_one = tf.constant(["THE QUICK"] * 4)
+        sentence_two = tf.constant(["BROWN FOX."] * 4)
         preprocessor = BertPreprocessor(
             BertTokenizer(vocabulary=self.vocab),
             sequence_length=8,

--- a/keras_nlp/utils/keras_utils.py
+++ b/keras_nlp/utils/keras_utils.py
@@ -33,15 +33,8 @@ def pack_x_y_sample_weight(x, y=None, sample_weight=None):
     """Packs user-provided data into a tuple.
 
     This is a temporary copy of `keras.utils.pack_x_y_sample_weight` while we
-    wait for the change in the following PR to get released:
-    https://github.com/keras-team/keras/pull/17233
-
-    The change makes it so that dictionary features are not packed in a tuple
-    needlessly. This is important for KerasNLP as almost all of our model inputs
-    are dicts.
-
-    We will likely want to carry this change until Tensorflow 2.12 is the
-    default installation on colab.
+    wait for the a change to the upstream version to propagate to a stable
+    release. See https://github.com/keras-team/keras-nlp/issues/492
     """
     if y is None:
         if not isinstance(x, (list, tuple)):

--- a/keras_nlp/utils/keras_utils.py
+++ b/keras_nlp/utils/keras_utils.py
@@ -27,3 +27,28 @@ def clone_initializer(initializer):
         return initializer
     config = initializer.get_config()
     return initializer.__class__.from_config(config)
+
+
+def pack_x_y_sample_weight(x, y=None, sample_weight=None):
+    """Packs user-provided data into a tuple.
+
+    This is a temporary copy of `keras.utils.pack_x_y_sample_weight` while we
+    wait for the change in the following PR to get released:
+    https://github.com/keras-team/keras/pull/17233
+
+    The change makes it so that dictionary features are not packed in a tuple
+    needlessly. This is important for KerasNLP as almost all of our model inputs
+    are dicts.
+
+    We will likely want to carry this change until Tensorflow 2.12 is the
+    default installation on colab.
+    """
+    if y is None:
+        if not isinstance(x, (list, tuple)):
+            return x
+        else:
+            return (x,)
+    elif sample_weight is None:
+        return (x, y)
+    else:
+        return (x, y, sample_weight)

--- a/keras_nlp/utils/keras_utils_test.py
+++ b/keras_nlp/utils/keras_utils_test.py
@@ -16,6 +16,7 @@ import tensorflow as tf
 from tensorflow import keras
 
 from keras_nlp.utils.keras_utils import clone_initializer
+from keras_nlp.utils.keras_utils import pack_x_y_sample_weight
 
 
 class CloneInitializerTest(tf.test.TestCase):
@@ -39,3 +40,28 @@ class CloneInitializerTest(tf.test.TestCase):
         initializer = "glorot_uniform"
         clone = clone_initializer(initializer)
         self.assertAllEqual(initializer, clone)
+
+
+class PackTest(tf.test.TestCase):
+    def test_pack_dict(self):
+        tensor_dict = {"foo": tf.constant([1, 2])}
+        data = pack_x_y_sample_weight(tensor_dict)
+        self.assertAllEqual(data, tensor_dict)
+
+    def test_pack_tuple(self):
+        tensor_tuple = (tf.constant([1, 2]),)
+        data = pack_x_y_sample_weight(tensor_tuple)
+        self.assertAllEqual(data, (tensor_tuple,))
+
+    def test_pack_pair(self):
+        x = tf.constant([1, 2])
+        y = tf.constant([3, 4])
+        data = pack_x_y_sample_weight(x, y)
+        self.assertAllEqual(data, (x, y))
+
+    def test_pack_triplet(self):
+        x = tf.constant([1, 2])
+        y = tf.constant([3, 4])
+        sw = tf.constant([5, 6])
+        data = pack_x_y_sample_weight(x, y, sw)
+        self.assertAllEqual(data, (x, y, sw))


### PR DESCRIPTION
By adding two optional arguments `y=None` and `sample_weight=None`, we allow the layed to be called directly on datasets in the format accepted by `keras.Model.fit()`. This does not change any existing functionality to the layer.