### PR TITLE
Create `Backbone` base class

### DIFF
--- a/keras_nlp/models/backbone.py
+++ b/keras_nlp/models/backbone.py
@@ -41,21 +41,21 @@ class Backbone(keras.Model):
         load_weights=True,
         **kwargs,
     ):
-        """Instantiate {model_name} model from preset architecture and weights.
+        """Instantiate {{model_name}} model from preset architecture and weights.
 
         Args:
-            preset: string. Must be one of {preset_names}.
+            preset: string. Must be one of {{preset_names}}.
             load_weights: Whether to load pre-trained weights into model.
                 Defaults to `True`.
 
         Examples:
         ```python
         # Load architecture and weights from preset
-        model = {model_name}Backbone.from_preset({example_preset_name})
+        model = {{model_name}}Backbone.from_preset({{example_preset_name}})
 
         # Load randomly initialized model from preset architecture
-        model = {model_name}Backbone.from_preset(
-            {example_preset_name},
+        model = {{model_name}}Backbone.from_preset(
+            {{example_preset_name}},
             load_weights=False
         )
         ```

--- a/keras_nlp/models/backbone.py
+++ b/keras_nlp/models/backbone.py
@@ -44,18 +44,18 @@ class Backbone(keras.Model):
         """Instantiate {{model_name}} model from preset architecture and weights.
 
         Args:
-            preset: string. Must be one of {{preset_names}}.
+            preset: string. Must be one of "{{preset_names}}".
             load_weights: Whether to load pre-trained weights into model.
                 Defaults to `True`.
 
         Examples:
         ```python
         # Load architecture and weights from preset
-        model = {{model_name}}Backbone.from_preset({{example_preset_name}})
+        model = {{model_name}}.from_preset("{{example_preset_name}}")
 
         # Load randomly initialized model from preset architecture
-        model = {{model_name}}Backbone.from_preset(
-            {{example_preset_name}},
+        model = {{model_name}}.from_preset(
+            "{{example_preset_name}}",
             load_weights=False
         )
         ```

--- a/keras_nlp/models/backbone.py
+++ b/keras_nlp/models/backbone.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Base classes for models API."""
+"""Base class for Backbone models."""
 
 import os
 

--- a/keras_nlp/models/base.py
+++ b/keras_nlp/models/base.py
@@ -61,6 +61,11 @@ class Backbone(keras.Model):
         ```
         """
 
+        if not cls.presets:
+            raise NotImplementedError(
+                "No presets have been created for this class."
+            )
+
         if preset not in cls.presets:
             raise ValueError(
                 "`preset` must be one of "

--- a/keras_nlp/models/base.py
+++ b/keras_nlp/models/base.py
@@ -1,0 +1,84 @@
+# Copyright 2022 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Base classes for models API."""
+
+import os
+
+from tensorflow import keras
+
+from keras_nlp.utils.python_utils import classproperty
+
+
+@keras.utils.register_keras_serializable(package="keras_nlp")
+class Backbone(keras.Model):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def from_config(cls, config):
+        return cls(**config)
+
+    @classproperty
+    def presets(cls):
+        return {}
+
+    @classmethod
+    def from_preset(
+        cls,
+        preset,
+        load_weights=True,
+        **kwargs,
+    ):
+        """Instantiate {model_name} model from preset architecture and weights.
+
+        Args:
+            preset: string. Must be one of {preset_names}.
+            load_weights: Whether to load pre-trained weights into model.
+                Defaults to `True`.
+
+        Examples:
+        ```python
+        # Load architecture and weights from preset
+        model = {model_name}Backbone.from_preset({example_preset_name})
+
+        # Load randomly initialized model from preset architecture
+        model = {model_name}Backbone.from_preset(
+            {example_preset_name},
+            load_weights=False
+        )
+        ```
+        """
+
+        if preset not in cls.presets:
+            raise ValueError(
+                "`preset` must be one of "
+                f"""{", ".join(cls.presets)}. Received: {preset}."""
+            )
+        metadata = cls.presets[preset]
+        config = metadata["config"]
+        model = cls.from_config({**config, **kwargs})
+
+        if not load_weights:
+            return model
+
+        weights = keras.utils.get_file(
+            "model.h5",
+            metadata["weights_url"],
+            cache_subdir=os.path.join("models", preset),
+            file_hash=metadata["weights_hash"],
+        )
+
+        model.load_weights(weights)
+        return model

--- a/keras_nlp/models/bert/bert_backbone.py
+++ b/keras_nlp/models/bert/bert_backbone.py
@@ -15,13 +15,13 @@
 """BERT backbone models."""
 
 import copy
-import os
 
 import tensorflow as tf
 from tensorflow import keras
 
 from keras_nlp.layers.position_embedding import PositionEmbedding
 from keras_nlp.layers.transformer_encoder import TransformerEncoder
+from keras_nlp.models.base import Backbone
 from keras_nlp.models.bert.bert_presets import backbone_presets
 from keras_nlp.utils.python_utils import classproperty
 from keras_nlp.utils.python_utils import format_docstring
@@ -32,7 +32,7 @@ def bert_kernel_initializer(stddev=0.02):
 
 
 @keras.utils.register_keras_serializable(package="keras_nlp")
-class BertBackbone(keras.Model):
+class BertBackbone(Backbone):
     """BERT encoder network.
 
     This class implements a bi-directional Transformer-based encoder as
@@ -212,71 +212,13 @@ class BertBackbone(keras.Model):
             "trainable": self.trainable,
         }
 
-    @classmethod
-    def from_config(cls, config):
-        return cls(**config)
-
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
-
-    @classmethod
-    @format_docstring(names=", ".join(backbone_presets))
-    def from_preset(
-        cls,
-        preset,
-        load_weights=True,
-        **kwargs,
-    ):
-        """Instantiate BERT model from preset architecture and weights.
-
-        Args:
-            preset: string. Must be one of {{names}}.
-            load_weights: Whether to load pre-trained weights into model.
-                Defaults to `True`.
-
-        Examples:
-        ```python
-        input_data = {
-            "token_ids": tf.ones(shape=(1, 12), dtype=tf.int64),
-            "segment_ids": tf.constant(
-                [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
-            ),
-            "padding_mask": tf.constant(
-                [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
-            ),
-        }
-
-        # Load architecture and weights from preset
-        model = BertBackbone.from_preset("bert_base_en_uncased")
-        output = model(input_data)
-
-        # Load randomly initialized model from preset architecture
-        model = BertBackbone.from_preset(
-            "bert_base_en_uncased",
-            load_weights=False
-        )
-        output = model(input_data)
-        ```
-        """
-        if preset not in cls.presets:
-            raise ValueError(
-                "`preset` must be one of "
-                f"""{", ".join(cls.presets)}. Received: {preset}."""
-            )
-        metadata = cls.presets[preset]
-        config = metadata["config"]
-        model = cls.from_config({**config, **kwargs})
-
-        if not load_weights:
-            return model
-
-        weights = keras.utils.get_file(
-            "model.h5",
-            metadata["weights_url"],
-            cache_subdir=os.path.join("models", preset),
-            file_hash=metadata["weights_hash"],
-        )
-
-        model.load_weights(weights)
-        return model
+    
+    
+BertBackbone.from_preset.__func__.__doc__ = Backbone.from_preset.__doc__.format(
+    model_name="Bert",
+    example_preset_name="bert_base_en_uncased",
+    preset_names=BertBackbone.presets,
+)

--- a/keras_nlp/models/bert/bert_backbone.py
+++ b/keras_nlp/models/bert/bert_backbone.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""BERT backbone models."""
+"""BERT backbone model."""
 
 import copy
 
@@ -21,7 +21,7 @@ from tensorflow import keras
 
 from keras_nlp.layers.position_embedding import PositionEmbedding
 from keras_nlp.layers.transformer_encoder import TransformerEncoder
-from keras_nlp.models.base import Backbone
+from keras_nlp.models.backbone import Backbone
 from keras_nlp.models.bert.bert_presets import backbone_presets
 from keras_nlp.utils.python_utils import classproperty
 
@@ -75,7 +75,11 @@ class BertBackbone(Backbone):
         ),
     }
 
-    # Randomly initialized BERT encoder
+    # Pretrained BERT encoder
+    model = keras_nlp.models.BertBackbone.from_preset("base_base_en_uncased")
+    output = model(input_data)
+
+    # Randomly initialized BERT encoder with a custom config.
     model = keras_nlp.models.BertBackbone(
         vocabulary_size=30552,
         num_layers=12,
@@ -217,7 +221,7 @@ class BertBackbone(Backbone):
 
 
 BertBackbone.from_preset.__func__.__doc__ = Backbone.from_preset.__doc__.format(
-    model_name="Bert",
+    model_name=BertBackbone.__name__,
     example_preset_name="bert_base_en_uncased",
     preset_names=BertBackbone.presets,
 )

--- a/keras_nlp/models/bert/bert_backbone.py
+++ b/keras_nlp/models/bert/bert_backbone.py
@@ -229,5 +229,5 @@ BertBackbone.from_preset.__func__.__doc__ = Backbone.from_preset.__doc__
 format_docstring(
     model_name=BertBackbone.__name__,
     example_preset_name="bert_base_en_uncased",
-    preset_names="\", \"".join(BertBackbone.presets),
+    preset_names='", "'.join(BertBackbone.presets),
 )(BertBackbone.from_preset.__func__)

--- a/keras_nlp/models/bert/bert_backbone.py
+++ b/keras_nlp/models/bert/bert_backbone.py
@@ -24,7 +24,6 @@ from keras_nlp.layers.transformer_encoder import TransformerEncoder
 from keras_nlp.models.base import Backbone
 from keras_nlp.models.bert.bert_presets import backbone_presets
 from keras_nlp.utils.python_utils import classproperty
-from keras_nlp.utils.python_utils import format_docstring
 
 
 def bert_kernel_initializer(stddev=0.02):
@@ -215,8 +214,8 @@ class BertBackbone(Backbone):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
-    
-    
+
+
 BertBackbone.from_preset.__func__.__doc__ = Backbone.from_preset.__doc__.format(
     model_name="Bert",
     example_preset_name="bert_base_en_uncased",

--- a/keras_nlp/models/bert/bert_backbone.py
+++ b/keras_nlp/models/bert/bert_backbone.py
@@ -24,6 +24,7 @@ from keras_nlp.layers.transformer_encoder import TransformerEncoder
 from keras_nlp.models.backbone import Backbone
 from keras_nlp.models.bert.bert_presets import backbone_presets
 from keras_nlp.utils.python_utils import classproperty
+from keras_nlp.utils.python_utils import format_docstring
 
 
 def bert_kernel_initializer(stddev=0.02):
@@ -220,8 +221,8 @@ class BertBackbone(Backbone):
         return copy.deepcopy(backbone_presets)
 
 
-BertBackbone.from_preset.__func__.__doc__ = Backbone.from_preset.__doc__.format(
+format_docstring(
     model_name=BertBackbone.__name__,
     example_preset_name="bert_base_en_uncased",
-    preset_names=BertBackbone.presets,
-)
+    preset_names=", ".join(BertBackbone.presets),
+)(BertBackbone.from_preset.__func__)

--- a/keras_nlp/models/bert/bert_backbone.py
+++ b/keras_nlp/models/bert/bert_backbone.py
@@ -80,7 +80,7 @@ class BertBackbone(Backbone):
     model = keras_nlp.models.BertBackbone.from_preset("base_base_en_uncased")
     output = model(input_data)
 
-    # Randomly initialized BERT encoder with a custom config.
+    # Randomly initialized BERT encoder with a custom config
     model = keras_nlp.models.BertBackbone(
         vocabulary_size=30552,
         num_layers=12,
@@ -220,9 +220,14 @@ class BertBackbone(Backbone):
     def presets(cls):
         return copy.deepcopy(backbone_presets)
 
+    @classmethod
+    def from_preset(cls, preset, load_weights=True, **kwargs):
+        return super().from_preset(preset, load_weights, **kwargs)
 
+
+BertBackbone.from_preset.__func__.__doc__ = Backbone.from_preset.__doc__
 format_docstring(
     model_name=BertBackbone.__name__,
     example_preset_name="bert_base_en_uncased",
-    preset_names=", ".join(BertBackbone.presets),
+    preset_names="\", \"".join(BertBackbone.presets),
 )(BertBackbone.from_preset.__func__)

--- a/keras_nlp/models/deberta_v3/deberta_v3_backbone.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_backbone.py
@@ -45,7 +45,7 @@ class DebertaV3Backbone(Backbone):
 
     The default constructor gives a fully customizable, randomly initialized
     DeBERTa encoder with any number of layers, heads, and embedding
-    dimensions. To load preset architectures and weights, use the `from_presets`
+    dimensions. To load preset architectures and weights, use the `from_preset`
     constructor.
 
     Disclaimer: Pre-trained models are provided on an "as is" basis, without

--- a/keras_nlp/models/deberta_v3/deberta_v3_backbone.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_backbone.py
@@ -212,5 +212,5 @@ DebertaV3Backbone.from_preset.__func__.__doc__ = Backbone.from_preset.__doc__
 format_docstring(
     model_name=DebertaV3Backbone.__name__,
     example_preset_name="deberta_base_en",
-    preset_names="\", \"".join(DebertaV3Backbone.presets),
+    preset_names='", "'.join(DebertaV3Backbone.presets),
 )(DebertaV3Backbone.from_preset.__func__)

--- a/keras_nlp/models/deberta_v3/deberta_v3_backbone.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_backbone.py
@@ -15,11 +15,11 @@
 """DeBERTa backbone model."""
 
 import copy
-import os
 
 import tensorflow as tf
 from tensorflow import keras
 
+from keras_nlp.models.backbone import Backbone
 from keras_nlp.models.deberta_v3.deberta_v3_presets import backbone_presets
 from keras_nlp.models.deberta_v3.disentangled_attention_encoder import (
     DisentangledAttentionEncoder,
@@ -34,7 +34,7 @@ def deberta_kernel_initializer(stddev=0.02):
 
 
 @keras.utils.register_keras_serializable(package="keras_nlp")
-class DebertaV3Backbone(keras.Model):
+class DebertaV3Backbone(Backbone):
     """DeBERTa encoder network.
 
     This network implements a bi-directional Transformer-based encoder as
@@ -76,7 +76,13 @@ class DebertaV3Backbone(keras.Model):
             [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)),
     }
 
-    # Randomly initialized DeBERTa model
+    # Pretrained DeBERTa encoder
+    model = keras_nlp.models.DebertaV3Backbone.from_preset(
+        "deberta_base_en",
+    )
+    output = model(input_data)
+
+    # Randomly initialized DeBERTa encoder with custom config
     model = keras_nlp.models.DebertaV3Backbone(
         vocabulary_size=128100,
         num_layers=12,
@@ -86,7 +92,6 @@ class DebertaV3Backbone(keras.Model):
         max_sequence_length=512,
         bucket_size=256,
     )
-
     # Call the model on the input data.
     output = model(input_data)
     ```
@@ -194,69 +199,18 @@ class DebertaV3Backbone(keras.Model):
             "trainable": self.trainable,
         }
 
-    @classmethod
-    def from_config(cls, config):
-        return cls(**config)
-
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
 
     @classmethod
-    @format_docstring(names=", ".join(backbone_presets))
-    def from_preset(
-        cls,
-        preset,
-        load_weights=True,
-        **kwargs,
-    ):
-        """Instantiate DeBERTa model from preset architecture and weights.
+    def from_preset(cls, preset, load_weights=True, **kwargs):
+        return super().from_preset(preset, load_weights, **kwargs)
 
-        Args:
-            preset: string. Must be one of {{names}}.
-            load_weights: Whether to load pre-trained weights into model.
-                Defaults to `True`.
 
-        Examples:
-        ```python
-        input_data = {
-            "token_ids": tf.ones(shape=(1, 12), dtype=tf.int64),
-            "padding_mask": tf.constant(
-                [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
-            ),
-        }
-
-        # Load architecture and weights from preset
-        model = keras_nlp.models.DebertaV3Backbone.from_preset(
-            "deberta_base_en",
-        )
-        output = model(input_data)
-
-        # Load randomly initialized model from preset architecture
-        model = keras_nlp.models.DebertaV3Backbone.from_preset(
-            "deberta_base_en", load_weights=False
-        )
-        output = model(input_data)
-        ```
-        """
-        if preset not in cls.presets:
-            raise ValueError(
-                "`preset` must be one of "
-                f"""{", ".join(cls.presets)}. Received: {preset}."""
-            )
-        metadata = cls.presets[preset]
-        config = metadata["config"]
-        model = cls.from_config({**config, **kwargs})
-
-        if not load_weights:
-            return model
-
-        weights = keras.utils.get_file(
-            "model.h5",
-            metadata["weights_url"],
-            cache_subdir=os.path.join("models", preset),
-            file_hash=metadata["weights_hash"],
-        )
-
-        model.load_weights(weights)
-        return model
+DebertaV3Backbone.from_preset.__func__.__doc__ = Backbone.from_preset.__doc__
+format_docstring(
+    model_name=DebertaV3Backbone.__name__,
+    example_preset_name="deberta_base_en",
+    preset_names="\", \"".join(DebertaV3Backbone.presets),
+)(DebertaV3Backbone.from_preset.__func__)

--- a/keras_nlp/models/distil_bert/distil_bert_backbone.py
+++ b/keras_nlp/models/distil_bert/distil_bert_backbone.py
@@ -15,7 +15,6 @@
 """DistilBERT backbone models."""
 
 import copy
-import os
 
 import tensorflow as tf
 from tensorflow import keras
@@ -24,6 +23,7 @@ from keras_nlp.layers.token_and_position_embedding import (
     TokenAndPositionEmbedding,
 )
 from keras_nlp.layers.transformer_encoder import TransformerEncoder
+from keras_nlp.models.backbone import Backbone
 from keras_nlp.models.distil_bert.distil_bert_presets import backbone_presets
 from keras_nlp.utils.python_utils import classproperty
 from keras_nlp.utils.python_utils import format_docstring
@@ -34,7 +34,7 @@ def distilbert_kernel_initializer(stddev=0.02):
 
 
 @keras.utils.register_keras_serializable(package="keras_nlp")
-class DistilBertBackbone(keras.Model):
+class DistilBertBackbone(Backbone):
     """DistilBERT encoder network.
 
     This network implements a bi-directional Transformer-based encoder as
@@ -76,7 +76,13 @@ class DistilBertBackbone(keras.Model):
         ),
     }
 
-    # Randomly initialized DistilBERT encoder
+    # Pretrained DistilBERT encoder
+    model = keras_nlp.models.DistilBertBackbone.from_preset(
+        "distil_bert_base_en_uncased"
+    )
+    output = model(input_data)
+    
+    # Randomly initialized DistilBERT encoder with custom config
     model = keras_nlp.models.DistilBertBackbone(
         vocabulary_size=30552,
         num_layers=6,
@@ -173,69 +179,18 @@ class DistilBertBackbone(keras.Model):
             "trainable": self.trainable,
         }
 
-    @classmethod
-    def from_config(cls, config):
-        return cls(**config)
-
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
 
     @classmethod
-    @format_docstring(names=", ".join(backbone_presets))
-    def from_preset(
-        cls,
-        preset,
-        load_weights=True,
-        **kwargs,
-    ):
-        """Instantiate a DistilBERT model from preset architecture and weights.
+    def from_preset(cls, preset, load_weights=True, **kwargs):
+        return super().from_preset(preset, load_weights, **kwargs)
 
-        Args:
-            preset: string. Must be one of {{names}}.
-            load_weights: Whether to load pre-trained weights into model.
-                Defaults to `True`.
 
-        Examples:
-        ```python
-        input_data = {
-            "token_ids": tf.ones(shape=(1, 12), dtype=tf.int64),
-            "padding_mask": tf.constant(
-                [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
-            ),
-        }
-
-        # Load architecture and weights from preset
-        model = keras_nlp.models.DistilBertBackbone.from_preset(
-            "distil_bert_base_en_uncased"
-        )
-        output = model(input_data)
-
-        # Load randomly initialized model from preset architecture
-        model = keras_nlp.models.DistilBertBackbone.from_preset(
-            "distil_bert_base_en_uncased", load_weights=False
-        )
-        output = model(input_data)
-        ```
-        """
-        if preset not in cls.presets:
-            raise ValueError(
-                "`preset` must be one of "
-                f"""{", ".join(cls.presets)}. Received: {preset}."""
-            )
-        metadata = cls.presets[preset]
-        config = metadata["config"]
-        model = cls.from_config({**config, **kwargs})
-
-        if not load_weights:
-            return model
-
-        weights = keras.utils.get_file(
-            "model.h5",
-            metadata["weights_url"],
-            cache_subdir=os.path.join("models", preset),
-            file_hash=metadata["weights_hash"],
-        )
-
-        model.load_weights(weights)
-        return model
+DistilBertBackbone.from_preset.__func__.__doc__ = Backbone.from_preset.__doc__
+format_docstring(
+    model_name=DistilBertBackbone.__name__,
+    example_preset_name="distil_bert_base_en_uncased",
+    preset_names="\", \"".join(DistilBertBackbone.presets),
+)(DistilBertBackbone.from_preset.__func__)

--- a/keras_nlp/models/distil_bert/distil_bert_backbone.py
+++ b/keras_nlp/models/distil_bert/distil_bert_backbone.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""DistilBERT backbone models."""
+"""DistilBERT backbone model."""
 
 import copy
 

--- a/keras_nlp/models/distil_bert/distil_bert_backbone.py
+++ b/keras_nlp/models/distil_bert/distil_bert_backbone.py
@@ -81,7 +81,7 @@ class DistilBertBackbone(Backbone):
         "distil_bert_base_en_uncased"
     )
     output = model(input_data)
-    
+
     # Randomly initialized DistilBERT encoder with custom config
     model = keras_nlp.models.DistilBertBackbone(
         vocabulary_size=30552,
@@ -192,5 +192,5 @@ DistilBertBackbone.from_preset.__func__.__doc__ = Backbone.from_preset.__doc__
 format_docstring(
     model_name=DistilBertBackbone.__name__,
     example_preset_name="distil_bert_base_en_uncased",
-    preset_names="\", \"".join(DistilBertBackbone.presets),
+    preset_names='", "'.join(DistilBertBackbone.presets),
 )(DistilBertBackbone.from_preset.__func__)

--- a/keras_nlp/models/distil_bert/distil_bert_backbone.py
+++ b/keras_nlp/models/distil_bert/distil_bert_backbone.py
@@ -45,7 +45,7 @@ class DistilBertBackbone(Backbone):
 
     The default constructor gives a fully customizable, randomly initialized
     DistilBERT encoder with any number of layers, heads, and embedding
-    dimensions. To load preset architectures and weights, use the `from_presets`
+    dimensions. To load preset architectures and weights, use the `from_preset`
     constructor.
 
     Disclaimer: Pre-trained models are provided on an "as is" basis, without

--- a/keras_nlp/models/gpt2/gpt2_backbone.py
+++ b/keras_nlp/models/gpt2/gpt2_backbone.py
@@ -15,13 +15,13 @@
 """GPT-2 backbone models."""
 
 import copy
-import os
 
 import tensorflow as tf
 from tensorflow import keras
 
 from keras_nlp.layers import PositionEmbedding
 from keras_nlp.layers import TransformerDecoder
+from keras_nlp.models.backbone import Backbone
 from keras_nlp.models.gpt2.gpt2_presets import backbone_presets
 from keras_nlp.utils.python_utils import classproperty
 from keras_nlp.utils.python_utils import format_docstring
@@ -32,7 +32,7 @@ def _gpt_2_kernel_initializer(stddev=0.02):
 
 
 @keras.utils.register_keras_serializable(package="keras_nlp")
-class GPT2Backbone(keras.Model):
+class GPT2Backbone(Backbone):
     """GPT-2 core network with hyperparameters.
 
     This network implements a Transformer-based decoder network,
@@ -42,7 +42,7 @@ class GPT2Backbone(keras.Model):
 
     The default constructor gives a fully customizable, randomly initialized
     GPT-2 model with any number of layers, heads, and embedding
-    dimensions. To load preset architectures and weights, use the `from_presets`
+    dimensions. To load preset architectures and weights, use the `from_preset`
     constructor.
 
     Disclaimer: Pre-trained models are provided on an "as is" basis, without
@@ -73,7 +73,11 @@ class GPT2Backbone(keras.Model):
         ),
     }
 
-    # Randomly initialized GPT-2 decoder
+    # Pretrained GPT-2 decoder
+    model = GPT2Backbone.from_preset("gpt2_base_en")
+    output = model(input_data)
+
+    # Randomly initialized GPT-2 decoder with custom config
     model = keras_nlp.models.GPT2Backbone(
         vocabulary_size=50257,
         num_layers=12,
@@ -182,66 +186,18 @@ class GPT2Backbone(keras.Model):
             "trainable": self.trainable,
         }
 
-    @classmethod
-    def from_config(cls, config):
-        return cls(**config)
-
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
 
     @classmethod
-    @format_docstring(names=", ".join(backbone_presets))
-    def from_preset(
-        cls,
-        preset,
-        load_weights=True,
-        **kwargs,
-    ):
-        """Instantiate GPT-2 model from preset architecture and weights.
+    def from_preset(cls, preset, load_weights=True, **kwargs):
+        return super().from_preset(preset, load_weights, **kwargs)
 
-        Args:
-            preset: string. Must be one of {{names}}.
-            load_weights: Whether to load pre-trained weights into model.
-                Defaults to `True`.
 
-        Examples:
-        ```python
-        input_data = {
-            "token_ids": tf.ones(shape=(1, 12), dtype=tf.int64),
-            "padding_mask": tf.constant(
-                [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
-            ),
-        }
-
-        # Load architecture and weights from preset
-        model = GPT2Backbone.from_preset("gpt2_base_en")
-        output = model(input_data)
-
-        # Load randomly initialized model from preset architecture
-        model = GPT2Backbone.from_preset("gpt2_base", load_weights=False)
-        output = model(input_data)
-        ```
-        """
-
-        if preset not in cls.presets:
-            raise ValueError(
-                "`preset` must be one of "
-                f"""{", ".join(cls.presets)}. Received: {preset}."""
-            )
-        metadata = cls.presets[preset]
-        config = metadata["config"]
-        model = cls.from_config({**config, **kwargs})
-
-        if not load_weights:
-            return model
-
-        weights = keras.utils.get_file(
-            "model.h5",
-            metadata["weights_url"],
-            cache_subdir=os.path.join("models", preset),
-            file_hash=metadata["weights_hash"],
-        )
-
-        model.load_weights(weights)
-        return model
+GPT2Backbone.from_preset.__func__.__doc__ = Backbone.from_preset.__doc__
+format_docstring(
+    model_name=GPT2Backbone.__name__,
+    example_preset_name="gpt2_base_en",
+    preset_names="\", \"".join(GPT2Backbone.presets),
+)(GPT2Backbone.from_preset.__func__)

--- a/keras_nlp/models/gpt2/gpt2_backbone.py
+++ b/keras_nlp/models/gpt2/gpt2_backbone.py
@@ -199,5 +199,5 @@ GPT2Backbone.from_preset.__func__.__doc__ = Backbone.from_preset.__doc__
 format_docstring(
     model_name=GPT2Backbone.__name__,
     example_preset_name="gpt2_base_en",
-    preset_names="\", \"".join(GPT2Backbone.presets),
+    preset_names='", "'.join(GPT2Backbone.presets),
 )(GPT2Backbone.from_preset.__func__)

--- a/keras_nlp/models/gpt2/gpt2_backbone.py
+++ b/keras_nlp/models/gpt2/gpt2_backbone.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""GPT-2 backbone models."""
+"""GPT-2 backbone model."""
 
 import copy
 

--- a/keras_nlp/models/roberta/roberta_backbone.py
+++ b/keras_nlp/models/roberta/roberta_backbone.py
@@ -177,9 +177,14 @@ class RobertaBackbone(Backbone):
     def presets(cls):
         return copy.deepcopy(backbone_presets)
 
+    @classmethod
+    def from_preset(cls, preset, load_weights=True, **kwargs):
+        return super().from_preset(preset, load_weights, **kwargs)
 
+
+RobertaBackbone.from_preset.__func__.__doc__ = Backbone.from_preset.__doc__
 format_docstring(
     model_name=RobertaBackbone.__name__,
     example_preset_name="roberta_base_en",
-    preset_names=", ".join(RobertaBackbone.presets),
+    preset_names="\", \"".join(RobertaBackbone.presets),
 )(RobertaBackbone.from_preset.__func__)

--- a/keras_nlp/models/roberta/roberta_backbone.py
+++ b/keras_nlp/models/roberta/roberta_backbone.py
@@ -42,7 +42,7 @@ class RobertaBackbone(Backbone):
 
     The default constructor gives a fully customizable, randomly initialized
     RoBERTa encoder with any number of layers, heads, and embedding
-    dimensions. To load preset architectures and weights, use the `from_presets`
+    dimensions. To load preset architectures and weights, use the `from_preset`
     constructor.
 
     Disclaimer: Pre-trained models are provided on an "as is" basis, without

--- a/keras_nlp/models/roberta/roberta_backbone.py
+++ b/keras_nlp/models/roberta/roberta_backbone.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""RoBERTa backbone models."""
+"""RoBERTa backbone model."""
 
 import copy
 

--- a/keras_nlp/models/roberta/roberta_backbone.py
+++ b/keras_nlp/models/roberta/roberta_backbone.py
@@ -186,5 +186,5 @@ RobertaBackbone.from_preset.__func__.__doc__ = Backbone.from_preset.__doc__
 format_docstring(
     model_name=RobertaBackbone.__name__,
     example_preset_name="roberta_base_en",
-    preset_names="\", \"".join(RobertaBackbone.presets),
+    preset_names='", "'.join(RobertaBackbone.presets),
 )(RobertaBackbone.from_preset.__func__)

--- a/keras_nlp/models/roberta/roberta_backbone.py
+++ b/keras_nlp/models/roberta/roberta_backbone.py
@@ -15,7 +15,6 @@
 """RoBERTa backbone models."""
 
 import copy
-import os
 
 import tensorflow as tf
 from tensorflow import keras
@@ -71,7 +70,7 @@ class RobertaBackbone(Backbone):
         "padding_mask": tf.constant(
             [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)),
     }
-        
+
     # Pretrained RoBERTa encoder
     model = keras_nlp.models.RobertaBackbone.from_preset("roberta_base_en")
     output = model(input_data)

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_backbone.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_backbone.py
@@ -37,7 +37,7 @@ class XLMRobertaBackbone(roberta_backbone.RobertaBackbone):
 
     The default constructor gives a fully customizable, randomly initialized
     RoBERTa encoder with any number of layers, heads, and embedding
-    dimensions. To load preset architectures and weights, use the `from_presets`
+    dimensions. To load preset architectures and weights, use the `from_preset`
     constructor.
 
     Disclaimer: Pre-trained models are provided on an "as is" basis, without

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_backbone.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_backbone.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""XLM-RoBERTa backbone models."""
+"""XLM-RoBERTa backbone model."""
 
 import copy
 

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_backbone.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_backbone.py
@@ -15,10 +15,10 @@
 """XLM-RoBERTa backbone models."""
 
 import copy
-import os
 
 from tensorflow import keras
 
+from keras_nlp.models.backbone import Backbone
 from keras_nlp.models.roberta import roberta_backbone
 from keras_nlp.models.xlm_roberta.xlm_roberta_presets import backbone_presets
 from keras_nlp.utils.python_utils import classproperty
@@ -66,7 +66,13 @@ class XLMRobertaBackbone(roberta_backbone.RobertaBackbone):
             [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)),
     }
 
-    # Randomly initialized XLM-R model
+    # Pretrained XLM-R encoder
+    model = keras_nlp.models.XLMRobertaBackbone.from_preset(
+        "xlm_roberta_base_multi",
+    )
+    output = model(input_data)
+
+    # Randomly initialized XLM-R model with custom config
     model = keras_nlp.models.XLMRobertaBackbone(
         vocabulary_size=250002,
         num_layers=12,
@@ -86,60 +92,13 @@ class XLMRobertaBackbone(roberta_backbone.RobertaBackbone):
         return copy.deepcopy(backbone_presets)
 
     @classmethod
-    @format_docstring(names=", ".join(backbone_presets))
-    def from_preset(
-        cls,
-        preset,
-        load_weights=True,
-        **kwargs,
-    ):
-        """Instantiate XLM-RoBERTa model from preset architecture and weights.
+    def from_preset(cls, preset, load_weights=True, **kwargs):
+        return super().from_preset(preset, load_weights, **kwargs)
 
-        Args:
-            preset: string. Must be one of {{names}}.
-            load_weights: Whether to load pre-trained weights into model.
-                Defaults to `True`.
 
-        Examples:
-        ```python
-        input_data = {
-            "token_ids": tf.ones(shape=(1, 12), dtype=tf.int64),
-            "padding_mask": tf.constant(
-                [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0], shape=(1, 12)
-            ),
-        }
-
-        # Load architecture and weights from preset
-        model = keras_nlp.models.XLMRobertaBackbone.from_preset(
-            "xlm_roberta_base_multi",
-        )
-        output = model(input_data)
-
-        # Load randomly initialized model from preset architecture
-        model = keras_nlp.models.XLMRobertaBackbone.from_preset(
-            "xlm_roberta_base_multi", load_weights=False
-        )
-        output = model(input_data)
-        ```
-        """
-        if preset not in cls.presets:
-            raise ValueError(
-                "`preset` must be one of "
-                f"""{", ".join(cls.presets)}. Received: {preset}."""
-            )
-        metadata = cls.presets[preset]
-        config = metadata["config"]
-        model = cls.from_config({**config, **kwargs})
-
-        if not load_weights:
-            return model
-
-        weights = keras.utils.get_file(
-            "model.h5",
-            metadata["weights_url"],
-            cache_subdir=os.path.join("models", preset),
-            file_hash=metadata["weights_hash"],
-        )
-
-        model.load_weights(weights)
-        return model
+XLMRobertaBackbone.from_preset.__func__.__doc__ = Backbone.from_preset.__doc__
+format_docstring(
+    model_name=XLMRobertaBackbone.__name__,
+    example_preset_name="xlm_roberta_base_multi",
+    preset_names=", ".join(XLMRobertaBackbone.presets),
+)(XLMRobertaBackbone.from_preset.__func__)


### PR DESCRIPTION
Pilot for how base classes could improve the maintainability of our library. The `Backbone` class can be easily extended to other model types and `Task`, `Preprocessor`, and `Tokenizer` base classes can also be added.

I've also simplified the `from_preset` docstring so we don't have to write a lot of custom copy for each model class. We already have all the information we need in the class docstring.

Part of #530