### PR TITLE
Add cache support to decoding journey

### DIFF
--- a/keras_nlp/layers/__init__.py
+++ b/keras_nlp/layers/__init__.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from keras_nlp.layers.cached_multi_head_attention import (
+    CachedMultiHeadAttention,
+)
 from keras_nlp.layers.f_net_encoder import FNetEncoder
 from keras_nlp.layers.masked_lm_head import MaskedLMHead
 from keras_nlp.layers.masked_lm_mask_generator import MaskedLMMaskGenerator

--- a/keras_nlp/layers/cached_multi_head_attention.py
+++ b/keras_nlp/layers/cached_multi_head_attention.py
@@ -1,0 +1,113 @@
+# Copyright 2023 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import tensorflow as tf
+from tensorflow import keras
+from tensorflow.compiler.tf2xla.python.xla import dynamic_update_slice
+
+
+class CachedMultiHeadAttention(keras.layers.MultiHeadAttention):
+    """MutliHeadAttention layer with cache support.
+
+    In autoregressive decoding, it's a common practice to cache the K and V for
+    previously seen tokens in order to make the computation faster. With cached
+    K and V, we can compute the attention output of the last token without
+    needing to recompute the forward pass for previously seen tokens. This
+    caching method is only useful during decoding, and should not be used
+    during training.
+    """
+
+    def _update_cache(self, key, value, cache):
+        """Updates cache states and gets full-length key/value tensors."""
+        if "keys" not in cache:
+            keys = key
+            values = value
+        else:
+            keys = tf.concat([tf.cast(cache["keys"], key.dtype), key], axis=1)
+            values = tf.concat(
+                [tf.cast(cache["values"], value.dtype), value], axis=1
+            )
+
+        # Update cache
+        cache["keys"] = keys
+        cache["values"] = values
+
+        return keys, values
+
+    def call(
+        self,
+        query,
+        value,
+        key=None,
+        current_index=None,
+        attention_mask=None,
+        cache=None,
+        return_attention_scores=False,
+        training=None,
+        use_causal_mask=True,
+    ):
+        if cache is None:
+            # When `cache` is None, it's the same as
+            # `keras.layers.MultiHeadAttention`.
+            return super().call(
+                query=query,
+                value=value,
+                key=key,
+                attention_mask=attention_mask,
+                return_attention_scores=return_attention_scores,
+                training=training,
+                use_causal_mask=use_causal_mask,
+            )
+
+        if not self._built_from_signature:
+            self._build_from_signature(query=query, value=value, key=key)
+        if key is None:
+            key = value
+
+        attention_mask = self._compute_attention_mask(
+            query,
+            value,
+            key=key,
+            attention_mask=attention_mask,
+            use_causal_mask=use_causal_mask,
+        )
+
+        query = self._query_dense(query)
+        key = self._key_dense(key)
+        value = self._value_dense(value)
+
+        if current_index is None:
+            seq_len = tf.shape(query)[1]
+            k_update_indices = [0, 0, 0, 0, 0]
+            v_update_indices = [1, 0, 0, 0, 0]
+
+            current_index = seq_len - 1
+        else:
+            k_update_indices = [0, 0, current_index, 0, 0]
+            v_update_indices = [1, 0, current_index, 0, 0]
+        cache = dynamic_update_slice(cache, [key], k_update_indices)
+        cache = dynamic_update_slice(cache, [value], v_update_indices)
+        keys = cache[0, :, : current_index + 1, :, :]
+        values = cache[1, :, : current_index + 1, :, :]
+        query = tf.multiply(query, 1.0 / tf.math.sqrt(float(self._key_dim)))
+        attention_scores = tf.einsum(self._dot_product_equation, keys, query)
+        attention_scores = self._masked_softmax(
+            attention_scores, attention_mask
+        )
+        attention_scores = self._dropout_layer(attention_scores)
+
+        attention_output = tf.einsum(
+            self._combine_equation, attention_scores, values
+        )
+        attention_output = self._output_dense(attention_output)
+        return attention_output, cache

--- a/keras_nlp/layers/cached_multi_head_attention.py
+++ b/keras_nlp/layers/cached_multi_head_attention.py
@@ -95,8 +95,12 @@ class CachedMultiHeadAttention(keras.layers.MultiHeadAttention):
         else:
             k_update_indices = [0, 0, current_index, 0, 0]
             v_update_indices = [1, 0, current_index, 0, 0]
-        cache = dynamic_update_slice(cache, [key], k_update_indices)
-        cache = dynamic_update_slice(cache, [value], v_update_indices)
+        cache = dynamic_update_slice(
+            cache, key[tf.newaxis, ...], k_update_indices
+        )
+        cache = dynamic_update_slice(
+            cache, value[tf.newaxis, ...], v_update_indices
+        )
         keys = cache[0, :, : current_index + 1, :, :]
         values = cache[1, :, : current_index + 1, :, :]
         query = tf.multiply(query, 1.0 / tf.math.sqrt(float(self._key_dim)))

--- a/keras_nlp/layers/cached_multi_head_attention.py
+++ b/keras_nlp/layers/cached_multi_head_attention.py
@@ -49,12 +49,11 @@ class CachedMultiHeadAttention(keras.layers.MultiHeadAttention):
             it's the first pass to build the cache.
 
     Returns:
-        attention_output: The result of the computation, of shape `(B, T, E)`,
-            where `T` is for target sequence shapes and `E` is the query input
-            last dimension if `output_shape` is `None`. Otherwise, the
-            multi-head outputs are projected to the shape specified by
-            `output_shape`.
-        cache: the updated cache.
+        An (attention_output, cache) tuple. `attention_output` is the result of
+        the computation, of shape `(B, T, E)`, where `T` is for target sequence
+        shapes and `E` is the query input last dimension if  `output_shape` is
+        `None`. Otherwise, the multi-head outputs are projected to the shape
+        specified by `output_shape`. `cache` is the updated cache.
     """
 
     def call(

--- a/keras_nlp/layers/cached_multi_head_attention.py
+++ b/keras_nlp/layers/cached_multi_head_attention.py
@@ -42,20 +42,11 @@ class CachedMultiHeadAttention(keras.layers.MultiHeadAttention):
             query elements can attend to which key elements, 1 indicates
             attention and 0 indicates no attention. Broadcasting can happen for
             the missing batch dimensions and the head dimension.
-        return_attention_scores: A boolean to indicate whether the output should
-            contain attention scores.
-        training: Python boolean indicating whether the layer should behave in
-            training mode (adding dropout) or in inference mode (no dropout).
-            Defaults to either using the training mode of the parent
-            layer/model, or False (inference) if there is no parent layer.
-        use_causal_mask: A boolean to indicate whether to apply a causal mask to
-            prevent tokens from attending to future tokens (e.g., used in a
-            decoder Transformer).
-        current_index: a int or int Tensor, the index of the current token being
-            processed. If `current_index=None` while `cache` is set, it means
-            it's the first pass to build the cache.
         cache: a dense float Tensor. The cache of key/value of leading tokens.
             `cache` is of shape [2, B, max_seq_len, num_heads, key_dims].
+        cache_index: a int or int Tensor, the index of the current token being
+            processed. If `cache_index=None` while `cache` is set, it means
+            it's the first pass to build the cache.
 
     Returns:
         attention_output: The result of the computation, of shape `(B, T, E)`,
@@ -64,8 +55,6 @@ class CachedMultiHeadAttention(keras.layers.MultiHeadAttention):
             multi-head outputs are projected to the shape specified by
             `output_shape`.
         cache: the updated cache.
-        attention_scores: [Optional] multi-head attention coefficients over
-            attention axes.
     """
 
     def call(
@@ -74,25 +63,10 @@ class CachedMultiHeadAttention(keras.layers.MultiHeadAttention):
         value,
         key=None,
         attention_mask=None,
-        return_attention_scores=False,
-        training=None,
         use_causal_mask=True,
-        current_index=None,
         cache=None,
+        cache_index=None,
     ):
-        if cache is None:
-            # When `cache` is None, it's the same as
-            # `keras.layers.MultiHeadAttention`.
-            return super().call(
-                query=query,
-                value=value,
-                key=key,
-                attention_mask=attention_mask,
-                return_attention_scores=return_attention_scores,
-                training=training,
-                use_causal_mask=use_causal_mask,
-            )
-
         if not self._built_from_signature:
             self._build_from_signature(query=query, value=value, key=key)
         if key is None:
@@ -110,33 +84,33 @@ class CachedMultiHeadAttention(keras.layers.MultiHeadAttention):
         key = self._key_dense(key)
         value = self._value_dense(value)
 
-        if current_index is None:
-            seq_len = tf.shape(query)[1]
-            k_update_indices = [0, 0, 0, 0, 0]
-            v_update_indices = [1, 0, 0, 0, 0]
-            current_index = seq_len - 1
-        else:
-            k_update_indices = [0, 0, current_index, 0, 0]
-            v_update_indices = [1, 0, current_index, 0, 0]
-        cache = dynamic_update_slice(
-            cache, key[tf.newaxis, ...], k_update_indices
-        )
-        cache = dynamic_update_slice(
-            cache, value[tf.newaxis, ...], v_update_indices
-        )
-        keys = cache[0, :, : current_index + 1, :, :]
-        values = cache[1, :, : current_index + 1, :, :]
+        if cache is not None:
+            if cache_index is None:
+                seq_len = tf.shape(query)[1]
+                k_update_indices = [0, 0, 0, 0, 0]
+                v_update_indices = [1, 0, 0, 0, 0]
+                cache_index = seq_len - 1
+            else:
+                k_update_indices = [0, 0, cache_index, 0, 0]
+                v_update_indices = [1, 0, cache_index, 0, 0]
+            cache = dynamic_update_slice(
+                cache, key[tf.newaxis, ...], k_update_indices
+            )
+            cache = dynamic_update_slice(
+                cache, value[tf.newaxis, ...], v_update_indices
+            )
+            key = cache[0, :, : cache_index + 1, :, :]
+            value = cache[1, :, : cache_index + 1, :, :]
+
         query = tf.multiply(query, 1.0 / tf.math.sqrt(float(self._key_dim)))
-        attention_scores = tf.einsum(self._dot_product_equation, keys, query)
+        attention_scores = tf.einsum(self._dot_product_equation, key, query)
         attention_scores = self._masked_softmax(
             attention_scores, attention_mask
         )
         attention_scores = self._dropout_layer(attention_scores)
 
         attention_output = tf.einsum(
-            self._combine_equation, attention_scores, values
+            self._combine_equation, attention_scores, value
         )
         attention_output = self._output_dense(attention_output)
-        if return_attention_scores:
-            return attention_output, cache, attention_scores
         return attention_output, cache

--- a/keras_nlp/layers/cached_multi_head_attention.py
+++ b/keras_nlp/layers/cached_multi_head_attention.py
@@ -63,7 +63,7 @@ class CachedMultiHeadAttention(keras.layers.MultiHeadAttention):
         value,
         key=None,
         attention_mask=None,
-        use_causal_mask=True,
+        use_causal_mask=False,
         cache=None,
         cache_index=None,
     ):

--- a/keras_nlp/layers/cached_multi_head_attention_test.py
+++ b/keras_nlp/layers/cached_multi_head_attention_test.py
@@ -85,7 +85,7 @@ class CachedMultiHeadAttentionTest(tf.test.TestCase, parameterized.TestCase):
         # Update the outputs in place.
         outputs = dynamic_update_slice(outputs, output, [0, 0, 0])
 
-        def foo(i, cache, outputs):
+        def call(i, cache, outputs):
             def loop_body(i, cache, outputs):
                 # Compute the rest tokens.
                 current_input = x[:, i : i + 1, :]
@@ -105,9 +105,9 @@ class CachedMultiHeadAttentionTest(tf.test.TestCase, parameterized.TestCase):
             )
             return cached_outputs
 
-        cached_outputs = foo(intial_seq_len, cache, outputs)
-        graph_foo = tf.function(foo)
-        graph_cached_outputs = graph_foo(intial_seq_len, cache, outputs)
+        cached_outputs = call(intial_seq_len, cache, outputs)
+        graph_call = tf.function(call)
+        graph_cached_outputs = graph_call(intial_seq_len, cache, outputs)
         normal_outputs = layer(query=x, value=x)
         self.assertAllClose(cached_outputs, normal_outputs)
         self.assertAllClose(graph_cached_outputs, normal_outputs)

--- a/keras_nlp/layers/cached_multi_head_attention_test.py
+++ b/keras_nlp/layers/cached_multi_head_attention_test.py
@@ -55,12 +55,12 @@ class CachedMultiHeadAttentionTest(tf.test.TestCase, parameterized.TestCase):
                 query=current_input,
                 value=current_input,
                 cache=cache,
-                current_index=i,
+                cache_index=i,
             )
             outputs.append(output)
         cached_outputs = tf.concat(outputs, axis=1)
 
-        normal_outputs = layer(query=x, value=x)
+        normal_outputs, _ = layer(query=x, value=x)
         self.assertAllClose(cached_outputs, normal_outputs)
 
     def test_cache_call_with_tf_while(self):
@@ -93,7 +93,7 @@ class CachedMultiHeadAttentionTest(tf.test.TestCase, parameterized.TestCase):
                     query=current_input,
                     value=current_input,
                     cache=cache,
-                    current_index=i,
+                    cache_index=i,
                 )
                 outputs = dynamic_update_slice(outputs, output, [0, i, 0])
                 return i + 1, cache, outputs
@@ -108,6 +108,6 @@ class CachedMultiHeadAttentionTest(tf.test.TestCase, parameterized.TestCase):
         cached_outputs = call(intial_seq_len, cache, outputs)
         graph_call = tf.function(call)
         graph_cached_outputs = graph_call(intial_seq_len, cache, outputs)
-        normal_outputs = layer(query=x, value=x)
+        normal_outputs, _ = layer(query=x, value=x)
         self.assertAllClose(cached_outputs, normal_outputs)
         self.assertAllClose(graph_cached_outputs, normal_outputs)

--- a/keras_nlp/layers/cached_multi_head_attention_test.py
+++ b/keras_nlp/layers/cached_multi_head_attention_test.py
@@ -33,46 +33,9 @@ class CachedMultiHeadAttentionTest(tf.test.TestCase, parameterized.TestCase):
         seq_len = 5
         num_heads = 2
         key_dim = 4
-        layer = CachedMultiHeadAttention(num_heads=num_heads, key_dim=key_dim)
-        x = tf.random.uniform(shape=[batch_size, seq_len, num_heads * key_dim])
-        cache = tf.zeros([batch_size, 2, seq_len, num_heads, key_dim])
-
-        # Build the intial cache.
-        intial_size = 2
-        initial_inputs = x[:, :intial_size, :]
-        outputs = []
-        output, cache = layer(
-            query=initial_inputs,
-            value=initial_inputs,
-            use_causal_mask=True,
-            cache=cache,
-        )
-        outputs.append(output)
-        # Compute the rest tokens.
-        for i in range(intial_size, seq_len):
-            current_input = x[:, i : i + 1, :]
-            output, cache = layer(
-                query=current_input,
-                value=current_input,
-                use_causal_mask=True,
-                cache=cache,
-                cache_index=i,
-            )
-            outputs.append(output)
-        cached_outputs = tf.concat(outputs, axis=1)
-
-        normal_outputs, _ = layer(query=x, value=x, use_causal_mask=True)
-        self.assertAllClose(cached_outputs, normal_outputs)
-
-    def test_cache_call_with_tf_while(self):
-        batch_size = 2
-        seq_len = 5
-        num_heads = 2
-        key_dim = 4
 
         layer = CachedMultiHeadAttention(num_heads=num_heads, key_dim=key_dim)
         x = tf.random.uniform(shape=[batch_size, seq_len, num_heads * key_dim])
-        # [2, batch_size, seq_length, num_heads, key_dim]
         cache = tf.zeros([batch_size, 2, seq_len, num_heads, key_dim])
         # Build the intial cache.
         intial_seq_len = 2

--- a/keras_nlp/layers/cached_multi_head_attention_test.py
+++ b/keras_nlp/layers/cached_multi_head_attention_test.py
@@ -1,0 +1,125 @@
+# Copyright 2023 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for CachedMultiHeadAttention."""
+
+import tensorflow as tf
+from absl.testing import parameterized
+from tensorflow.compiler.tf2xla.python.xla import dynamic_update_slice
+
+from keras_nlp.layers.cached_multi_head_attention import (
+    CachedMultiHeadAttention,
+)
+
+
+class CachedMultiHeadAttentionTest(tf.test.TestCase, parameterized.TestCase):
+    def test_valid_call(self):
+        layer = CachedMultiHeadAttention(num_heads=2, key_dim=4)
+        x = tf.random.uniform(shape=[2, 2, 8])
+        layer(query=x, value=x)
+
+    def test_cache_call_is_correct(self):
+        batch_size = 2
+        seq_len = 5
+        num_heads = 2
+        key_dim = 4
+        layer = CachedMultiHeadAttention(num_heads=num_heads, key_dim=key_dim)
+        x = tf.random.uniform(shape=[batch_size, seq_len, num_heads * key_dim])
+        # [2, batch_size, seq_length, num_heads, key_dim]
+        cache = tf.zeros([2, batch_size, seq_len, num_heads, key_dim])
+
+        # Build the intial cache.
+        intial_size = 2
+        initial_inputs = x[:, :intial_size, :]
+        outputs = []
+        output, cache = layer(
+            query=initial_inputs,
+            value=initial_inputs,
+            cache=cache,
+        )
+        outputs.append(output)
+        # Compute the rest tokens.
+        for i in range(intial_size, seq_len):
+            current_input = x[:, i : i + 1, :]
+            output, cache = layer(
+                query=current_input,
+                value=current_input,
+                cache=cache,
+                current_index=i,
+            )
+            outputs.append(output)
+        cached_outputs = tf.concat(outputs, axis=1)
+
+        normal_outputs = layer(query=x, value=x)
+        self.assertAllClose(
+            cached_outputs, normal_outputs, rtol=1e-5, atol=1e-5
+        )
+
+    def test_cache_call_with_tf_while(self):
+        batch_size = 2
+        seq_len = 5
+        num_heads = 2
+        key_dim = 4
+
+        layer = CachedMultiHeadAttention(num_heads=num_heads, key_dim=key_dim)
+        x = tf.random.uniform(shape=[batch_size, seq_len, num_heads * key_dim])
+        # [2, batch_size, seq_length, num_heads, key_dim]
+        cache = tf.zeros([2, batch_size, seq_len, num_heads, key_dim])
+        # Build the intial cache.
+        intial_seq_len = 2
+        initial_inputs = x[:, :intial_seq_len, :]
+        outputs = tf.zeros_like(x)
+        output, cache = layer(
+            query=initial_inputs,
+            value=initial_inputs,
+            cache=cache,
+        )
+        # Update the outputs in place.
+        outputs = dynamic_update_slice(outputs, output, [0, 0, 0])
+
+        def foo(i, cache, outputs):
+            def loop_body(i, cache, outputs):
+                # Compute the rest tokens.
+                current_input = x[:, i : i + 1, :]
+                output, cache = layer(
+                    query=current_input,
+                    value=current_input,
+                    cache=cache,
+                    current_index=i,
+                )
+                outputs = dynamic_update_slice(outputs, output, [0, i, 0])
+                return i + 1, cache, outputs
+
+            i, cache, cached_outputs = tf.while_loop(
+                cond=lambda i, cache, outputs: i < seq_len,
+                body=loop_body,
+                loop_vars=[i, cache, outputs],
+            )
+            return cached_outputs
+
+        cached_outputs = foo(intial_seq_len, cache, outputs)
+        graph_foo = tf.function(foo)
+        graph_cached_outputs = graph_foo(intial_seq_len, cache, outputs)
+        normal_outputs = layer(query=x, value=x)
+        self.assertAllClose(
+            cached_outputs,
+            normal_outputs,
+            rtol=1e-5,
+            atol=1e-5,
+        )
+        self.assertAllClose(
+            graph_cached_outputs,
+            normal_outputs,
+            rtol=1e-5,
+            atol=1e-5,
+        )

--- a/keras_nlp/layers/cached_multi_head_attention_test.py
+++ b/keras_nlp/layers/cached_multi_head_attention_test.py
@@ -61,9 +61,7 @@ class CachedMultiHeadAttentionTest(tf.test.TestCase, parameterized.TestCase):
         cached_outputs = tf.concat(outputs, axis=1)
 
         normal_outputs = layer(query=x, value=x)
-        self.assertAllClose(
-            cached_outputs, normal_outputs, rtol=1e-5, atol=1e-5
-        )
+        self.assertAllClose(cached_outputs, normal_outputs)
 
     def test_cache_call_with_tf_while(self):
         batch_size = 2
@@ -111,15 +109,5 @@ class CachedMultiHeadAttentionTest(tf.test.TestCase, parameterized.TestCase):
         graph_foo = tf.function(foo)
         graph_cached_outputs = graph_foo(intial_seq_len, cache, outputs)
         normal_outputs = layer(query=x, value=x)
-        self.assertAllClose(
-            cached_outputs,
-            normal_outputs,
-            rtol=1e-5,
-            atol=1e-5,
-        )
-        self.assertAllClose(
-            graph_cached_outputs,
-            normal_outputs,
-            rtol=1e-5,
-            atol=1e-5,
-        )
+        self.assertAllClose(cached_outputs, normal_outputs)
+        self.assertAllClose(graph_cached_outputs, normal_outputs)

--- a/keras_nlp/layers/cached_multi_head_attention_test.py
+++ b/keras_nlp/layers/cached_multi_head_attention_test.py
@@ -35,7 +35,6 @@ class CachedMultiHeadAttentionTest(tf.test.TestCase, parameterized.TestCase):
         key_dim = 4
         layer = CachedMultiHeadAttention(num_heads=num_heads, key_dim=key_dim)
         x = tf.random.uniform(shape=[batch_size, seq_len, num_heads * key_dim])
-        # [2, batch_size, seq_length, num_heads, key_dim]
         cache = tf.zeros([2, batch_size, seq_len, num_heads, key_dim])
 
         # Build the intial cache.

--- a/keras_nlp/layers/transformer_decoder.py
+++ b/keras_nlp/layers/transformer_decoder.py
@@ -239,7 +239,8 @@ class TransformerDecoder(keras.layers.Layer):
                 being processed. If `cache_index=None` while `cache` is set, it
                 means it's the first pass to build the cache.
         Returns:
-            A Tensor of the same shape as the `decoder_sequence`.
+            x: A Tensor of the same shape as the `decoder_sequence`.
+            cache: [Optional], a dense float Tensor. The updated `cache`.
         """
 
         has_encoder_sequence = encoder_sequence is not None

--- a/keras_nlp/layers/transformer_decoder.py
+++ b/keras_nlp/layers/transformer_decoder.py
@@ -211,8 +211,8 @@ class TransformerDecoder(keras.layers.Layer):
         decoder_attention_mask=None,
         encoder_padding_mask=None,
         encoder_attention_mask=None,
-        current_index=None,
         cache=None,
+        cache_index=None,
     ):
         """Forward pass of the TransformerDecoder.
 
@@ -276,20 +276,13 @@ class TransformerDecoder(keras.layers.Layer):
         residual = x
         if self.normalize_first:
             x = self._self_attention_layernorm(x)
-        if cache is None:
-            x = self._self_attention_layer(
-                query=x,
-                value=x,
-                attention_mask=self_attention_mask,
-            )
-        else:
-            x, cache = self._self_attention_layer(
-                query=x,
-                value=x,
-                current_index=current_index,
-                cache=cache,
-                attention_mask=self_attention_mask,
-            )
+        x, cache = self._self_attention_layer(
+            query=x,
+            value=x,
+            cache=cache,
+            cache_index=cache_index,
+            attention_mask=self_attention_mask,
+        )
         x = self._self_attention_dropout(x)
         x = x + residual
         if not self.normalize_first:

--- a/keras_nlp/layers/transformer_decoder.py
+++ b/keras_nlp/layers/transformer_decoder.py
@@ -233,7 +233,7 @@ class TransformerDecoder(keras.layers.Layer):
                 sequence mask, must of shape
                 [batch_size, encoder_sequence_length, encoder_sequence_length].
             cache: a dense float Tensor. The cache of key/value of leading
-                tokens. `cache` is of shape [2, B, max_seq_len, num_heads,
+                tokens. `cache` is of shape [B, 2, max_seq_len, num_heads,
                 key_dims].
             cache_index: a int or int Tensor, the index of the current token
                 being processed. If `cache_index=None` while `cache` is set, it

--- a/keras_nlp/layers/transformer_decoder.py
+++ b/keras_nlp/layers/transformer_decoder.py
@@ -239,8 +239,8 @@ class TransformerDecoder(keras.layers.Layer):
                 being processed. If `cache_index=None` while `cache` is set, it
                 means it's the first pass to build the cache.
         Returns:
-            x: A Tensor of the same shape as the `decoder_sequence`.
-            cache: [Optional], a dense float Tensor. The updated `cache`.
+            Either a tuple of (outputs, cache) if a cache was passed, or a
+            single value outputs if a cache was not passed.
         """
 
         has_encoder_sequence = encoder_sequence is not None
@@ -329,7 +329,7 @@ class TransformerDecoder(keras.layers.Layer):
 
         if cache is None:
             return x
-        return x, cache
+        return (x, cache)
 
     def get_config(self):
         config = super().get_config()

--- a/keras_nlp/layers/transformer_decoder.py
+++ b/keras_nlp/layers/transformer_decoder.py
@@ -232,6 +232,12 @@ class TransformerDecoder(keras.layers.Layer):
             encoder_attention_mask: a boolean Tensor. Customized encoder
                 sequence mask, must of shape
                 [batch_size, encoder_sequence_length, encoder_sequence_length].
+            cache: a dense float Tensor. The cache of key/value of leading
+                tokens. `cache` is of shape [2, B, max_seq_len, num_heads,
+                key_dims].
+            cache_index: a int or int Tensor, the index of the current token
+                being processed. If `cache_index=None` while `cache` is set, it
+                means it's the first pass to build the cache.
         Returns:
             A Tensor of the same shape as the `decoder_sequence`.
         """

--- a/keras_nlp/layers/transformer_decoder_test.py
+++ b/keras_nlp/layers/transformer_decoder_test.py
@@ -18,6 +18,7 @@ import os
 import tensorflow as tf
 from absl.testing import parameterized
 from tensorflow import keras
+from tensorflow.compiler.tf2xla.python.xla import dynamic_update_slice
 
 from keras_nlp.layers import transformer_decoder
 
@@ -264,6 +265,68 @@ class TransformerDecoderTest(tf.test.TestCase, parameterized.TestCase):
         decoder_sequence._keras_mask = mask
         outputs = decoder(decoder_sequence)
         self.assertAllEqual(outputs._keras_mask, mask)
+
+    def test_cached_decoding_is_correct(self):
+        batch_size = 2
+        seq_len = 5
+        num_heads = 2
+        hidden_dim = 8
+
+        layer = transformer_decoder.TransformerDecoder(
+            intermediate_dim=4,
+            num_heads=num_heads,
+        )
+        x = tf.random.uniform(shape=[batch_size, seq_len, hidden_dim])
+        # [2, batch_size, seq_length, num_heads, hidden_dim // num_heads]
+        cache = tf.zeros(
+            [2, batch_size, seq_len, num_heads, hidden_dim // num_heads]
+        )
+        # Build the intial cache.
+        intial_seq_len = 2
+        initial_inputs = x[:, :intial_seq_len, :]
+        outputs = tf.zeros_like(x)
+        output, cache = layer(
+            decoder_sequence=initial_inputs,
+            cache=cache,
+        )
+        # Update the outputs in place.
+        outputs = dynamic_update_slice(outputs, output, [0, 0, 0])
+
+        def foo(i, cache, outputs):
+            def loop_body(i, cache, outputs):
+                # Compute the rest tokens.
+                current_input = x[:, i : i + 1, :]
+                output, cache = layer(
+                    decoder_sequence=current_input,
+                    cache=cache,
+                    current_index=i,
+                )
+                outputs = dynamic_update_slice(outputs, output, [0, i, 0])
+                return i + 1, cache, outputs
+
+            i, cache, cached_outputs = tf.while_loop(
+                cond=lambda i, cache, outputs: i < seq_len,
+                body=loop_body,
+                loop_vars=[i, cache, outputs],
+            )
+            return cached_outputs
+
+        cached_outputs = foo(intial_seq_len, cache, outputs)
+        graph_foo = tf.function(foo)
+        graph_cached_outputs = graph_foo(intial_seq_len, cache, outputs)
+        normal_outputs = layer(decoder_sequence=x)
+        self.assertAllClose(
+            cached_outputs,
+            normal_outputs,
+            rtol=1e-5,
+            atol=1e-5,
+        )
+        self.assertAllClose(
+            graph_cached_outputs,
+            normal_outputs,
+            rtol=1e-5,
+            atol=1e-5,
+        )
 
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),

--- a/keras_nlp/layers/transformer_decoder_test.py
+++ b/keras_nlp/layers/transformer_decoder_test.py
@@ -292,7 +292,7 @@ class TransformerDecoderTest(tf.test.TestCase, parameterized.TestCase):
         # Update the outputs in place.
         outputs = dynamic_update_slice(outputs, output, [0, 0, 0])
 
-        def foo(i, cache, outputs):
+        def call(i, cache, outputs):
             def loop_body(i, cache, outputs):
                 # Compute the rest tokens.
                 current_input = x[:, i : i + 1, :]
@@ -311,9 +311,9 @@ class TransformerDecoderTest(tf.test.TestCase, parameterized.TestCase):
             )
             return cached_outputs
 
-        cached_outputs = foo(initial_seq_len, cache, outputs)
-        graph_foo = tf.function(foo)
-        graph_cached_outputs = graph_foo(initial_seq_len, cache, outputs)
+        cached_outputs = call(initial_seq_len, cache, outputs)
+        graph_call = tf.function(call)
+        graph_cached_outputs = graph_call(initial_seq_len, cache, outputs)
         normal_outputs = layer(decoder_sequence=x)
         self.assertAllClose(cached_outputs, normal_outputs)
         self.assertAllClose(graph_cached_outputs, normal_outputs)

--- a/keras_nlp/layers/transformer_decoder_test.py
+++ b/keras_nlp/layers/transformer_decoder_test.py
@@ -277,9 +277,8 @@ class TransformerDecoderTest(tf.test.TestCase, parameterized.TestCase):
             num_heads=num_heads,
         )
         x = tf.random.uniform(shape=[batch_size, seq_len, hidden_dim])
-        # [2, batch_size, seq_length, num_heads, hidden_dim // num_heads]
         cache = tf.zeros(
-            [2, batch_size, seq_len, num_heads, hidden_dim // num_heads]
+            [batch_size, 2, seq_len, num_heads, hidden_dim // num_heads]
         )
         # Build the intial cache.
         initial_seq_len = 2

--- a/keras_nlp/layers/transformer_decoder_test.py
+++ b/keras_nlp/layers/transformer_decoder_test.py
@@ -282,8 +282,8 @@ class TransformerDecoderTest(tf.test.TestCase, parameterized.TestCase):
             [2, batch_size, seq_len, num_heads, hidden_dim // num_heads]
         )
         # Build the intial cache.
-        intial_seq_len = 2
-        initial_inputs = x[:, :intial_seq_len, :]
+        initial_seq_len = 2
+        initial_inputs = x[:, :initial_seq_len, :]
         outputs = tf.zeros_like(x)
         output, cache = layer(
             decoder_sequence=initial_inputs,
@@ -311,22 +311,12 @@ class TransformerDecoderTest(tf.test.TestCase, parameterized.TestCase):
             )
             return cached_outputs
 
-        cached_outputs = foo(intial_seq_len, cache, outputs)
+        cached_outputs = foo(initial_seq_len, cache, outputs)
         graph_foo = tf.function(foo)
-        graph_cached_outputs = graph_foo(intial_seq_len, cache, outputs)
+        graph_cached_outputs = graph_foo(initial_seq_len, cache, outputs)
         normal_outputs = layer(decoder_sequence=x)
-        self.assertAllClose(
-            cached_outputs,
-            normal_outputs,
-            rtol=1e-5,
-            atol=1e-5,
-        )
-        self.assertAllClose(
-            graph_cached_outputs,
-            normal_outputs,
-            rtol=1e-5,
-            atol=1e-5,
-        )
+        self.assertAllClose(cached_outputs, normal_outputs)
+        self.assertAllClose(graph_cached_outputs, normal_outputs)
 
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),

--- a/keras_nlp/layers/transformer_decoder_test.py
+++ b/keras_nlp/layers/transformer_decoder_test.py
@@ -299,7 +299,7 @@ class TransformerDecoderTest(tf.test.TestCase, parameterized.TestCase):
                 output, cache = layer(
                     decoder_sequence=current_input,
                     cache=cache,
-                    current_index=i,
+                    cache_index=i,
                 )
                 outputs = dynamic_update_slice(outputs, output, [0, i, 0])
                 return i + 1, cache, outputs

--- a/keras_nlp/models/backbone.py
+++ b/keras_nlp/models/backbone.py
@@ -102,7 +102,6 @@ class Backbone(keras.Model):
             cache_subdir=os.path.join("models", preset),
             file_hash=metadata["weights_hash"],
         )
-
         model.load_weights(weights)
         return model
 

--- a/keras_nlp/models/gpt2/gpt2_backbone.py
+++ b/keras_nlp/models/gpt2/gpt2_backbone.py
@@ -200,7 +200,7 @@ class GPT2Backbone(Backbone):
                 represents the index of current inputs in the whole sequence.
 
         Returns:
-            x: a dense float Tensor, the predicted next token logits of `inputs`.
+            x: a dense float Tensor, the next token logits of `inputs`.
             cache: a dense float Tensor, the updated cache.
         """
         token_ids = inputs["token_ids"]

--- a/keras_nlp/models/gpt2/gpt2_backbone.py
+++ b/keras_nlp/models/gpt2/gpt2_backbone.py
@@ -125,7 +125,9 @@ class GPT2Backbone(Backbone):
         )(token_embedding)
 
         # Sum and apply dropout to embeddings.
-        x = keras.layers.Add()((token_embedding, position_embedding))
+        x = keras.layers.Add(name="embeddings_add")(
+            (token_embedding, position_embedding)
+        )
         x = keras.layers.Dropout(
             dropout,
             name="embeddings_dropout",
@@ -144,10 +146,7 @@ class GPT2Backbone(Backbone):
                 kernel_initializer=_gpt_2_kernel_initializer(stddev=0.02),
                 normalize_first=True,
                 name=f"transformer_layer_{i}",
-            )(
-                x,
-                decoder_padding_mask=padding_mask,
-            )
+            )(x, decoder_padding_mask=padding_mask)
 
         sequence_output = keras.layers.LayerNormalization(
             name="layer_norm",

--- a/keras_nlp/models/gpt2/gpt2_backbone.py
+++ b/keras_nlp/models/gpt2/gpt2_backbone.py
@@ -215,7 +215,9 @@ class GPT2Backbone(Backbone):
         x = token_embedding + position_embedding
         x = self.embeddings_dropout(x)
         if current_index is not None:
-            x = x[:, current_index : current_index + 1, :]
+            batch_size = tf.shape(x)[0]
+            hidden_dim = tf.shape(x)[2]
+            x = tf.slice(x, [0, current_index, 0], [batch_size, 1, hidden_dim])
             padding_mask = padding_mask[:, : current_index + 1]
         for i, transformer_layer in enumerate(self.transformer_layers):
             current_cache = cache[:, i, ...]

--- a/keras_nlp/models/gpt2/gpt2_backbone_test.py
+++ b/keras_nlp/models/gpt2/gpt2_backbone_test.py
@@ -87,7 +87,7 @@ class GPT2Test(tf.test.TestCase, parameterized.TestCase):
                 output, cache = self.model.call_with_cache(
                     inputs=self.input_batch,
                     cache=cache,
-                    current_index=i,
+                    cache_index=i,
                 )
                 outputs = dynamic_update_slice(outputs, output, [0, i, 0])
                 return i + 1, cache, outputs

--- a/keras_nlp/models/gpt2/gpt2_backbone_test.py
+++ b/keras_nlp/models/gpt2/gpt2_backbone_test.py
@@ -81,7 +81,7 @@ class GPT2Test(tf.test.TestCase, parameterized.TestCase):
             max_seq_len,
         )
 
-        def foo(i, cache, outputs):
+        def call(i, cache, outputs):
             def loop_body(i, cache, outputs):
                 # Compute the rest tokens.
                 output, cache = self.model.call_with_cache(
@@ -99,9 +99,9 @@ class GPT2Test(tf.test.TestCase, parameterized.TestCase):
             )
             return cached_outputs
 
-        cached_outputs = foo(initial_seq_len, cache, outputs)
-        graph_foo = tf.function(foo)
-        graph_cached_outputs = graph_foo(initial_seq_len, cache, outputs)
+        cached_outputs = call(initial_seq_len, cache, outputs)
+        graph_call = tf.function(call)
+        graph_cached_outputs = graph_call(initial_seq_len, cache, outputs)
         normal_outputs = self.model(self.input_batch)
         normal_outputs = normal_outputs[:, :max_seq_len, :]
 

--- a/keras_nlp/models/gpt2/gpt2_backbone_test.py
+++ b/keras_nlp/models/gpt2/gpt2_backbone_test.py
@@ -18,7 +18,6 @@ import os
 import tensorflow as tf
 from absl.testing import parameterized
 from tensorflow import keras
-from tensorflow.compiler.tf2xla.python.xla import dynamic_update_slice
 
 from keras_nlp.models.gpt2.gpt2_backbone import GPT2Backbone
 
@@ -64,49 +63,6 @@ class GPT2Test(tf.test.TestCase, parameterized.TestCase):
                 ),
             }
             self.model(input_data)
-
-    def test_cache_call_is_correct(self):
-        initial_seq_len = 64
-        max_seq_len = 80
-        initial_inputs = {
-            "token_ids": tf.ones(
-                (self.batch_size, initial_seq_len), dtype="int32"
-            ),
-            "padding_mask": tf.ones(
-                (self.batch_size, initial_seq_len), dtype="int32"
-            ),
-        }
-        outputs, cache = self.model.build_initial_cache(
-            initial_inputs,
-            max_seq_len,
-        )
-
-        def call(i, cache, outputs):
-            def loop_body(i, cache, outputs):
-                # Compute the rest tokens.
-                output, cache = self.model.call_with_cache(
-                    inputs=self.input_batch,
-                    cache=cache,
-                    cache_index=i,
-                )
-                outputs = dynamic_update_slice(outputs, output, [0, i, 0])
-                return i + 1, cache, outputs
-
-            i, cache, cached_outputs = tf.while_loop(
-                cond=lambda i, cache, outputs: i < max_seq_len,
-                body=loop_body,
-                loop_vars=[i, cache, outputs],
-            )
-            return cached_outputs
-
-        cached_outputs = call(initial_seq_len, cache, outputs)
-        graph_call = tf.function(call)
-        graph_cached_outputs = graph_call(initial_seq_len, cache, outputs)
-        normal_outputs = self.model(self.input_batch)
-        normal_outputs = normal_outputs[:, :max_seq_len, :]
-
-        self.assertAllClose(cached_outputs, normal_outputs)
-        self.assertAllClose(graph_cached_outputs, normal_outputs)
 
     @parameterized.named_parameters(
         ("jit_compile_false", False), ("jit_compile_true", True)

--- a/keras_nlp/models/gpt2/gpt2_causal_lm.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm.py
@@ -247,7 +247,7 @@ class GPT2CausalLM(Task):
         )
         return existing_outputs, cache
 
-    def _get_token_probability(self, prompt, mask, current_index=None):
+    def _get_token_probability(self, prompt, mask):
         model_inputs = {
             "token_ids": prompt,
             "padding_mask": mask,

--- a/keras_nlp/models/gpt2/gpt2_causal_lm.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm.py
@@ -272,6 +272,8 @@ class GPT2CausalLM(Task):
             prompt: a string, string Tensor or string RaggedTensor. The prompt
                 text for generation.
             max_length: int. The max length of generated sequence.
+            use_cache: bool, defaults to True. If True, cache will be used
+                during decoding, which increases the decoding speed.
             sampler: a string or `keras_nlp.samplers.Sampler` instance. The
                 sampler to be used for text generation.
         """

--- a/keras_nlp/models/gpt2/gpt2_causal_lm_test.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm_test.py
@@ -142,22 +142,6 @@ class GPT2CausalLMTest(tf.test.TestCase, parameterized.TestCase):
         generated = generated.numpy().decode("utf-8")
         self.assertTrue(prompt in generated)
 
-    def test_generate_same_with_cache(self):
-        self.causal_lm.compile(jit_compile=False)
-        cached_result = self.causal_lm.generate(
-            self.raw_batch,
-            max_length=10,
-            sampler="greedy",
-            use_cache=True,
-        )
-        non_cached_result = self.causal_lm.generate(
-            self.raw_batch,
-            max_length=10,
-            sampler="greedy",
-            use_cache=False,
-        )
-        self.assertAllEqual(cached_result, non_cached_result)
-
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),

--- a/keras_nlp/samplers/beam_sampler.py
+++ b/keras_nlp/samplers/beam_sampler.py
@@ -93,7 +93,7 @@ class BeamSampler(Sampler):
         num_steps,
         from_logits=True,
         cache=None,
-        existing_outputs=None,
+        token_probs=None,
     ):
         """Sampling logic implementation.
 

--- a/keras_nlp/samplers/beam_sampler.py
+++ b/keras_nlp/samplers/beam_sampler.py
@@ -14,6 +14,7 @@
 """Beam Sampler."""
 
 import tensorflow as tf
+from absl import logging
 from tensorflow import keras
 
 from keras_nlp.samplers.sampler import Sampler
@@ -85,13 +86,26 @@ class BeamSampler(Sampler):
         pass
 
     def sample(
-        self, prompt, token_probability_fn, mask, num_steps, from_logits=True
+        self,
+        prompt,
+        token_probability_fn,
+        mask,
+        num_steps,
+        from_logits=True,
+        cache=None,
+        existing_outputs=None,
     ):
         """Sampling logic implementation.
 
         Because beam search uses a different loop body, we have to override the
         whole `sample` method instead of just the `get_next_token` method.
         """
+        if cache is not None:
+            logging.warning(
+                "`BeamSampler` does not support cache decoding now, the cache "
+                "will be ignored. To use cache decoding, please use a "
+                "different sampler, e.g., `TopPSampler`."
+            )
         batch_size, max_length = tf.shape(prompt)[0], tf.shape(prompt)[1]
         max_length = tf.cast(max_length, num_steps.dtype)
         length = max_length - num_steps

--- a/keras_nlp/samplers/sampler.py
+++ b/keras_nlp/samplers/sampler.py
@@ -343,7 +343,7 @@ class Sampler:
                     prompt, mask, last_index, cache, token_probs
                 )
             else:
-                probs = token_probability_fn(prompt, mask, last_index)
+                probs = token_probability_fn(prompt, mask)
 
             next_token_probs = tf.gather(
                 probs,

--- a/keras_nlp/samplers/sampler.py
+++ b/keras_nlp/samplers/sampler.py
@@ -401,7 +401,7 @@ class Sampler:
                 body=one_step,
                 loop_vars=[current_index, prompt, mask],
             )
-            return prompt, None, None
+            return prompt
         # Run a while loop till `max_length` of tokens has been generated.
         current_index, prompt, mask, cache, token_probs = tf.while_loop(
             cond=lambda current_index, prompt, mask, cache, token_probs: tf.less(

--- a/keras_nlp/samplers/sampler.py
+++ b/keras_nlp/samplers/sampler.py
@@ -298,7 +298,7 @@ class Sampler:
         current_index = max_length - num_steps
 
         def one_step(current_index, prompt, mask):
-            probs = token_probability_fn(prompt, mask)
+            probs = token_probability_fn(prompt, mask, current_index - 1)
             next_token_probs = tf.gather(
                 probs,
                 tf.repeat(current_index - 1, batch_size),


### PR DESCRIPTION
There are a few things to note here:
- XLA path is not supported as it returns a different result from non-xla graph, I am looking into the cause.
- Beam search does not support cache for now, because it needs to maintain `num=num_beams` cache. I will do this as a followup.
- We are using a lot of slicing and update calls now, unsure how to optimize it. I have been looking into this for too long, so I am trapped in the rabbit hole.
- To play with the API and compare the performance, you can use this [colab](https://colab.research.google.com/gist/chenmoneygithub/b02eaf70d3004063b1c4b92965174ec6/cached-decoding-solution-branch-version.ipynb).

This is oddly and insanely complex, so thanks for the review work. 

Cheers.

