### PR TITLE
Fix nightly builds

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ filterwarnings =
     ignore::PendingDeprecationWarning
     ignore::FutureWarning
     ignore::UserWarning
+    ignore::keras.saving.legacy.serialization.CustomMaskWarning
 
 addopts=-vv
 


### PR DESCRIPTION
Temporarily ignore a specific warning from core Keras, it is getting generated for any functional model saving on nightly.