### PR TITLE
Clean up class name and `self` in calls to `super()`

### DIFF
--- a/keras_nlp/layers/transformer_decoder_test.py
+++ b/keras_nlp/layers/transformer_decoder_test.py
@@ -132,7 +132,7 @@ class TransformerDecoderTest(tf.test.TestCase, parameterized.TestCase):
     def test_one_training_step_of_transformer_with_cross_attention(self):
         class MyModel(keras.Model):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
                 self._decoder = transformer_decoder.TransformerDecoder(
                     intermediate_dim=4, num_heads=2
                 )
@@ -160,7 +160,7 @@ class TransformerDecoderTest(tf.test.TestCase, parameterized.TestCase):
     def test_one_training_step_of_transformer_without_cross_attention(self):
         class MyModel(keras.Model):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
                 self._decoder = transformer_decoder.TransformerDecoder(
                     intermediate_dim=4,
                     num_heads=2,


### PR DESCRIPTION
PEP 3135 [^1] simplified the syntax for `super()` in Python 3.0 from:

    super(ClassName, self)

to the following very simple and equivalent [^2] syntax:

    super()

The current Keras codebase already requires Python 3+, and there's a mix of the two syntax formats above, sometimes both are used in a single file.

This change simplifies the entire code base by cleaning up the remaining explicit uses of the current class name and `self` and using the cleaner `super()` syntax everywhere consistently.

Since the new syntax is intended to be a shorthand for the old syntax, this change should have no semantic differences from before.

[^1]: https://peps.python.org/pep-3135/
[^2]: https://docs.python.org/3/library/functions.html#super