### PR TITLE
Fix nightlies take two

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,8 @@ filterwarnings =
     ignore::PendingDeprecationWarning
     ignore::FutureWarning
     ignore::UserWarning
-    ignore::keras.saving.legacy.serialization.CustomMaskWarning
+    # Ignore a spurious warning on tf-nightly related to save model changes.
+    ignore:Custom mask layers require a config
 
 addopts=-vv
 


### PR DESCRIPTION
The previous fix in #522 to ignore the spurious error being raise by our nightlies fixes tf-nightly, but broke environments with tf < 2.10 as the error symbol did not exists.

Let's match the error message, rather than the class, to work around this.