### PR TITLE
Remove support for Python 3.7 to align with keras-nightly

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Get pip cache dir
         id: pip-cache
         run: |
@@ -39,10 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Get pip cache dir
         id: pip-cache
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Get pip cache dir
         id: pip-cache
         run: |

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,4 +1,5 @@
 # Tooling.
+numpy~=1.23.2  # Numpy 1.24 breaks tests on ragged tensors
 packaging
 black>=22
 black[juypter]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # Core deps.
+numpy~=1.23.2  # Numpy 1.24 breaks tests on ragged tensors.
 tensorflow~=2.11.0
 tensorflow-text~=2.11.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # Core deps.
-numpy~=1.23.2  # Numpy 1.24 breaks tests on ragged tensors.
 tensorflow~=2.11.0
 tensorflow-text~=2.11.0
 

--- a/setup.py
+++ b/setup.py
@@ -61,14 +61,14 @@ setup(
         ],
     },
     # Supported Python versions
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3 :: Only",
         "Operating System :: Unix",
         "Operating System :: Microsoft :: Windows",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     license="Apache License 2.0",
     install_requires=[
         "absl-py",
-        "numpy",
+        "numpy~=1.23.2",  # Numpy 1.24 breaks ragged tensors. Pin to keras build
         "packaging",
         # Don't require tensorflow on MacOS; tensorflow-macos will not
         # satisfy the requirement.

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     license="Apache License 2.0",
     install_requires=[
         "absl-py",
-        "numpy~=1.23.2",  # Numpy 1.24 breaks ragged tensors. Pin to keras build
+        "numpy",
         "packaging",
         # Don't require tensorflow on MacOS; tensorflow-macos will not
         # satisfy the requirement.


### PR DESCRIPTION
Keras Nightly & TensorFlow Nightly have dropped support for Python 3.7 so it can support numpy 1.23+