### PR TITLE
Make tokenizer, backbone, preprocessor properties settable on base class

### DIFF
--- a/keras_nlp/models/albert/albert_preprocessor.py
+++ b/keras_nlp/models/albert/albert_preprocessor.py
@@ -149,7 +149,7 @@ class AlbertPreprocessor(Preprocessor):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self._tokenizer = tokenizer
+        self.tokenizer = tokenizer
         self.packer = MultiSegmentPacker(
             start_value=self.tokenizer.cls_token_id,
             end_value=self.tokenizer.sep_token_id,

--- a/keras_nlp/models/bert/bert_classifier.py
+++ b/keras_nlp/models/bert/bert_classifier.py
@@ -185,8 +185,8 @@ class BertClassifier(Task):
             **kwargs,
         )
         # All references to `self` below this line
-        self._backbone = backbone
-        self._preprocessor = preprocessor
+        self.backbone = backbone
+        self.preprocessor = preprocessor
         self.num_classes = num_classes
         self.dropout = dropout
 

--- a/keras_nlp/models/bert/bert_preprocessor.py
+++ b/keras_nlp/models/bert/bert_preprocessor.py
@@ -158,7 +158,7 @@ class BertPreprocessor(Preprocessor):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self._tokenizer = tokenizer
+        self.tokenizer = tokenizer
         self.packer = MultiSegmentPacker(
             start_value=self.tokenizer.cls_token_id,
             end_value=self.tokenizer.sep_token_id,

--- a/keras_nlp/models/deberta_v3/deberta_v3_classifier.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_classifier.py
@@ -193,8 +193,8 @@ class DebertaV3Classifier(Task):
             **kwargs,
         )
         # All references to `self` below this line
-        self._backbone = backbone
-        self._preprocessor = preprocessor
+        self.backbone = backbone
+        self.preprocessor = preprocessor
         self.num_classes = num_classes
         self.hidden_dim = hidden_dim
         self.dropout = dropout

--- a/keras_nlp/models/deberta_v3/deberta_v3_preprocessor.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_preprocessor.py
@@ -153,7 +153,7 @@ class DebertaV3Preprocessor(Preprocessor):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self._tokenizer = tokenizer
+        self.tokenizer = tokenizer
         self.packer = MultiSegmentPacker(
             start_value=self.tokenizer.cls_token_id,
             end_value=self.tokenizer.sep_token_id,

--- a/keras_nlp/models/distil_bert/distil_bert_classifier.py
+++ b/keras_nlp/models/distil_bert/distil_bert_classifier.py
@@ -196,8 +196,8 @@ class DistilBertClassifier(Task):
             **kwargs,
         )
         # All references to `self` below this line
-        self._backbone = backbone
-        self._preprocessor = preprocessor
+        self.backbone = backbone
+        self.preprocessor = preprocessor
         self.num_classes = num_classes
         self.hidden_dim = hidden_dim
         self.dropout = dropout

--- a/keras_nlp/models/distil_bert/distil_bert_preprocessor.py
+++ b/keras_nlp/models/distil_bert/distil_bert_preprocessor.py
@@ -157,7 +157,7 @@ class DistilBertPreprocessor(Preprocessor):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self._tokenizer = tokenizer
+        self.tokenizer = tokenizer
         self.packer = MultiSegmentPacker(
             start_value=self.tokenizer.cls_token_id,
             end_value=self.tokenizer.sep_token_id,

--- a/keras_nlp/models/f_net/f_net_classifier.py
+++ b/keras_nlp/models/f_net/f_net_classifier.py
@@ -116,8 +116,8 @@ class FNetClassifier(Task):
             **kwargs,
         )
         # All references to `self` below this line
-        self._backbone = backbone
-        self._preprocessor = preprocessor
+        self.backbone = backbone
+        self.preprocessor = preprocessor
         self.num_classes = num_classes
         self.dropout = dropout
 

--- a/keras_nlp/models/f_net/f_net_preprocessor.py
+++ b/keras_nlp/models/f_net/f_net_preprocessor.py
@@ -148,7 +148,7 @@ class FNetPreprocessor(Preprocessor):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self._tokenizer = tokenizer
+        self.tokenizer = tokenizer
         self.packer = MultiSegmentPacker(
             start_value=self.tokenizer.cls_token_id,
             end_value=self.tokenizer.sep_token_id,

--- a/keras_nlp/models/gpt2/gpt2_causal_lm.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm.py
@@ -180,8 +180,8 @@ class GPT2CausalLM(Task):
             **kwargs,
         )
 
-        self._backbone = backbone
-        self._preprocessor = preprocessor
+        self.backbone = backbone
+        self.preprocessor = preprocessor
 
     @classproperty
     def presets(cls):

--- a/keras_nlp/models/gpt2/gpt2_preprocessor.py
+++ b/keras_nlp/models/gpt2/gpt2_preprocessor.py
@@ -124,7 +124,7 @@ class GPT2Preprocessor(Preprocessor):
 
         super().__init__(**kwargs)
 
-        self._tokenizer = tokenizer
+        self.tokenizer = tokenizer
         self.sequence_length = sequence_length
 
     def get_config(self):

--- a/keras_nlp/models/preprocessor.py
+++ b/keras_nlp/models/preprocessor.py
@@ -27,6 +27,10 @@ class Preprocessor(keras.layers.Layer):
         """The tokenizer used to tokenize strings."""
         return self._tokenizer
 
+    @tokenizer.setter
+    def tokenizer(self, value):
+        self._tokenizer = value
+
     def get_config(self):
         config = super().get_config()
         config["tokenizer"] = keras.layers.serialize(self.tokenizer)

--- a/keras_nlp/models/roberta/roberta_classifier.py
+++ b/keras_nlp/models/roberta/roberta_classifier.py
@@ -188,8 +188,8 @@ class RobertaClassifier(Task):
             **kwargs,
         )
         # All references to `self` below this line
-        self._backbone = backbone
-        self._preprocessor = preprocessor
+        self.backbone = backbone
+        self.preprocessor = preprocessor
         self.num_classes = num_classes
         self.hidden_dim = hidden_dim
         self.dropout = dropout

--- a/keras_nlp/models/roberta/roberta_preprocessor.py
+++ b/keras_nlp/models/roberta/roberta_preprocessor.py
@@ -167,7 +167,7 @@ class RobertaPreprocessor(Preprocessor):
     ):
         super().__init__(**kwargs)
 
-        self._tokenizer = tokenizer
+        self.tokenizer = tokenizer
         self.packer = RobertaMultiSegmentPacker(
             start_value=self.tokenizer.start_token_id,
             end_value=self.tokenizer.end_token_id,

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -34,10 +34,19 @@ class Task(PipelineModel):
         """A `keras.Model` instance providing the backbone submodel."""
         return self._backbone
 
+    @backbone.setter
+    def backbone(self, value):
+        self._backbone = value
+
     @property
     def preprocessor(self):
         """A `keras.layers.Layer` instance used to preprocess inputs."""
         return self._preprocessor
+
+    @preprocessor.setter
+    def preprocessor(self, value):
+        self.include_preprocessing = value is not None
+        self._preprocessor = value
 
     def get_config(self):
         # Don't chain to super here. The default `get_config()` for functional

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_classifier.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_classifier.py
@@ -190,8 +190,8 @@ class XLMRobertaClassifier(Task):
             **kwargs,
         )
         # All references to `self` below this line
-        self._backbone = backbone
-        self._preprocessor = preprocessor
+        self.backbone = backbone
+        self.preprocessor = preprocessor
         self.num_classes = num_classes
         self.hidden_dim = hidden_dim
         self.dropout = dropout

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_preprocessor.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_preprocessor.py
@@ -161,7 +161,7 @@ class XLMRobertaPreprocessor(Preprocessor):
     ):
         super().__init__(**kwargs)
 
-        self._tokenizer = tokenizer
+        self.tokenizer = tokenizer
 
         self.packer = RobertaMultiSegmentPacker(
             start_value=self.tokenizer.start_token_id,


### PR DESCRIPTION
This improves the readability of our subclasses, instead of writing to a hidden property `self.backbone` and reading from `self._backbone`, we can use a consistent style everywhere.