### PR TITLE
Fix the nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,7 +31,9 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements-nightly.txt --progress-bar off
-          pip install -e "." --progress-bar off
+          # --no-deps so pip will not try to install tf and tf-text stable
+          # versions after installing the nightly versions above.
+          pip install --no-deps -e "." --progress-bar off
       - name: Test with pytest
         run: |
           pytest --cov=keras_nlp --cov-report xml:coverage.xml


### PR DESCRIPTION
Right now, tf has a new stable release than tf-text, so installing them both can lead to a slow process of downloading many version of tf.

When we are running the nightly version, we actually don't want any stable versions of tf installed at all. The easiest way to to do this is to specify --no-deps when pip install our source (after installing all our nightly dependencies via our requirements file).