### PR TITLE
Consolidate docstring formatting weirdness in Backbone and Preprocessor base classes

### DIFF
--- a/keras_nlp/models/backbone.py
+++ b/keras_nlp/models/backbone.py
@@ -19,12 +19,26 @@ import os
 from tensorflow import keras
 
 from keras_nlp.utils.python_utils import classproperty
+from keras_nlp.utils.python_utils import format_docstring
 
 
 @keras.utils.register_keras_serializable(package="keras_nlp")
 class Backbone(keras.Model):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+    def __init_subclass__(cls, **kwargs):
+        # We use the __init_subclass__ hook to properly format the from_preset
+        # docstring on subclasses.
+        if cls.from_preset.__func__.__doc__ is None:
+            cls.from_preset.__func__.__doc__ = Backbone.from_preset.__doc__
+            preset_names = list(cls.presets.keys())
+            format_docstring(
+                model_name=cls.__name__,
+                example_preset_name=preset_names[0],
+                preset_names='", "'.join(preset_names),
+            )(cls.from_preset.__func__)
+        super().__init_subclass__(**kwargs)
 
     @classmethod
     def from_config(cls, config):

--- a/keras_nlp/models/bert/bert_backbone.py
+++ b/keras_nlp/models/bert/bert_backbone.py
@@ -24,7 +24,6 @@ from keras_nlp.layers.transformer_encoder import TransformerEncoder
 from keras_nlp.models.backbone import Backbone
 from keras_nlp.models.bert.bert_presets import backbone_presets
 from keras_nlp.utils.python_utils import classproperty
-from keras_nlp.utils.python_utils import format_docstring
 
 
 def bert_kernel_initializer(stddev=0.02):
@@ -223,11 +222,3 @@ class BertBackbone(Backbone):
     @classmethod
     def from_preset(cls, preset, load_weights=True, **kwargs):
         return super().from_preset(preset, load_weights, **kwargs)
-
-
-BertBackbone.from_preset.__func__.__doc__ = Backbone.from_preset.__doc__
-format_docstring(
-    model_name=BertBackbone.__name__,
-    example_preset_name="bert_base_en_uncased",
-    preset_names='", "'.join(BertBackbone.presets),
-)(BertBackbone.from_preset.__func__)

--- a/keras_nlp/models/bert/bert_backbone.py
+++ b/keras_nlp/models/bert/bert_backbone.py
@@ -218,7 +218,3 @@ class BertBackbone(Backbone):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
-
-    @classmethod
-    def from_preset(cls, preset, load_weights=True, **kwargs):
-        return super().from_preset(preset, load_weights, **kwargs)

--- a/keras_nlp/models/bert/bert_preprocessor.py
+++ b/keras_nlp/models/bert/bert_preprocessor.py
@@ -195,7 +195,3 @@ class BertPreprocessor(Preprocessor):
     @classproperty
     def presets(cls):
         return copy.deepcopy({**backbone_presets, **classifier_presets})
-
-    @classmethod
-    def from_preset(cls, preset, **kwargs):
-        return super().from_preset(preset, **kwargs)

--- a/keras_nlp/models/bert/bert_preprocessor.py
+++ b/keras_nlp/models/bert/bert_preprocessor.py
@@ -27,7 +27,6 @@ from keras_nlp.utils.keras_utils import (
 )
 from keras_nlp.utils.keras_utils import pack_x_y_sample_weight
 from keras_nlp.utils.python_utils import classproperty
-from keras_nlp.utils.python_utils import format_docstring
 
 PRESET_NAMES = ", ".join(list(backbone_presets) + list(classifier_presets))
 
@@ -200,11 +199,3 @@ class BertPreprocessor(Preprocessor):
     @classmethod
     def from_preset(cls, preset, **kwargs):
         return super().from_preset(preset, **kwargs)
-
-
-BertPreprocessor.from_preset.__func__.__doc__ = Preprocessor.from_preset.__doc__
-format_docstring(
-    preprocessor_name=BertPreprocessor.__name__,
-    example_preset_name="bert_base_en_uncased",
-    preset_names='", "'.join(BertPreprocessor.presets),
-)(BertPreprocessor.from_preset.__func__)

--- a/keras_nlp/models/deberta_v3/deberta_v3_backbone.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_backbone.py
@@ -201,7 +201,3 @@ class DebertaV3Backbone(Backbone):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
-
-    @classmethod
-    def from_preset(cls, preset, load_weights=True, **kwargs):
-        return super().from_preset(preset, load_weights, **kwargs)

--- a/keras_nlp/models/deberta_v3/deberta_v3_backbone.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_backbone.py
@@ -26,7 +26,6 @@ from keras_nlp.models.deberta_v3.disentangled_attention_encoder import (
 )
 from keras_nlp.models.deberta_v3.relative_embedding import RelativeEmbedding
 from keras_nlp.utils.python_utils import classproperty
-from keras_nlp.utils.python_utils import format_docstring
 
 
 def deberta_kernel_initializer(stddev=0.02):
@@ -206,11 +205,3 @@ class DebertaV3Backbone(Backbone):
     @classmethod
     def from_preset(cls, preset, load_weights=True, **kwargs):
         return super().from_preset(preset, load_weights, **kwargs)
-
-
-DebertaV3Backbone.from_preset.__func__.__doc__ = Backbone.from_preset.__doc__
-format_docstring(
-    model_name=DebertaV3Backbone.__name__,
-    example_preset_name="deberta_base_en",
-    preset_names='", "'.join(DebertaV3Backbone.presets),
-)(DebertaV3Backbone.from_preset.__func__)

--- a/keras_nlp/models/deberta_v3/deberta_v3_preprocessor.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_preprocessor.py
@@ -26,7 +26,6 @@ from keras_nlp.utils.keras_utils import (
 )
 from keras_nlp.utils.keras_utils import pack_x_y_sample_weight
 from keras_nlp.utils.python_utils import classproperty
-from keras_nlp.utils.python_utils import format_docstring
 
 
 @keras.utils.register_keras_serializable(package="keras_nlp")
@@ -194,13 +193,3 @@ class DebertaV3Preprocessor(Preprocessor):
     @classmethod
     def from_preset(cls, preset, **kwargs):
         return super().from_preset(preset, **kwargs)
-
-
-DebertaV3Preprocessor.from_preset.__func__.__doc__ = (
-    Preprocessor.from_preset.__doc__
-)
-format_docstring(
-    preprocessor_name=DebertaV3Preprocessor.__name__,
-    example_preset_name="deberta_v3_base_en",
-    preset_names='", "'.join(DebertaV3Preprocessor.presets),
-)(DebertaV3Preprocessor.from_preset.__func__)

--- a/keras_nlp/models/deberta_v3/deberta_v3_preprocessor.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_preprocessor.py
@@ -189,7 +189,3 @@ class DebertaV3Preprocessor(Preprocessor):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
-
-    @classmethod
-    def from_preset(cls, preset, **kwargs):
-        return super().from_preset(preset, **kwargs)

--- a/keras_nlp/models/distil_bert/distil_bert_backbone.py
+++ b/keras_nlp/models/distil_bert/distil_bert_backbone.py
@@ -26,7 +26,6 @@ from keras_nlp.layers.transformer_encoder import TransformerEncoder
 from keras_nlp.models.backbone import Backbone
 from keras_nlp.models.distil_bert.distil_bert_presets import backbone_presets
 from keras_nlp.utils.python_utils import classproperty
-from keras_nlp.utils.python_utils import format_docstring
 
 
 def distilbert_kernel_initializer(stddev=0.02):
@@ -182,15 +181,3 @@ class DistilBertBackbone(Backbone):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
-
-    @classmethod
-    def from_preset(cls, preset, load_weights=True, **kwargs):
-        return super().from_preset(preset, load_weights, **kwargs)
-
-
-DistilBertBackbone.from_preset.__func__.__doc__ = Backbone.from_preset.__doc__
-format_docstring(
-    model_name=DistilBertBackbone.__name__,
-    example_preset_name="distil_bert_base_en_uncased",
-    preset_names='", "'.join(DistilBertBackbone.presets),
-)(DistilBertBackbone.from_preset.__func__)

--- a/keras_nlp/models/distil_bert/distil_bert_preprocessor.py
+++ b/keras_nlp/models/distil_bert/distil_bert_preprocessor.py
@@ -28,7 +28,6 @@ from keras_nlp.utils.keras_utils import (
 )
 from keras_nlp.utils.keras_utils import pack_x_y_sample_weight
 from keras_nlp.utils.python_utils import classproperty
-from keras_nlp.utils.python_utils import format_docstring
 
 
 @keras.utils.register_keras_serializable(package="keras_nlp")
@@ -194,17 +193,3 @@ class DistilBertPreprocessor(Preprocessor):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
-
-    @classmethod
-    def from_preset(cls, preset, **kwargs):
-        return super().from_preset(preset, **kwargs)
-
-
-DistilBertPreprocessor.from_preset.__func__.__doc__ = (
-    Preprocessor.from_preset.__doc__
-)
-format_docstring(
-    preprocessor_name=DistilBertPreprocessor.__name__,
-    example_preset_name="distil_bert_base_en_uncased",
-    preset_names='", "'.join(DistilBertPreprocessor.presets),
-)(DistilBertPreprocessor.from_preset.__func__)

--- a/keras_nlp/models/gpt2/gpt2_backbone.py
+++ b/keras_nlp/models/gpt2/gpt2_backbone.py
@@ -188,7 +188,3 @@ class GPT2Backbone(Backbone):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
-
-    @classmethod
-    def from_preset(cls, preset, load_weights=True, **kwargs):
-        return super().from_preset(preset, load_weights, **kwargs)

--- a/keras_nlp/models/gpt2/gpt2_backbone.py
+++ b/keras_nlp/models/gpt2/gpt2_backbone.py
@@ -24,7 +24,6 @@ from keras_nlp.layers import TransformerDecoder
 from keras_nlp.models.backbone import Backbone
 from keras_nlp.models.gpt2.gpt2_presets import backbone_presets
 from keras_nlp.utils.python_utils import classproperty
-from keras_nlp.utils.python_utils import format_docstring
 
 
 def _gpt_2_kernel_initializer(stddev=0.02):
@@ -193,11 +192,3 @@ class GPT2Backbone(Backbone):
     @classmethod
     def from_preset(cls, preset, load_weights=True, **kwargs):
         return super().from_preset(preset, load_weights, **kwargs)
-
-
-GPT2Backbone.from_preset.__func__.__doc__ = Backbone.from_preset.__doc__
-format_docstring(
-    model_name=GPT2Backbone.__name__,
-    example_preset_name="gpt2_base_en",
-    preset_names='", "'.join(GPT2Backbone.presets),
-)(GPT2Backbone.from_preset.__func__)

--- a/keras_nlp/models/preprocessor.py
+++ b/keras_nlp/models/preprocessor.py
@@ -15,11 +15,25 @@
 from tensorflow import keras
 
 from keras_nlp.utils.python_utils import classproperty
+from keras_nlp.utils.python_utils import format_docstring
 
 
 @keras.utils.register_keras_serializable(package="keras_nlp")
 class Preprocessor(keras.layers.Layer):
     """Base class for model preprocessors."""
+
+    def __init_subclass__(cls, **kwargs):
+        # We use the __init_subclass__ hook to properly format the from_preset
+        # docstring on subclasses.
+        if cls.from_preset.__func__.__doc__ is None:
+            cls.from_preset.__func__.__doc__ = Preprocessor.from_preset.__doc__
+            preset_names = list(cls.presets.keys())
+            format_docstring(
+                preprocessor_name=cls.__name__,
+                example_preset_name=preset_names[0],
+                preset_names='", "'.join(preset_names),
+            )(cls.from_preset.__func__)
+        super().__init_subclass__(**kwargs)
 
     @property
     def tokenizer(self):

--- a/keras_nlp/models/roberta/roberta_backbone.py
+++ b/keras_nlp/models/roberta/roberta_backbone.py
@@ -175,7 +175,3 @@ class RobertaBackbone(Backbone):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
-
-    @classmethod
-    def from_preset(cls, preset, load_weights=True, **kwargs):
-        return super().from_preset(preset, load_weights, **kwargs)

--- a/keras_nlp/models/roberta/roberta_backbone.py
+++ b/keras_nlp/models/roberta/roberta_backbone.py
@@ -24,7 +24,6 @@ from keras_nlp.layers import TransformerEncoder
 from keras_nlp.models.backbone import Backbone
 from keras_nlp.models.roberta.roberta_presets import backbone_presets
 from keras_nlp.utils.python_utils import classproperty
-from keras_nlp.utils.python_utils import format_docstring
 
 
 def roberta_kernel_initializer(stddev=0.02):
@@ -180,11 +179,3 @@ class RobertaBackbone(Backbone):
     @classmethod
     def from_preset(cls, preset, load_weights=True, **kwargs):
         return super().from_preset(preset, load_weights, **kwargs)
-
-
-RobertaBackbone.from_preset.__func__.__doc__ = Backbone.from_preset.__doc__
-format_docstring(
-    model_name=RobertaBackbone.__name__,
-    example_preset_name="roberta_base_en",
-    preset_names='", "'.join(RobertaBackbone.presets),
-)(RobertaBackbone.from_preset.__func__)

--- a/keras_nlp/models/roberta/roberta_preprocessor.py
+++ b/keras_nlp/models/roberta/roberta_preprocessor.py
@@ -28,7 +28,6 @@ from keras_nlp.utils.keras_utils import (
 )
 from keras_nlp.utils.keras_utils import pack_x_y_sample_weight
 from keras_nlp.utils.python_utils import classproperty
-from keras_nlp.utils.python_utils import format_docstring
 
 
 @keras.utils.register_keras_serializable(package="keras_nlp")
@@ -203,16 +202,6 @@ class RobertaPreprocessor(Preprocessor):
     @classmethod
     def from_preset(cls, preset, **kwargs):
         return super().from_preset(preset, **kwargs)
-
-
-RobertaPreprocessor.from_preset.__func__.__doc__ = (
-    Preprocessor.from_preset.__doc__
-)
-format_docstring(
-    preprocessor_name=RobertaPreprocessor.__name__,
-    example_preset_name="roberta_base_en",
-    preset_names='", "'.join(RobertaPreprocessor.presets),
-)(RobertaPreprocessor.from_preset.__func__)
 
 
 # TODO: This is a temporary, unexported layer until we find a way to make the

--- a/keras_nlp/models/roberta/roberta_preprocessor.py
+++ b/keras_nlp/models/roberta/roberta_preprocessor.py
@@ -199,10 +199,6 @@ class RobertaPreprocessor(Preprocessor):
     def presets(cls):
         return copy.deepcopy(backbone_presets)
 
-    @classmethod
-    def from_preset(cls, preset, **kwargs):
-        return super().from_preset(preset, **kwargs)
-
 
 # TODO: This is a temporary, unexported layer until we find a way to make the
 # `MultiSegmentPacker` layer more generic.

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_backbone.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_backbone.py
@@ -88,7 +88,3 @@ class XLMRobertaBackbone(roberta_backbone.RobertaBackbone):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
-
-    @classmethod
-    def from_preset(cls, preset, load_weights=True, **kwargs):
-        return super().from_preset(preset, load_weights, **kwargs)

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_backbone.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_backbone.py
@@ -18,11 +18,9 @@ import copy
 
 from tensorflow import keras
 
-from keras_nlp.models.backbone import Backbone
 from keras_nlp.models.roberta import roberta_backbone
 from keras_nlp.models.xlm_roberta.xlm_roberta_presets import backbone_presets
 from keras_nlp.utils.python_utils import classproperty
-from keras_nlp.utils.python_utils import format_docstring
 
 
 @keras.utils.register_keras_serializable(package="keras_nlp")
@@ -94,11 +92,3 @@ class XLMRobertaBackbone(roberta_backbone.RobertaBackbone):
     @classmethod
     def from_preset(cls, preset, load_weights=True, **kwargs):
         return super().from_preset(preset, load_weights, **kwargs)
-
-
-XLMRobertaBackbone.from_preset.__func__.__doc__ = Backbone.from_preset.__doc__
-format_docstring(
-    model_name=XLMRobertaBackbone.__name__,
-    example_preset_name="xlm_roberta_base_multi",
-    preset_names=", ".join(XLMRobertaBackbone.presets),
-)(XLMRobertaBackbone.from_preset.__func__)

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_preprocessor.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_preprocessor.py
@@ -198,7 +198,3 @@ class XLMRobertaPreprocessor(Preprocessor):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
-
-    @classmethod
-    def from_preset(cls, preset, **kwargs):
-        return super().from_preset(preset, **kwargs)

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_preprocessor.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_preprocessor.py
@@ -31,7 +31,6 @@ from keras_nlp.utils.keras_utils import (
 )
 from keras_nlp.utils.keras_utils import pack_x_y_sample_weight
 from keras_nlp.utils.python_utils import classproperty
-from keras_nlp.utils.python_utils import format_docstring
 
 
 @keras.utils.register_keras_serializable(package="keras_nlp")
@@ -203,13 +202,3 @@ class XLMRobertaPreprocessor(Preprocessor):
     @classmethod
     def from_preset(cls, preset, **kwargs):
         return super().from_preset(preset, **kwargs)
-
-
-XLMRobertaPreprocessor.from_preset.__func__.__doc__ = (
-    Preprocessor.from_preset.__doc__
-)
-format_docstring(
-    preprocessor_name=XLMRobertaPreprocessor.__name__,
-    example_preset_name="xlm_roberta_base_multi",
-    preset_names='", "'.join(XLMRobertaPreprocessor.presets),
-)(XLMRobertaPreprocessor.from_preset.__func__)


### PR DESCRIPTION
I've been poking around trying to figure out how to best remove the weird docstring cruft we have on each of our backbones and preprocessors. Python gives an `__init_subclass__` hook that will allow us to do this in a consolidate place.