### PR TITLE
Raise a friendly error message for unbatched input

### DIFF
--- a/keras_nlp/utils/pipeline_model_test.py
+++ b/keras_nlp/utils/pipeline_model_test.py
@@ -557,3 +557,18 @@ class TestFitArguments(tf.test.TestCase):
             model.fit(ds, y=y)
         with self.assertRaises(ValueError):
             model.fit(ds, sample_weight=sw)
+
+
+class TestInputErrors(tf.test.TestCase):
+    def test_unbatched_input_raises(self):
+        model = FeaturePipeline()
+        with self.assertRaisesRegex(ValueError, "must have a batch dimension"):
+            model.fit(x=tf.constant("test"))
+        with self.assertRaisesRegex(ValueError, "must have a batch dimension"):
+            model.fit(x=tf.constant(["test"]), y=tf.constant(0))
+        with self.assertRaisesRegex(ValueError, "must have a batch dimension"):
+            model.fit(
+                x=tf.constant(["test"]), y=tf.constant([0]), sample_weight=0.0
+            )
+        with self.assertRaisesRegex(ValueError, "must have a batch dimension"):
+            model.fit(x="test")


### PR DESCRIPTION
When fit/predict/evaluate are passed input without a batch dimension, we will generally error out. This is true for all Keras models: functional, sequential, subclass.

The core Keras error is not actually super helpful here, you just get 'IndexError: tuple index out of range'. We can add a better error message for our pipeline models though, explaining the issue and suggesting a fix.