### PR TITLE
Fix Fenced Doc-String #782

### DIFF
--- a/keras_nlp/models/albert/albert_masked_lm_preprocessor.py
+++ b/keras_nlp/models/albert/albert_masked_lm_preprocessor.py
@@ -118,9 +118,9 @@ class AlbertMaskedLMPreprocessor(AlbertPreprocessor):
 
     proto = bytes_io.getvalue()
 
-    tokenizer = AlbertTokenizer(proto=proto)
+    tokenizer = keras_nlp.models.AlbertTokenizer(proto=proto)
 
-    preprocessor = AlbertMaskedLMPreprocessor(
+    preprocessor = keras_nlp.models.AlbertMaskedLMPreprocessor(
         tokenizer=tokenizer
     )
 

--- a/keras_nlp/models/distil_bert/distil_bert_masked_lm_preprocessor.py
+++ b/keras_nlp/models/distil_bert/distil_bert_masked_lm_preprocessor.py
@@ -67,7 +67,7 @@ class DistilBertMaskedLMPreprocessor(DistilBertPreprocessor):
 
     # Alternatively, you can create a preprocessor from your own vocabulary.
     # The usage is exactly the same as above.
-    vocab = ["[PAD]", "[UNK]", "[CLS]", "[SEP]"]
+    vocab = ["[PAD]", "[UNK]", "[CLS]", "[SEP]", "[MASK]"]
     vocab += ["The", "qu", "##ick", "br", "##own", "fox", "tripped"]
     vocab += ["Call", "me", "Ish", "##mael", "."]
     vocab += ["Oh", "look", "a", "whale"]

--- a/keras_nlp/models/distil_bert/distil_bert_preprocessor.py
+++ b/keras_nlp/models/distil_bert/distil_bert_preprocessor.py
@@ -139,7 +139,7 @@ class DistilBertPreprocessor(Preprocessor):
 
     # Alternatively, you can create a preprocessor from your own vocabulary.
     # The usage is exactly the same as above.
-    vocab = ["[PAD]", "[UNK]", "[CLS]", "[SEP]"]
+    vocab = ["[PAD]", "[UNK]", "[CLS]", "[SEP]","[MASK]"]
     vocab += ["The", "qu", "##ick", "br", "##own", "fox", "tripped"]
     vocab += ["Call", "me", "Ish", "##mael", "."]
     vocab += ["Oh", "look", "a", "whale"]

--- a/keras_nlp/models/distil_bert/distil_bert_preprocessor.py
+++ b/keras_nlp/models/distil_bert/distil_bert_preprocessor.py
@@ -139,7 +139,7 @@ class DistilBertPreprocessor(Preprocessor):
 
     # Alternatively, you can create a preprocessor from your own vocabulary.
     # The usage is exactly the same as above.
-    vocab = ["[PAD]", "[UNK]", "[CLS]", "[SEP]","[MASK]"]
+    vocab = ["[PAD]", "[UNK]", "[CLS]", "[SEP]", "[MASK]"]
     vocab += ["The", "qu", "##ick", "br", "##own", "fox", "tripped"]
     vocab += ["Call", "me", "Ish", "##mael", "."]
     vocab += ["Oh", "look", "a", "whale"]

--- a/keras_nlp/models/f_net/f_net_classifier.py
+++ b/keras_nlp/models/f_net/f_net_classifier.py
@@ -71,7 +71,6 @@ class FNetClassifier(Task):
     backbone = keras_nlp.models.FNetBackbone(
         vocabulary_size=32000,
         num_layers=12,
-        num_heads=12,
         hidden_dim=768,
         intermediate_dim=3072,
         max_sequence_length=12,

--- a/keras_nlp/models/f_net/f_net_classifier.py
+++ b/keras_nlp/models/f_net/f_net_classifier.py
@@ -67,7 +67,7 @@ class FNetClassifier(Task):
     }
     labels = [0, 3]
 
-    # Randomly initialize a Fnet backbone
+    # Randomly initialize a FNet backbone.
     backbone = keras_nlp.models.FNetBackbone(
         vocabulary_size=32000,
         num_layers=12,
@@ -77,8 +77,8 @@ class FNetClassifier(Task):
         max_sequence_length=12,
     )
 
-    # Create a Fnet classifier and fit your data.
-    classifier = keras_nlp.models.FnetClassifier(
+    # Create a FNet classifier and fit your data.
+    classifier = keras_nlp.models.FNetClassifier(
         backbone,
         num_classes=4,
         preprocessor=None,

--- a/keras_nlp/models/f_net/f_net_masked_lm.py
+++ b/keras_nlp/models/f_net/f_net_masked_lm.py
@@ -87,7 +87,6 @@ class FNetMaskedLM(Task):
     backbone = keras_nlp.models.FNetBackbone(
         vocabulary_size=50265,
         num_layers=12,
-        num_heads=12,
         hidden_dim=768,
         intermediate_dim=3072,
         max_sequence_length=12

--- a/keras_nlp/models/f_net/f_net_masked_lm.py
+++ b/keras_nlp/models/f_net/f_net_masked_lm.py
@@ -76,7 +76,7 @@ class FNetMaskedLM(Task):
             [[1, 2, 0, 4, 0, 6, 7, 8]] * 2, shape=(2, 8)
         ),
         "segment_ids": tf.constant(
-            [[1, 0, 0, 4, 0, 6, 7, 8]] * 2, shape=(2, 8)
+            [[0, 0, 0, 1, 1, 1, 0, 0]] * 2, shape=(2, 8)
         ),
         "mask_positions": tf.constant([[2, 4]] * 2, shape=(2, 2))
     }

--- a/keras_nlp/models/f_net/f_net_masked_lm_preprocessor.py
+++ b/keras_nlp/models/f_net/f_net_masked_lm_preprocessor.py
@@ -112,8 +112,8 @@ class FNetMaskedLMPreprocessor(FNetPreprocessor):
         user_defined_symbols="[MASK]",
     )
     proto = bytes_io.getvalue()
-    tokenizer = FNetTokenizer(proto=proto)
-    preprocessor = FNetMaskedLMPreprocessor(tokenizer=tokenizer)
+    tokenizer = keras_nlp.models.FNetTokenizer(proto=proto)
+    preprocessor = keras_nlp.models.FNetMaskedLMPreprocessor(tokenizer=tokenizer)
     ```
     """
 

--- a/keras_nlp/tests/doc_tests/docstring_test.py
+++ b/keras_nlp/tests/doc_tests/docstring_test.py
@@ -114,6 +114,9 @@ def test_fenced_docstrings():
             "keras_nlp.models.xlm_roberta.xlm_roberta_preprocessor",
             "keras_nlp.models.f_net.f_net_preprocessor",
             "keras_nlp.models.f_net.f_net_tokenizer",
+            "keras_nlp.tokenizers.byte_pair_tokenizer",
+            "keras_nlp.tokenizers.sentence_piece_tokenizer",
+            "keras_nlp.tokenizers.word_piece_tokenizer",
         ]:
             continue
 

--- a/keras_nlp/tests/doc_tests/docstring_test.py
+++ b/keras_nlp/tests/doc_tests/docstring_test.py
@@ -108,12 +108,12 @@ def test_fenced_docstrings():
             "keras_nlp.models.backbone",
             "keras_nlp.models.preprocessor",
             "keras_nlp.models.task",
-            # Preprocessors and tokenizers which use `model.spm` (temporary).
-            "keras_nlp.models.albert.albert_preprocessor",
-            "keras_nlp.models.albert.albert_tokenizer",
             "keras_nlp.models.xlm_roberta.xlm_roberta_preprocessor",
             "keras_nlp.models.f_net.f_net_preprocessor",
             "keras_nlp.models.f_net.f_net_tokenizer",
+            # Preprocessors and tokenizers which use `model.spm` (temporary).
+            "keras_nlp.models.albert.albert_preprocessor",
+            "keras_nlp.models.albert.albert_tokenizer",
             "keras_nlp.tokenizers.byte_pair_tokenizer",
             "keras_nlp.tokenizers.sentence_piece_tokenizer",
             "keras_nlp.tokenizers.word_piece_tokenizer",


### PR DESCRIPTION
Following changes were made in Doc-String Examples -  

- Add models to the list in docstring_test.py
- Import from the root of the library
- Fix typo in f_net_classifier.py
- add [MASK] in Vocaburay
- remove num_heads parameter 

The number of failed examples has gone down from 5 to 1, however I am getting 1 error in `File "/content/keras-nlp/keras-nlp/keras-nlp/keras_nlp/models/f_net/f_net_masked_lm.py", line 73, in keras_nlp.models.f_net.f_net_masked_lm.FNetMaskedLM`- 

`Node: 'f_net_masked_lm_1/f_net_backbone_3/segment_embedding/embedding_lookup'
    indices[0,3] = 4 is not in [0, 4)
    	 [[{{node f_net_masked_lm_1/f_net_backbone_3/segment_embedding/embedding_lookup}}]] [Op:__inference_train_function_458156]
`
Might need help from @abheesht17 , or any other developer who can assist.
Thanks!
Fixes keras-team/keras-nlp #782