### PR TITLE
Default compilation for BERT/RoBERTa classifiers

### DIFF
--- a/keras_nlp/models/bert/bert_classifier.py
+++ b/keras_nlp/models/bert/bert_classifier.py
@@ -190,6 +190,14 @@ class BertClassifier(Task):
         self.num_classes = num_classes
         self.dropout = dropout
 
+        # Default compilation
+        self.compile(
+            loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+            optimizer=keras.optimizers.Adam(5e-5),
+            metrics=keras.metrics.SparseCategoricalAccuracy(),
+            jit_compile=True,
+        )
+
     def get_config(self):
         config = super().get_config()
         config.update(

--- a/keras_nlp/models/bert/bert_classifier.py
+++ b/keras_nlp/models/bert/bert_classifier.py
@@ -23,6 +23,7 @@ from keras_nlp.models.bert.bert_preprocessor import BertPreprocessor
 from keras_nlp.models.bert.bert_presets import backbone_presets
 from keras_nlp.models.bert.bert_presets import classifier_presets
 from keras_nlp.models.task import Task
+from keras_nlp.utils.keras_utils import is_xla_compatible
 from keras_nlp.utils.python_utils import classproperty
 
 
@@ -195,7 +196,7 @@ class BertClassifier(Task):
             loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
             optimizer=keras.optimizers.Adam(5e-5),
             metrics=keras.metrics.SparseCategoricalAccuracy(),
-            jit_compile=True,
+            jit_compile=is_xla_compatible(self),
         )
 
     def get_config(self):

--- a/keras_nlp/models/bert/bert_classifier_test.py
+++ b/keras_nlp/models/bert/bert_classifier_test.py
@@ -84,6 +84,9 @@ class BertClassifierTest(tf.test.TestCase, parameterized.TestCase):
         self.classifier_no_preprocessing.compile(jit_compile=jit_compile)
         self.classifier_no_preprocessing.predict(self.preprocessed_batch)
 
+    def test_bert_classifier_fit_default_compile(self):
+        self.classifier.fit(self.raw_dataset)
+
     @parameterized.named_parameters(
         ("jit_compile_false", False), ("jit_compile_true", True)
     )

--- a/keras_nlp/models/roberta/roberta_classifier.py
+++ b/keras_nlp/models/roberta/roberta_classifier.py
@@ -22,6 +22,7 @@ from keras_nlp.models.roberta.roberta_backbone import roberta_kernel_initializer
 from keras_nlp.models.roberta.roberta_preprocessor import RobertaPreprocessor
 from keras_nlp.models.roberta.roberta_presets import backbone_presets
 from keras_nlp.models.task import Task
+from keras_nlp.utils.keras_utils import is_xla_compatible
 from keras_nlp.utils.python_utils import classproperty
 
 
@@ -199,7 +200,7 @@ class RobertaClassifier(Task):
             loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
             optimizer=keras.optimizers.Adam(2e-5),
             metrics=keras.metrics.SparseCategoricalAccuracy(),
-            jit_compile=True,
+            jit_compile=is_xla_compatible(self),
         )
 
     def get_config(self):

--- a/keras_nlp/models/roberta/roberta_classifier.py
+++ b/keras_nlp/models/roberta/roberta_classifier.py
@@ -194,6 +194,14 @@ class RobertaClassifier(Task):
         self.hidden_dim = hidden_dim
         self.dropout = dropout
 
+        # Default compilation
+        self.compile(
+            loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+            optimizer=keras.optimizers.Adam(2e-5),
+            metrics=keras.metrics.SparseCategoricalAccuracy(),
+            jit_compile=True,
+        )
+
     def get_config(self):
         config = super().get_config()
         config.update(

--- a/keras_nlp/models/roberta/roberta_classifier_test.py
+++ b/keras_nlp/models/roberta/roberta_classifier_test.py
@@ -101,6 +101,9 @@ class RobertaClassifierTest(tf.test.TestCase, parameterized.TestCase):
         self.classifier_no_preprocessing.compile(jit_compile=jit_compile)
         self.classifier_no_preprocessing.predict(self.preprocessed_batch)
 
+    def test_roberta_classifier_fit_default_compile(self):
+        self.classifier.fit(self.raw_dataset)
+
     @parameterized.named_parameters(
         ("jit_compile_false", False), ("jit_compile_true", True)
     )

--- a/keras_nlp/utils/keras_utils.py
+++ b/keras_nlp/utils/keras_utils.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+import platform
+
 import tensorflow as tf
 from tensorflow import keras
 
@@ -96,3 +98,16 @@ def convert_inputs_to_list_of_tensor_segments(x):
             f"list of tensors. Received `x={x}`"
         )
     return x
+
+
+def is_xla_compatible(model):
+    """Determine if model and platform xla-compatible."""
+    return not (
+        platform.system() == "Darwin" and "arm" in platform.processor().lower()
+    ) and not isinstance(
+        model.distribute_strategy,
+        (
+            tf.compat.v1.distribute.experimental.TPUStrategy,
+            tf.distribute.TPUStrategy,
+        ),
+    )


### PR DESCRIPTION
Pilot to offer intelligent default compilation for all task models. Part of #619 

Right now we only have defaults validated for BERT and RoBERTa classifers ([link](https://github.com/keras-team/keras-nlp/blob/master/examples/glue_benchmark/scores.md)), but we can prioritize adding more in the future. We will never have 100% coverage of all tasks, but it's best to minimize user confusion.