### PR TITLE
Don't install tf stable when building our nightly image

### DIFF
--- a/examples/bert_pretraining/README.md
+++ b/examples/bert_pretraining/README.md
@@ -39,13 +39,12 @@ python3 examples/bert_pretraining/bert_pretrain.py \
 
 ## Installing dependencies
 
-Pip dependencies for all KerasNLP examples are listed in `setup.py`. The
-following command will create a virtual environment, install all dependencies,
-and install KerasNLP from source.
+This example needs a few extra dependencies to run (e.g. wikiextractor for
+using wikipedia downloads). You can install these into a KerasNLP development
+environment with:
 
 ```shell
-python3 -m venv path/to/venv && source path/to/venv/bin/activate
-pip install -e ".[examples]"
+pip install -r "examples/bert_pretraining/requirements.txt"
 ```
 
 ## Pretraining BERT

--- a/examples/bert_pretraining/requirements.txt
+++ b/examples/bert_pretraining/requirements.txt
@@ -1,0 +1,2 @@
+nltk
+wikiextractor

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -11,8 +11,3 @@ pytest-cov
 # Optional deps.
 rouge-score
 sentencepiece
-# Examples deps.
-nltk
-tensorflow_datasets
-wikiextractor
-keras-tuner

--- a/requirements-macos-m1.txt
+++ b/requirements-macos-m1.txt
@@ -6,10 +6,11 @@
 # before proceeding.
 
 # Core deps.
-tensorflow-macos==2.9
+tensorflow-macos~=2.9
 https://github.com/sun1638650145/Libraries-and-Extensions-for-TensorFlow-for-Apple-Silicon/releases/download/v2.9/tensorflow_text-2.9.0-cp39-cp39-macosx_11_0_arm64.whl
+tensorflow-datasets
 # The metal plugin breaks many tests, so is not enabled by default.
-# tensorflow-metal==0.5.1
+# tensorflow-metal~=0.5
 
 # Common deps.
 -r requirements-common.txt

--- a/requirements-nightly.txt
+++ b/requirements-nightly.txt
@@ -1,6 +1,7 @@
 # Core deps.
 tf-nightly
 tensorflow-text-nightly
+tfds-nightly
 
 # Common deps.
 -r requirements-common.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Core deps.
 tensorflow~=2.11.0
 tensorflow-text~=2.11.0
+tensorflow-datasets
 
 # Common deps.
 -r requirements-common.txt


### PR DESCRIPTION
While debugging our latest nightly failures, I noticed we were downloading a ton of stable tf versions into our nightly image and ultimately installing one.

Switching the nightly requirements file to pull the nightly version of tfds, and avoid keras-tuner entirely (which we no longer use), should avoid this.