### PR TITLE
New docstring example for TokenAndPosition Embedding layer.

### DIFF
--- a/keras_nlp/layers/token_and_position_embedding.py
+++ b/keras_nlp/layers/token_and_position_embedding.py
@@ -47,14 +47,11 @@ class TokenAndPositionEmbedding(keras.layers.Layer):
 
     Examples:
     ```python
-    seq_length = 50
-    vocab_size = 5000
-    embed_dim = 128
-    inputs = keras.Input(shape=(seq_length,))
+    inputs = tf.ones(shape=(1, 50), dtype=tf.int64)
     embedding_layer = keras_nlp.layers.TokenAndPositionEmbedding(
-        vocabulary_size=vocab_size,
-        sequence_length=seq_length,
-        embedding_dim=embed_dim,
+        vocabulary_size=10_000,
+        sequence_length=50,
+        embedding_dim=128,
     )
     outputs = embedding_layer(inputs)
     ```


### PR DESCRIPTION
I have made some changes in the docstring example of the TokenAndPosition Embedding Layer.

Resolves #658.