### PR TITLE
Consolidate preset testing

### DIFF
--- a/keras_nlp/models/bert/bert_models_test.py
+++ b/keras_nlp/models/bert/bert_models_test.py
@@ -69,59 +69,6 @@ class BertTest(tf.test.TestCase, parameterized.TestCase):
             }
             self.model(input_data)
 
-    def test_valid_call_presets(self):
-        # Test preset loading without weights
-        for preset in Bert.presets:
-            model = Bert.from_preset(preset, load_weights=False, name="encoder")
-            input_data = {
-                "token_ids": tf.ones(
-                    (self.batch_size, self.model.max_sequence_length),
-                    dtype="int32",
-                ),
-                "segment_ids": tf.ones(
-                    (self.batch_size, self.model.max_sequence_length),
-                    dtype="int32",
-                ),
-                "padding_mask": tf.ones(
-                    (self.batch_size, self.model.max_sequence_length),
-                    dtype="int32",
-                ),
-            }
-            model(input_data)
-
-    def test_unknown_preset_error(self):
-        # Not a preset name
-        with self.assertRaises(ValueError):
-            Bert.from_preset(
-                "bert_base_uncased_clowntown",
-                load_weights=False,
-            )
-
-    def test_preset_mutability(self):
-        preset = "bert_base_uncased_en"
-        # Cannot overwrite the presents attribute in an object
-        with self.assertRaises(AttributeError):
-            self.model.presets = {"my_model": "clowntown"}
-        # Cannot mutate presents in an object
-        config = self.model.presets[preset]["config"]
-        config["max_sequence_length"] = 1
-        self.assertEqual(config["max_sequence_length"], 1)
-        self.assertEqual(
-            self.model.presets[preset]["config"]["max_sequence_length"], 512
-        )
-        # Cannot mutate presets in the class
-        config = Bert.presets[preset]["config"]
-        config["max_sequence_length"] = 1
-        self.assertEqual(config["max_sequence_length"], 1)
-        self.assertEqual(
-            Bert.presets[preset]["config"]["max_sequence_length"], 512
-        )
-
-    def test_preset_docstring(self):
-        """Check we did our docstring formatting correctly."""
-        for name in Bert.presets:
-            self.assertRegex(Bert.from_preset.__doc__, name)
-
     @parameterized.named_parameters(
         ("jit_compile_false", False), ("jit_compile_true", True)
     )

--- a/keras_nlp/models/bert/bert_preprocessing_test.py
+++ b/keras_nlp/models/bert/bert_preprocessing_test.py
@@ -14,7 +14,6 @@
 """Tests for BERT preprocessing layers."""
 
 import os
-import unittest
 
 import tensorflow as tf
 from absl.testing import parameterized
@@ -57,26 +56,6 @@ class BertTokenizerTest(tf.test.TestCase, parameterized.TestCase):
     def test_vocabulary_size(self):
         tokenizer = BertTokenizer(vocabulary=self.vocab)
         self.assertEqual(tokenizer.vocabulary_size(), 13)
-
-    def test_unknown_preset_error(self):
-        # Not a preset name
-        with self.assertRaises(ValueError):
-            BertPreprocessor.from_preset("bert_base_uncased_clowntown")
-
-    def test_preset_docstring(self):
-        """Check we did our docstring formatting correctly."""
-        for name in BertPreprocessor.presets:
-            self.assertRegex(BertPreprocessor.from_preset.__doc__, name)
-
-    @unittest.mock.patch("tensorflow.keras.utils.get_file")
-    def test_valid_call_presets(self, get_file_mock):
-        """Ensure presets have necessary structure, but no RPCs."""
-        input_data = ["THE QUICK BROWN FOX."]
-        get_file_mock.return_value = self.vocab
-        for preset in BertTokenizer.presets:
-            tokenizer = BertTokenizer.from_preset(preset)
-            tokenizer(input_data)
-        self.assertEqual(get_file_mock.call_count, len(BertTokenizer.presets))
 
     @parameterized.named_parameters(
         ("save_format_tf", "tf"), ("save_format_h5", "h5")
@@ -180,50 +159,6 @@ class BertPreprocessorTest(tf.test.TestCase, parameterized.TestCase):
         self.assertAllEqual(
             output["padding_mask"], [[1, 1, 1, 1, 1, 1, 1, 1]] * 4
         )
-
-    def test_unknown_preset_error(self):
-        # Not a preset name
-        with self.assertRaises(ValueError):
-            BertPreprocessor.from_preset("bert_base_uncased_clowntown")
-
-    def test_preset_docstring(self):
-        """Check we did our docstring formatting correctly."""
-        for name in BertPreprocessor.presets:
-            self.assertRegex(BertPreprocessor.from_preset.__doc__, name)
-
-    @unittest.mock.patch("tensorflow.keras.utils.get_file")
-    def test_valid_call_presets(self, get_file_mock):
-        """Ensure presets have necessary structure, but no RPCs."""
-        input_data = ["THE QUICK BROWN FOX."]
-        get_file_mock.return_value = self.vocab
-        for preset in BertPreprocessor.presets:
-            preprocessor = BertPreprocessor.from_preset(preset)
-            preprocessor(input_data)
-        self.assertEqual(
-            get_file_mock.call_count, len(BertPreprocessor.presets)
-        )
-
-    @unittest.mock.patch("tensorflow.keras.utils.get_file")
-    def test_override_preprocessor_sequence_length(self, get_file_mock):
-        get_file_mock.return_value = self.vocab
-        preprocessor = BertPreprocessor.from_preset(
-            "bert_base_uncased_en",
-            sequence_length=64,
-        )
-        self.assertEqual(preprocessor.get_config()["sequence_length"], 64)
-        preprocessor("The quick brown fox.")
-        get_file_mock.assert_called_once()
-
-    @unittest.mock.patch("tensorflow.keras.utils.get_file")
-    def test_override_preprocessor_sequence_length_gt_max(self, get_file_mock):
-        """Override sequence length longer than model's maximum."""
-        get_file_mock.return_value = self.vocab
-        with self.assertRaises(ValueError):
-            BertPreprocessor.from_preset(
-                "bert_base_uncased_en",
-                sequence_length=1024,
-            )
-        get_file_mock.assert_called_once()
 
     @parameterized.named_parameters(
         ("save_format_tf", "tf"), ("save_format_h5", "h5")

--- a/keras_nlp/models/bert/bert_tasks_test.py
+++ b/keras_nlp/models/bert/bert_tasks_test.py
@@ -58,39 +58,6 @@ class BertClassifierTest(tf.test.TestCase, parameterized.TestCase):
     def test_valid_call_classifier(self):
         self.classifier(self.input_batch)
 
-    def test_valid_call_presets(self):
-        # Test preset loading without weights
-        for preset in BertClassifier.presets:
-            classifier = BertClassifier.from_preset(preset, load_weights=False)
-            input_data = {
-                "token_ids": tf.ones(
-                    (self.batch_size, self.backbone.max_sequence_length),
-                    dtype="int32",
-                ),
-                "segment_ids": tf.ones(
-                    (self.batch_size, self.backbone.max_sequence_length),
-                    dtype="int32",
-                ),
-                "padding_mask": tf.ones(
-                    (self.batch_size, self.backbone.max_sequence_length),
-                    dtype="int32",
-                ),
-            }
-            classifier(input_data)
-
-    def test_unknown_preset_error(self):
-        # Not a preset name
-        with self.assertRaises(ValueError):
-            BertClassifier.from_preset(
-                "bert_base_uncased_clowntown",
-                load_weights=False,
-            )
-
-    def test_preset_docstring(self):
-        """Check we did our docstring formatting correctly."""
-        for name in BertClassifier.presets:
-            self.assertRegex(BertClassifier.from_preset.__doc__, name)
-
     @parameterized.named_parameters(
         ("jit_compile_false", False), ("jit_compile_true", True)
     )


### PR DESCRIPTION
Overall this feels like a good direction:
- This increases the actual continuous coverage for from_preset.
- This increases the actual manual coverage for from_preset.
- This reduces and consolidates the code for testing from_preset. Consolidating the preset testing code will make it way easier for this to be contributed as a separate step (as will often be the case).
- This removes the need for any mocks of private implementation.
- The default "fast" run of pytest will no longer attempt to create full sized LLM networks (which can get quite large and slow).

A few more nuanced parts of this PR:
- If you are changing preset code, you will need to remember to to run something like `pytest keras_nlp/models/bert/ --run_large` But if you forget to do this, we will actually still get test failures on github when we run the large tests on CI, so we have an effective safeguard.
- We will no longer create randomly instantiated models of all preset sizes on CI. This leads to OOM issues for larger models. Rather we will only test the smallest preset with random weights on CI, and rely on manual testing for now for the full enumeration of presets.