### PR TITLE
Fix LinearDecayWithWarmup crash in BERT model.

### DIFF
--- a/examples/bert/bert_train.py
+++ b/examples/bert/bert_train.py
@@ -253,6 +253,7 @@ class LinearDecayWithWarmup(keras.optimizers.schedules.LearningRateSchedule):
         peak_lr = tf.cast(self.learning_rate, dtype=tf.float32)
         warmup = tf.cast(self.warmup_steps, dtype=tf.float32)
         training = tf.cast(self.train_steps, dtype=tf.float32)
+        step = tf.cast(step, dtype=tf.float32)
 
         is_warmup = step < warmup
 


### PR DESCRIPTION
Keras optimizers pass an int64 tensor to the "step" parameter for `LearningRateSchedule.__call__` in TF 2.11. The LinearDecayWithWarmup in the BERT model would compare this with a float32 tensor, causing a crash. This change makes LinearDecayWithWarmup cast "step" to float32.