### PR TITLE
Speed up pip install keras-nlp; simplify deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,26 +38,16 @@ setup(
         "absl-py",
         "numpy",
         "packaging",
-        # Don't require tensorflow on MacOS; tensorflow-macos will not
-        # satisfy the requirement.
-        "tensorflow; platform_system != 'Darwin'",
+        # Don't require tensorflow-text on MacOS, there are no binaries for ARM.
+        # Also, we rely on tensorflow *transitively* through tensorflow-text.
+        # This avoid a slowdown during `pip install keras-nlp` where pip would
+        # download many version of both libraries to find compatible versions.
         "tensorflow-text; platform_system != 'Darwin'",
     ],
     extras_require={
-        "tests": [
-            "black",
-            "flake8",
-            "isort",
-            "pytest",
-            "pytest-cov",
+        "extras": [
             "rouge-score",
             "sentencepiece",
-        ],
-        "examples": [
-            "tensorflow_datasets",  # For GLUE in BERT example.
-            "nltk",
-            "wikiextractor",
-            "keras-tuner",
         ],
     },
     # Supported Python versions


### PR DESCRIPTION
We will transitively depend on tensorflow through tensorflow-text, to avoid pip slowly looking for a dependency match.

We will also simplify our extra dependencies, so they no longer include dev environment tooling and BERT pre-training deps. These will be handle via requirements files.