### PR TITLE
Added model card links for all pretrained models.

### DIFF
--- a/keras_nlp/models/albert/albert_presets.py
+++ b/keras_nlp/models/albert/albert_presets.py
@@ -54,7 +54,7 @@ backbone_presets = {
             "params": 17683968,
             "official_name": "ALBERT",
             "path": "albert",
-            "model_card": "https://github.com/google-research/albert/blob/master/README.md"
+            "model_card": "https://github.com/google-research/albert/blob/master/README.md",
         },
         "config": {
             "vocabulary_size": 30000,
@@ -84,7 +84,7 @@ backbone_presets = {
             "params": 58724864,
             "official_name": "ALBERT",
             "path": "albert",
-            "model_card": "https://github.com/google-research/albert/blob/master/README.md"
+            "model_card": "https://github.com/google-research/albert/blob/master/README.md",
         },
         "config": {
             "vocabulary_size": 30000,
@@ -114,7 +114,7 @@ backbone_presets = {
             "params": 222595584,
             "official_name": "ALBERT",
             "path": "albert",
-            "model_card": "https://github.com/google-research/albert/blob/master/README.md"
+            "model_card": "https://github.com/google-research/albert/blob/master/README.md",
         },
         "config": {
             "vocabulary_size": 30000,

--- a/keras_nlp/models/albert/albert_presets.py
+++ b/keras_nlp/models/albert/albert_presets.py
@@ -24,6 +24,7 @@ backbone_presets = {
             "params": 11683584,
             "official_name": "ALBERT",
             "path": "albert",
+            "model_card": "https://github.com/google-research/albert/blob/master/README.md",
         },
         "config": {
             "vocabulary_size": 30000,
@@ -53,6 +54,7 @@ backbone_presets = {
             "params": 17683968,
             "official_name": "ALBERT",
             "path": "albert",
+            "model_card": "https://github.com/google-research/albert/blob/master/README.md"
         },
         "config": {
             "vocabulary_size": 30000,
@@ -82,6 +84,7 @@ backbone_presets = {
             "params": 58724864,
             "official_name": "ALBERT",
             "path": "albert",
+            "model_card": "https://github.com/google-research/albert/blob/master/README.md"
         },
         "config": {
             "vocabulary_size": 30000,
@@ -111,6 +114,7 @@ backbone_presets = {
             "params": 222595584,
             "official_name": "ALBERT",
             "path": "albert",
+            "model_card": "https://github.com/google-research/albert/blob/master/README.md"
         },
         "config": {
             "vocabulary_size": 30000,

--- a/keras_nlp/models/bart/bart_presets.py
+++ b/keras_nlp/models/bart/bart_presets.py
@@ -23,7 +23,7 @@ backbone_presets = {
             "params": 139417344,
             "official_name": "BART",
             "path": "bart",
-            "model_card": "https://huggingface.co/facebook/bart-base",
+            "model_card": "https://github.com/facebookresearch/fairseq/blob/main/examples/bart/README.md",
         },
         "config": {
             "vocabulary_size": 50265,
@@ -51,7 +51,7 @@ backbone_presets = {
             "params": 406287360,
             "official_name": "BART",
             "path": "bart",
-            "model_card": "https://huggingface.co/facebook/bart-large",
+            "model_card": "https://github.com/facebookresearch/fairseq/blob/main/examples/bart/README.md",
         },
         "config": {
             "vocabulary_size": 50265,

--- a/keras_nlp/models/bart/bart_presets.py
+++ b/keras_nlp/models/bart/bart_presets.py
@@ -15,6 +15,16 @@
 
 backbone_presets = {
     "bart_base_en": {
+        "metadata": {
+            "description": (
+                "6-layer BART model where case is maintained. "
+                "Trained on BookCorpus, English Wikipedia and CommonCrawl."
+            ),
+            "params": 139417344,
+            "official_name": "BART",
+            "path": "bart",
+            "model_card": "https://huggingface.co/facebook/bart-base",
+        },
         "config": {
             "vocabulary_size": 50265,
             "num_layers": 6,
@@ -25,15 +35,6 @@ backbone_presets = {
             "max_sequence_length": 1024,
         },
         "preprocessor_config": {},
-        "metadata": {
-            "description": (
-                "6-layer BART model where case is maintained. "
-                "Trained on BookCorpus, English Wikipedia and CommonCrawl."
-            ),
-            "params": 139417344,
-            "official_name": "BART",
-            "path": "bart",
-        },
         "weights_url": "https://storage.googleapis.com/keras-nlp/models/bart_base_en/v1/model.h5",
         "weights_hash": "5b59403f0cafafbd89680e0785791163",
         "vocabulary_url": "https://storage.googleapis.com/keras-nlp/models/bart_base_en/v1/vocab.json",
@@ -42,6 +43,16 @@ backbone_presets = {
         "merges_hash": "75a37753dd7a28a2c5df80c28bf06e4e",
     },
     "bart_large_en": {
+        "metadata": {
+            "description": (
+                "12-layer BART model where case is maintained. "
+                "Trained on BookCorpus, English Wikipedia and CommonCrawl."
+            ),
+            "params": 406287360,
+            "official_name": "BART",
+            "path": "bart",
+            "model_card": "https://huggingface.co/facebook/bart-large",
+        },
         "config": {
             "vocabulary_size": 50265,
             "num_layers": 12,
@@ -52,15 +63,6 @@ backbone_presets = {
             "max_sequence_length": 1024,
         },
         "preprocessor_config": {},
-        "metadata": {
-            "description": (
-                "12-layer BART model where case is maintained. "
-                "Trained on BookCorpus, English Wikipedia and CommonCrawl."
-            ),
-            "params": 406287360,
-            "official_name": "BART",
-            "path": "bart",
-        },
         "weights_url": "https://storage.googleapis.com/keras-nlp/models/bart_large_en/v1/model.h5",
         "weights_hash": "6bfe7e591af8c5699ce6f9f18753af9a",
         "vocabulary_url": "https://storage.googleapis.com/keras-nlp/models/bart_large_en/v1/vocab.json",

--- a/keras_nlp/models/bert/bert_presets.py
+++ b/keras_nlp/models/bert/bert_presets.py
@@ -25,6 +25,7 @@ backbone_presets = {
             "params": 4385920,
             "official_name": "BERT",
             "path": "bert",
+            "model_card": "https://github.com/google-research/bert/blob/master/README.md"
         },
         "config": {
             "vocabulary_size": 30522,
@@ -53,6 +54,7 @@ backbone_presets = {
             "params": 28763648,
             "official_name": "BERT",
             "path": "bert",
+            "model_card": "https://github.com/google-research/bert/blob/master/README.md"
         },
         "config": {
             "vocabulary_size": 30522,
@@ -81,6 +83,7 @@ backbone_presets = {
             "params": 41373184,
             "official_name": "BERT",
             "path": "bert",
+            "model_card": "https://github.com/google-research/bert/blob/master/README.md"
         },
         "config": {
             "vocabulary_size": 30522,
@@ -109,6 +112,7 @@ backbone_presets = {
             "params": 109482240,
             "official_name": "BERT",
             "path": "bert",
+            "model_card": "https://github.com/google-research/bert/blob/master/README.md"
         },
         "config": {
             "vocabulary_size": 30522,
@@ -137,6 +141,7 @@ backbone_presets = {
             "params": 108310272,
             "official_name": "BERT",
             "path": "bert",
+            "model_card": "https://github.com/google-research/bert/blob/master/README.md"
         },
         "config": {
             "vocabulary_size": 28996,
@@ -164,6 +169,7 @@ backbone_presets = {
             "params": 102267648,
             "official_name": "BERT",
             "path": "bert",
+            "model_card": "https://github.com/google-research/bert/blob/master/README.md"
         },
         "config": {
             "vocabulary_size": 21128,
@@ -191,6 +197,7 @@ backbone_presets = {
             "params": 177853440,
             "official_name": "BERT",
             "path": "bert",
+            "model_card": "https://github.com/google-research/bert/blob/master/README.md"
         },
         "config": {
             "vocabulary_size": 119547,
@@ -219,6 +226,7 @@ backbone_presets = {
             "params": 335141888,
             "official_name": "BERT",
             "path": "bert",
+            "model_card": "https://github.com/google-research/bert/blob/master/README.md",
         },
         "config": {
             "vocabulary_size": 30522,
@@ -247,6 +255,7 @@ backbone_presets = {
             "params": 333579264,
             "official_name": "BERT",
             "path": "bert",
+            "model_card": "https://github.com/google-research/bert/blob/master/README.md"
         },
         "config": {
             "vocabulary_size": 28996,
@@ -277,6 +286,7 @@ classifier_presets = {
             "params": 4385920,
             "official_name": "BERT",
             "path": "bert",
+            "model_card": "https://github.com/google-research/bert/blob/master/README.md",        
         },
         "config": {
             "backbone": {

--- a/keras_nlp/models/bert/bert_presets.py
+++ b/keras_nlp/models/bert/bert_presets.py
@@ -25,7 +25,7 @@ backbone_presets = {
             "params": 4385920,
             "official_name": "BERT",
             "path": "bert",
-            "model_card": "https://github.com/google-research/bert/blob/master/README.md"
+            "model_card": "https://github.com/google-research/bert/blob/master/README.md",
         },
         "config": {
             "vocabulary_size": 30522,
@@ -54,7 +54,7 @@ backbone_presets = {
             "params": 28763648,
             "official_name": "BERT",
             "path": "bert",
-            "model_card": "https://github.com/google-research/bert/blob/master/README.md"
+            "model_card": "https://github.com/google-research/bert/blob/master/README.md",
         },
         "config": {
             "vocabulary_size": 30522,
@@ -83,7 +83,7 @@ backbone_presets = {
             "params": 41373184,
             "official_name": "BERT",
             "path": "bert",
-            "model_card": "https://github.com/google-research/bert/blob/master/README.md"
+            "model_card": "https://github.com/google-research/bert/blob/master/README.md",
         },
         "config": {
             "vocabulary_size": 30522,
@@ -112,7 +112,7 @@ backbone_presets = {
             "params": 109482240,
             "official_name": "BERT",
             "path": "bert",
-            "model_card": "https://github.com/google-research/bert/blob/master/README.md"
+            "model_card": "https://github.com/google-research/bert/blob/master/README.md",
         },
         "config": {
             "vocabulary_size": 30522,
@@ -141,7 +141,7 @@ backbone_presets = {
             "params": 108310272,
             "official_name": "BERT",
             "path": "bert",
-            "model_card": "https://github.com/google-research/bert/blob/master/README.md"
+            "model_card": "https://github.com/google-research/bert/blob/master/README.md",
         },
         "config": {
             "vocabulary_size": 28996,
@@ -169,7 +169,7 @@ backbone_presets = {
             "params": 102267648,
             "official_name": "BERT",
             "path": "bert",
-            "model_card": "https://github.com/google-research/bert/blob/master/README.md"
+            "model_card": "https://github.com/google-research/bert/blob/master/README.md",
         },
         "config": {
             "vocabulary_size": 21128,
@@ -197,7 +197,7 @@ backbone_presets = {
             "params": 177853440,
             "official_name": "BERT",
             "path": "bert",
-            "model_card": "https://github.com/google-research/bert/blob/master/README.md"
+            "model_card": "https://github.com/google-research/bert/blob/master/README.md",
         },
         "config": {
             "vocabulary_size": 119547,
@@ -255,7 +255,7 @@ backbone_presets = {
             "params": 333579264,
             "official_name": "BERT",
             "path": "bert",
-            "model_card": "https://github.com/google-research/bert/blob/master/README.md"
+            "model_card": "https://github.com/google-research/bert/blob/master/README.md",
         },
         "config": {
             "vocabulary_size": 28996,
@@ -286,7 +286,7 @@ classifier_presets = {
             "params": 4385920,
             "official_name": "BERT",
             "path": "bert",
-            "model_card": "https://github.com/google-research/bert/blob/master/README.md",        
+            "model_card": "https://github.com/google-research/bert/blob/master/README.md",
         },
         "config": {
             "backbone": {

--- a/keras_nlp/models/deberta_v3/deberta_v3_presets.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_presets.py
@@ -50,7 +50,7 @@ backbone_presets = {
             "params": 141304320,
             "official_name": "DeBERTaV3",
             "path": "deberta_v3",
-            "model_card": "https://huggingface.co/microsoft/deberta-v3-small",            
+            "model_card": "https://huggingface.co/microsoft/deberta-v3-small",
         },
         "config": {
             "vocabulary_size": 128100,
@@ -77,7 +77,7 @@ backbone_presets = {
             "params": 183831552,
             "official_name": "DeBERTaV3",
             "path": "deberta_v3",
-            "model_card": "https://huggingface.co/microsoft/deberta-v3-base"
+            "model_card": "https://huggingface.co/microsoft/deberta-v3-base",
         },
         "config": {
             "vocabulary_size": 128100,

--- a/keras_nlp/models/deberta_v3/deberta_v3_presets.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_presets.py
@@ -15,6 +15,16 @@
 
 backbone_presets = {
     "deberta_v3_extra_small_en": {
+        "metadata": {
+            "description": (
+                "12-layer DeBERTaV3 model where case is maintained. "
+                "Trained on English Wikipedia, BookCorpus and OpenWebText."
+            ),
+            "params": 70682112,
+            "official_name": "DeBERTaV3",
+            "path": "deberta_v3",
+            "model_card": "https://huggingface.co/microsoft/deberta-v3-xsmall",
+        },
         "config": {
             "vocabulary_size": 128100,
             "num_layers": 12,
@@ -26,21 +36,22 @@ backbone_presets = {
             "bucket_size": 256,
         },
         "preprocessor_config": {},
-        "metadata": {
-            "description": (
-                "12-layer DeBERTaV3 model where case is maintained. "
-                "Trained on English Wikipedia, BookCorpus and OpenWebText."
-            ),
-            "params": 70682112,
-            "official_name": "DeBERTaV3",
-            "path": "deberta_v3",
-        },
         "weights_url": "https://storage.googleapis.com/keras-nlp/models/deberta_v3_extra_small_en/v1/model.h5",
         "weights_hash": "d8e10327107e5c5e20b45548a5028619",
         "spm_proto_url": "https://storage.googleapis.com/keras-nlp/models/deberta_v3_extra_small_en/v1/vocab.spm",
         "spm_proto_hash": "1613fcbf3b82999c187b09c9db79b568",
     },
     "deberta_v3_small_en": {
+        "metadata": {
+            "description": (
+                "6-layer DeBERTaV3 model where case is maintained. "
+                "Trained on English Wikipedia, BookCorpus and OpenWebText."
+            ),
+            "params": 141304320,
+            "official_name": "DeBERTaV3",
+            "path": "deberta_v3",
+            "model_card": "https://huggingface.co/microsoft/deberta-v3-small",            
+        },
         "config": {
             "vocabulary_size": 128100,
             "num_layers": 6,
@@ -52,21 +63,22 @@ backbone_presets = {
             "bucket_size": 256,
         },
         "preprocessor_config": {},
-        "metadata": {
-            "description": (
-                "6-layer DeBERTaV3 model where case is maintained. "
-                "Trained on English Wikipedia, BookCorpus and OpenWebText."
-            ),
-            "params": 141304320,
-            "official_name": "DeBERTaV3",
-            "path": "deberta_v3",
-        },
         "weights_url": "https://storage.googleapis.com/keras-nlp/models/deberta_v3_small_en/v1/model.h5",
         "weights_hash": "84118eb7c5a735f2061ecccaf71bb888",
         "spm_proto_url": "https://storage.googleapis.com/keras-nlp/models/deberta_v3_small_en/v1/vocab.spm",
         "spm_proto_hash": "1613fcbf3b82999c187b09c9db79b568",
     },
     "deberta_v3_base_en": {
+        "metadata": {
+            "description": (
+                "12-layer DeBERTaV3 model where case is maintained. "
+                "Trained on English Wikipedia, BookCorpus and OpenWebText."
+            ),
+            "params": 183831552,
+            "official_name": "DeBERTaV3",
+            "path": "deberta_v3",
+            "model_card": "https://huggingface.co/microsoft/deberta-v3-base"
+        },
         "config": {
             "vocabulary_size": 128100,
             "num_layers": 12,
@@ -78,21 +90,22 @@ backbone_presets = {
             "bucket_size": 256,
         },
         "preprocessor_config": {},
-        "metadata": {
-            "description": (
-                "12-layer DeBERTaV3 model where case is maintained. "
-                "Trained on English Wikipedia, BookCorpus and OpenWebText."
-            ),
-            "params": 183831552,
-            "official_name": "DeBERTaV3",
-            "path": "deberta_v3",
-        },
         "weights_url": "https://storage.googleapis.com/keras-nlp/models/deberta_v3_base_en/v1/model.h5",
         "weights_hash": "cebce044aeed36aec9b94e3b8a255430",
         "spm_proto_url": "https://storage.googleapis.com/keras-nlp/models/deberta_v3_base_en/v1/vocab.spm",
         "spm_proto_hash": "1613fcbf3b82999c187b09c9db79b568",
     },
     "deberta_v3_large_en": {
+        "metadata": {
+            "description": (
+                "24-layer DeBERTaV3 model where case is maintained. "
+                "Trained on English Wikipedia, BookCorpus and OpenWebText."
+            ),
+            "params": 434012160,
+            "official_name": "DeBERTaV3",
+            "path": "deberta_v3",
+            "model_card": "https://huggingface.co/microsoft/deberta-v3-large",
+        },
         "config": {
             "vocabulary_size": 128100,
             "num_layers": 24,
@@ -104,21 +117,22 @@ backbone_presets = {
             "bucket_size": 256,
         },
         "preprocessor_config": {},
-        "metadata": {
-            "description": (
-                "24-layer DeBERTaV3 model where case is maintained. "
-                "Trained on English Wikipedia, BookCorpus and OpenWebText."
-            ),
-            "params": 434012160,
-            "official_name": "DeBERTaV3",
-            "path": "deberta_v3",
-        },
         "weights_url": "https://storage.googleapis.com/keras-nlp/models/deberta_v3_large_en/v1/model.h5",
         "weights_hash": "bce7690f358a9e39304f8c0ebc71a745",
         "spm_proto_url": "https://storage.googleapis.com/keras-nlp/models/deberta_v3_large_en/v1/vocab.spm",
         "spm_proto_hash": "1613fcbf3b82999c187b09c9db79b568",
     },
     "deberta_v3_base_multi": {
+        "metadata": {
+            "description": (
+                "12-layer DeBERTaV3 model where case is maintained. "
+                "Trained on the 2.5TB multilingual CC100 dataset."
+            ),
+            "params": 278218752,
+            "official_name": "DeBERTaV3",
+            "path": "deberta_v3",
+            "model_card": "https://huggingface.co/microsoft/mdeberta-v3-base",
+        },
         "config": {
             "vocabulary_size": 251000,
             "num_layers": 12,
@@ -130,15 +144,6 @@ backbone_presets = {
             "bucket_size": 256,
         },
         "preprocessor_config": {},
-        "metadata": {
-            "description": (
-                "12-layer DeBERTaV3 model where case is maintained. "
-                "Trained on the 2.5TB multilingual CC100 dataset."
-            ),
-            "params": 278218752,
-            "official_name": "DeBERTaV3",
-            "path": "deberta_v3",
-        },
         "weights_url": "https://storage.googleapis.com/keras-nlp/models/deberta_v3_base_multi/v1/model.h5",
         "weights_hash": "26e5a824b26afd2ee336835bd337bbeb",
         "spm_proto_url": "https://storage.googleapis.com/keras-nlp/models/deberta_v3_base_multi/v1/vocab.spm",

--- a/keras_nlp/models/distil_bert/distil_bert_presets.py
+++ b/keras_nlp/models/distil_bert/distil_bert_presets.py
@@ -24,6 +24,7 @@ backbone_presets = {
             "params": 66362880,
             "official_name": "DistilBERT",
             "path": "distil_bert",
+            "model_card": "https://huggingface.co/distilbert-base-uncased",
         },
         "config": {
             "vocabulary_size": 30522,
@@ -52,6 +53,7 @@ backbone_presets = {
             "params": 65190912,
             "official_name": "DistilBERT",
             "path": "distil_bert",
+            "model_card": "https://huggingface.co/distilbert-base-cased",
         },
         "config": {
             "vocabulary_size": 28996,
@@ -78,6 +80,7 @@ backbone_presets = {
             "params": 134734080,
             "official_name": "DistilBERT",
             "path": "distil_bert",
+            "model_card": "https://huggingface.co/distilbert-base-multilingual-cased",
         },
         "config": {
             "vocabulary_size": 119547,

--- a/keras_nlp/models/f_net/f_net_presets.py
+++ b/keras_nlp/models/f_net/f_net_presets.py
@@ -15,6 +15,16 @@
 
 backbone_presets = {
     "f_net_base_en": {
+        "metadata": {
+            "description": (
+                "12-layer FNet model where case is maintained. "
+                "Trained on the C4 dataset."
+            ),
+            "params": 82861056,
+            "official_name": "FNet",
+            "path": "f_net",
+            "model_card": "https://huggingface.co/google/fnet-base",
+        },
         "config": {
             "vocabulary_size": 32000,
             "num_layers": 12,
@@ -25,21 +35,22 @@ backbone_presets = {
             "num_segments": 4,
         },
         "preprocessor_config": {},
-        "metadata": {
-            "description": (
-                "12-layer FNet model where case is maintained. "
-                "Trained on the C4 dataset."
-            ),
-            "params": 82861056,
-            "official_name": "FNet",
-            "path": "f_net",
-        },
         "weights_url": "https://storage.googleapis.com/keras-nlp/models/f_net_base_en/v1/model.h5",
         "weights_hash": "35db90842b85a985a0e54c86c00746fe",
         "spm_proto_url": "https://storage.googleapis.com/keras-nlp/models/f_net_base_en/v1/vocab.spm",
         "spm_proto_hash": "71c5f4610bef1daf116998a113a01f3d",
     },
     "f_net_large_en": {
+        "metadata": {
+            "description": (
+                "24-layer FNet model where case is maintained. "
+                "Trained on the C4 dataset."
+            ),
+            "params": 236945408,
+            "official_name": "FNet",
+            "path": "f_net",
+            "model_card": "https://huggingface.co/google/fnet-large",
+        },
         "config": {
             "vocabulary_size": 32000,
             "num_layers": 24,
@@ -50,15 +61,6 @@ backbone_presets = {
             "num_segments": 4,
         },
         "preprocessor_config": {},
-        "metadata": {
-            "description": (
-                "24-layer FNet model where case is maintained. "
-                "Trained on the C4 dataset."
-            ),
-            "params": 236945408,
-            "official_name": "FNet",
-            "path": "f_net",
-        },
         "weights_url": "https://storage.googleapis.com/keras-nlp/models/f_net_large_en/v1/model.h5",
         "weights_hash": "7ae4a3faa67ff054f8cecffb5619f779",
         "spm_proto_url": "https://storage.googleapis.com/keras-nlp/models/f_net_large_en/v1/vocab.spm",

--- a/keras_nlp/models/f_net/f_net_presets.py
+++ b/keras_nlp/models/f_net/f_net_presets.py
@@ -23,7 +23,7 @@ backbone_presets = {
             "params": 82861056,
             "official_name": "FNet",
             "path": "f_net",
-            "model_card": "https://huggingface.co/google/fnet-base",
+            "model_card": "https://github.com/google-research/google-research/blob/master/f_net/README.md",
         },
         "config": {
             "vocabulary_size": 32000,
@@ -49,7 +49,7 @@ backbone_presets = {
             "params": 236945408,
             "official_name": "FNet",
             "path": "f_net",
-            "model_card": "https://huggingface.co/google/fnet-large",
+            "model_card": "https://github.com/google-research/google-research/blob/master/f_net/README.md",
         },
         "config": {
             "vocabulary_size": 32000,

--- a/keras_nlp/models/gpt2/gpt2_presets.py
+++ b/keras_nlp/models/gpt2/gpt2_presets.py
@@ -56,7 +56,6 @@ backbone_presets = {
             "official_name": "GPT-2",
             "path": "gpt2",
             "model_card": "https://github.com/openai/gpt-2/blob/master/model_card.md",
-
         },
         "config": {
             "vocabulary_size": 50257,

--- a/keras_nlp/models/gpt2/gpt2_presets.py
+++ b/keras_nlp/models/gpt2/gpt2_presets.py
@@ -24,6 +24,7 @@ backbone_presets = {
             "params": 124439808,
             "official_name": "GPT-2",
             "path": "gpt2",
+            "model_card": "https://github.com/openai/gpt-2/blob/master/model_card.md",
         },
         "config": {
             "vocabulary_size": 50257,
@@ -54,6 +55,8 @@ backbone_presets = {
             "params": 354823168,
             "official_name": "GPT-2",
             "path": "gpt2",
+            "model_card": "https://github.com/openai/gpt-2/blob/master/model_card.md",
+
         },
         "config": {
             "vocabulary_size": 50257,
@@ -84,6 +87,7 @@ backbone_presets = {
             "params": 774030080,
             "official_name": "GPT-2",
             "path": "gpt2",
+            "model_card": "https://github.com/openai/gpt-2/blob/master/model_card.md",
         },
         "config": {
             "vocabulary_size": 50257,
@@ -114,6 +118,7 @@ backbone_presets = {
             "params": 1557611200,
             "official_name": "GPT-2",
             "path": "gpt2",
+            "model_card": "https://github.com/openai/gpt-2/blob/master/model_card.md",
         },
         "config": {
             "vocabulary_size": 50257,

--- a/keras_nlp/models/gpt2/gpt2_presets.py
+++ b/keras_nlp/models/gpt2/gpt2_presets.py
@@ -36,9 +36,6 @@ backbone_presets = {
             "max_sequence_length": 1024,
         },
         "preprocessor_config": {},
-        "description": (
-            "Base size of GPT-2 with 124M parameters. Trained on WebText."
-        ),
         "weights_url": "https://storage.googleapis.com/keras-nlp/models/gpt2_base_en/v1/model.h5",
         "weights_hash": "f4ea6e1b214516dd7de452461ee6e16e",
         "vocabulary_url": "https://storage.googleapis.com/keras-nlp/models/gpt2_base_en/v1/vocab.json",
@@ -67,9 +64,6 @@ backbone_presets = {
             "max_sequence_length": 1024,
         },
         "preprocessor_config": {},
-        "description": (
-            "Medium size of GPT-2 with 355M parameters. Trained on WebText."
-        ),
         "weights_url": "https://storage.googleapis.com/keras-nlp/models/gpt2_medium_en/v1/model.h5",
         "weights_hash": "580ff9b79c04fc90e6d6f47e975c5afe",
         "vocabulary_url": "https://storage.googleapis.com/keras-nlp/models/gpt2_medium_en/v1/vocab.json",
@@ -98,9 +92,6 @@ backbone_presets = {
             "max_sequence_length": 1024,
         },
         "preprocessor_config": {},
-        "description": (
-            "Large size of GPT-2 with 774M parameters. Trained on WebText."
-        ),
         "weights_url": "https://storage.googleapis.com/keras-nlp/models/gpt2_large_en/v1/model.h5",
         "weights_hash": "67957cb3dfc9e965960dabe068811e1a",
         "vocabulary_url": "https://storage.googleapis.com/keras-nlp/models/gpt2_large_en/v1/vocab.json",
@@ -129,10 +120,6 @@ backbone_presets = {
             "max_sequence_length": 1024,
         },
         "preprocessor_config": {},
-        "description": (
-            "Extra large size of GPT-2 with 1558M parameters. "
-            "Trained on WebText."
-        ),
         "weights_url": "https://storage.googleapis.com/keras-nlp/models/gpt2_extra_large_en/v1/model.h5",
         "weights_hash": "d093c1ee0d9705d845c0190909aa2917",
         "vocabulary_url": "https://storage.googleapis.com/keras-nlp/models/gpt2_extra_large_en/v1/vocab.json",

--- a/keras_nlp/models/opt/opt_presets.py
+++ b/keras_nlp/models/opt/opt_presets.py
@@ -24,7 +24,7 @@ backbone_presets = {
             "params": 125237760,
             "official_name": "OPT",
             "path": "opt",
-            "model_card": "https://huggingface.co/facebook/opt-125m",
+            "model_card": "https://ar5iv.labs.arxiv.org/html/2205.01068#:~:text=D.1-,Model%20Details,-%E2%80%A2%20Person%20or",
         },
         "config": {
             "vocabulary_size": 50272,
@@ -54,7 +54,7 @@ backbone_presets = {
             "params": 1315753984,
             "official_name": "OPT",
             "path": "opt",
-            "model_card": "https://huggingface.co/facebook/opt-1.3b",
+            "model_card": "https://ar5iv.labs.arxiv.org/html/2205.01068#:~:text=D.1-,Model%20Details,-%E2%80%A2%20Person%20or",
         },
         "config": {
             "vocabulary_size": 50272,
@@ -82,7 +82,7 @@ backbone_presets = {
             "params": 2700000000,
             "official_name": "OPT",
             "path": "opt",
-            "model_card": "https://huggingface.co/facebook/opt-2.7b",
+            "model_card": "https://ar5iv.labs.arxiv.org/html/2205.01068#:~:text=D.1-,Model%20Details,-%E2%80%A2%20Person%20or",
         },
         "config": {
             "vocabulary_size": 50272,
@@ -110,7 +110,7 @@ backbone_presets = {
             "params": 6700000000,
             "official_name": "OPT",
             "path": "opt",
-            "model_card": "https://huggingface.co/facebook/opt-6.7b",
+            "model_card": "https://ar5iv.labs.arxiv.org/html/2205.01068#:~:text=D.1-,Model%20Details,-%E2%80%A2%20Person%20or",
         },
         "config": {
             "vocabulary_size": 50272,

--- a/keras_nlp/models/opt/opt_presets.py
+++ b/keras_nlp/models/opt/opt_presets.py
@@ -24,7 +24,7 @@ backbone_presets = {
             "params": 125237760,
             "official_name": "OPT",
             "path": "opt",
-            "model_card": "https://ar5iv.labs.arxiv.org/html/2205.01068#:~:text=D.1-,Model%20Details,-%E2%80%A2%20Person%20or",
+            "model_card": "https://github.com/facebookresearch/metaseq/blob/main/projects/OPT/model_card.md",
         },
         "config": {
             "vocabulary_size": 50272,
@@ -54,7 +54,7 @@ backbone_presets = {
             "params": 1315753984,
             "official_name": "OPT",
             "path": "opt",
-            "model_card": "https://ar5iv.labs.arxiv.org/html/2205.01068#:~:text=D.1-,Model%20Details,-%E2%80%A2%20Person%20or",
+            "model_card": "https://github.com/facebookresearch/metaseq/blob/main/projects/OPT/model_card.md",
         },
         "config": {
             "vocabulary_size": 50272,
@@ -82,7 +82,7 @@ backbone_presets = {
             "params": 2700000000,
             "official_name": "OPT",
             "path": "opt",
-            "model_card": "https://ar5iv.labs.arxiv.org/html/2205.01068#:~:text=D.1-,Model%20Details,-%E2%80%A2%20Person%20or",
+            "model_card": "https://github.com/facebookresearch/metaseq/blob/main/projects/OPT/model_card.md",
         },
         "config": {
             "vocabulary_size": 50272,
@@ -110,7 +110,7 @@ backbone_presets = {
             "params": 6700000000,
             "official_name": "OPT",
             "path": "opt",
-            "model_card": "https://ar5iv.labs.arxiv.org/html/2205.01068#:~:text=D.1-,Model%20Details,-%E2%80%A2%20Person%20or",
+            "model_card": "https://github.com/facebookresearch/metaseq/blob/main/projects/OPT/model_card.md",
         },
         "config": {
             "vocabulary_size": 50272,

--- a/keras_nlp/models/opt/opt_presets.py
+++ b/keras_nlp/models/opt/opt_presets.py
@@ -82,7 +82,7 @@ backbone_presets = {
             "params": 2700000000,
             "official_name": "OPT",
             "path": "opt",
-            "model_card": "https://huggingface.co/facebook/opt-2.7b"
+            "model_card": "https://huggingface.co/facebook/opt-2.7b",
         },
         "config": {
             "vocabulary_size": 50272,
@@ -110,7 +110,7 @@ backbone_presets = {
             "params": 6700000000,
             "official_name": "OPT",
             "path": "opt",
-            "model_card": "https://huggingface.co/facebook/opt-6.7b"
+            "model_card": "https://huggingface.co/facebook/opt-6.7b",
         },
         "config": {
             "vocabulary_size": 50272,

--- a/keras_nlp/models/opt/opt_presets.py
+++ b/keras_nlp/models/opt/opt_presets.py
@@ -24,6 +24,7 @@ backbone_presets = {
             "params": 125237760,
             "official_name": "OPT",
             "path": "opt",
+            "model_card": "https://huggingface.co/facebook/opt-125m",
         },
         "config": {
             "vocabulary_size": 50272,
@@ -53,6 +54,7 @@ backbone_presets = {
             "params": 1315753984,
             "official_name": "OPT",
             "path": "opt",
+            "model_card": "https://huggingface.co/facebook/opt-1.3b",
         },
         "config": {
             "vocabulary_size": 50272,
@@ -80,6 +82,7 @@ backbone_presets = {
             "params": 2700000000,
             "official_name": "OPT",
             "path": "opt",
+            "model_card": "https://huggingface.co/facebook/opt-2.7b"
         },
         "config": {
             "vocabulary_size": 50272,
@@ -107,6 +110,7 @@ backbone_presets = {
             "params": 6700000000,
             "official_name": "OPT",
             "path": "opt",
+            "model_card": "https://huggingface.co/facebook/opt-6.7b"
         },
         "config": {
             "vocabulary_size": 50272,

--- a/keras_nlp/models/roberta/roberta_presets.py
+++ b/keras_nlp/models/roberta/roberta_presets.py
@@ -23,7 +23,7 @@ backbone_presets = {
             "params": 124052736,
             "official_name": "RoBERTa",
             "path": "roberta",
-            "model_card": "https://huggingface.co/roberta-base",
+            "model_card": "https://github.com/facebookresearch/fairseq/blob/main/examples/roberta/README.md",
         },
         "config": {
             "vocabulary_size": 50265,
@@ -51,7 +51,7 @@ backbone_presets = {
             "params": 354307072,
             "official_name": "RoBERTa",
             "path": "roberta",
-            "model_card": "https://huggingface.co/roberta-large",
+            "model_card": "https://github.com/facebookresearch/fairseq/blob/main/examples/roberta/README.md",
         },
         "config": {
             "vocabulary_size": 50265,

--- a/keras_nlp/models/roberta/roberta_presets.py
+++ b/keras_nlp/models/roberta/roberta_presets.py
@@ -23,6 +23,7 @@ backbone_presets = {
             "params": 124052736,
             "official_name": "RoBERTa",
             "path": "roberta",
+            "model_card": "https://huggingface.co/roberta-base",
         },
         "config": {
             "vocabulary_size": 50265,
@@ -50,6 +51,7 @@ backbone_presets = {
             "params": 354307072,
             "official_name": "RoBERTa",
             "path": "roberta",
+            "model_card": "https://huggingface.co/roberta-large"
         },
         "config": {
             "vocabulary_size": 50265,

--- a/keras_nlp/models/roberta/roberta_presets.py
+++ b/keras_nlp/models/roberta/roberta_presets.py
@@ -51,7 +51,7 @@ backbone_presets = {
             "params": 354307072,
             "official_name": "RoBERTa",
             "path": "roberta",
-            "model_card": "https://huggingface.co/roberta-large"
+            "model_card": "https://huggingface.co/roberta-large",
         },
         "config": {
             "vocabulary_size": 50265,

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_presets.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_presets.py
@@ -23,7 +23,7 @@ backbone_presets = {
             "params": 277450752,
             "official_name": "XLM-RoBERTa",
             "path": "xlm_roberta",
-            "model_card": "https://github.com/facebookresearch/fairseq/tree/main/examples/xlmr",
+            "model_card": "https://github.com/facebookresearch/fairseq/blob/main/examples/xlmr/README.md",
         },
         "config": {
             "vocabulary_size": 250002,
@@ -49,7 +49,7 @@ backbone_presets = {
             "params": 558837760,
             "official_name": "XLM-RoBERTa",
             "path": "xlm_roberta",
-            "model_card": "https://github.com/facebookresearch/fairseq/tree/main/examples/xlmr",
+            "model_card": "https://github.com/facebookresearch/fairseq/blob/main/examples/xlmr/README.md",
         },
         "config": {
             "vocabulary_size": 250002,

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_presets.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_presets.py
@@ -23,6 +23,7 @@ backbone_presets = {
             "params": 277450752,
             "official_name": "XLM-RoBERTa",
             "path": "xlm_roberta",
+            "model_card": "https://huggingface.co/xlm-roberta-base",
         },
         "config": {
             "vocabulary_size": 250002,
@@ -48,6 +49,7 @@ backbone_presets = {
             "params": 558837760,
             "official_name": "XLM-RoBERTa",
             "path": "xlm_roberta",
+            "model_card": "https://huggingface.co/xlm-roberta-large",
         },
         "config": {
             "vocabulary_size": 250002,

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_presets.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_presets.py
@@ -23,7 +23,7 @@ backbone_presets = {
             "params": 277450752,
             "official_name": "XLM-RoBERTa",
             "path": "xlm_roberta",
-            "model_card": "https://huggingface.co/xlm-roberta-base",
+            "model_card": "https://github.com/facebookresearch/fairseq/tree/main/examples/xlmr",
         },
         "config": {
             "vocabulary_size": 250002,
@@ -49,7 +49,7 @@ backbone_presets = {
             "params": 558837760,
             "official_name": "XLM-RoBERTa",
             "path": "xlm_roberta",
-            "model_card": "https://huggingface.co/xlm-roberta-large",
+            "model_card": "https://github.com/facebookresearch/fairseq/tree/main/examples/xlmr",
         },
         "config": {
             "vocabulary_size": 250002,


### PR DESCRIPTION
Fixes: #789 

@mattdangerw I have added `model_card` for all pre-trained models under `metadata`. 

I have used model_cards provided by [huggingface](huggingface.co) which are officially maintained by the organization or mentioned in the official paper for each of the models. BART & OPT models are maintained by Facebook, DeBERTa-V3 are maintained by Microsoft, RoBERTa, DistilBERT, and XLM_RoBERTa are maintained by hf-maintainers and FNet is maintained by Google.

Since not all models under BERT was maintained officially at huggingface, I have added a link to the README file for all BERT model.

For GPT-2 I have added a link to model_card present on their Github.

I am thinking to render the model card in one of the following ways:


 <img src="https://user-images.githubusercontent.com/60005585/222231711-26b6829e-eaa3-406d-8f1f-be714826c433.png">

<img src="https://user-images.githubusercontent.com/60005585/222235575-24323bd7-2011-4321-b439-e6f85758b96e.png">


My plan is to integrate model card from first way into [keras-io](https://keras.io/).

Awaiting for your suggestions to this PR.


