### PR TITLE
Move generate compilation to the task model

### DIFF
--- a/keras_nlp/models/gpt2/gpt2_causal_lm.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm.py
@@ -280,7 +280,7 @@ class GPT2CausalLM(Task):
                 cache_index = index - 1
                 prompt = tf.slice(prompt, [0, cache_index], [-1, 1])
                 probs, state = self.call_with_cache(
-                    prompt, padding_mask, state, cache_index
+                    prompt, tf.ones_like(prompt), state, cache_index
                 )
                 return tf.squeeze(probs, axis=1), state
 

--- a/keras_nlp/models/gpt2/gpt2_causal_lm.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm.py
@@ -297,8 +297,8 @@ class GPT2CausalLM(Task):
                 # The cache index is for our previous token.
                 cache_index = index - 1
                 prompt = tf.slice(prompt, [0, cache_index], [-1, 1])
-                probs, state = self.call_with_cache(prompt, state, cache_index)
-                return tf.squeeze(probs, axis=1), state
+                logits, state = self.call_with_cache(prompt, state, cache_index)
+                return tf.squeeze(logits, axis=1), state
 
             return self.sampler(
                 next=next,

--- a/keras_nlp/models/gpt2/gpt2_causal_lm_test.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm_test.py
@@ -122,18 +122,17 @@ class GPT2CausalLMTest(tf.test.TestCase, parameterized.TestCase):
         self.causal_lm_no_preprocessing.fit(self.preprocessed_dataset)
 
     @parameterized.named_parameters(
-        ("non_jit_compile_cache", False, True),
-        ("non_jit_compile_non_cache", False, False),
-        ("jit_compile_non_cache", True, False),
+        ("jit_compile_false", False), ("jit_compile_true", True)
     )
-    def test_gpt2_causal_lm_generate(self, jit_compile, use_cache):
+    def test_compilation(self, jit_compile):
+        # Tensor input.
         self.causal_lm.compile(jit_compile=jit_compile)
         self.causal_lm.generate(
             self.raw_batch,
             max_length=10,
         )
-
-        # String input
+        first_fn = self.causal_lm.generate_function
+        # String input.
         prompt = " airplane"
         generated = self.causal_lm.generate(
             prompt,
@@ -141,6 +140,9 @@ class GPT2CausalLMTest(tf.test.TestCase, parameterized.TestCase):
         )
         generated = generated.numpy().decode("utf-8")
         self.assertTrue(prompt in generated)
+        second_fn = self.causal_lm.generate_function
+        # Assert we did not recompile.
+        self.assertEqual(first_fn, second_fn)
 
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),

--- a/keras_nlp/models/gpt2/gpt2_causal_lm_test.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm_test.py
@@ -143,6 +143,8 @@ class GPT2CausalLMTest(tf.test.TestCase, parameterized.TestCase):
         second_fn = self.causal_lm.generate_function
         # Assert we did not recompile.
         self.assertEqual(first_fn, second_fn)
+        self.causal_lm.compile(sampler="greedy")
+        self.assertIsNone(self.causal_lm.generate_function)
 
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),

--- a/keras_nlp/models/gpt2/gpt2_causal_lm_test.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm_test.py
@@ -124,7 +124,7 @@ class GPT2CausalLMTest(tf.test.TestCase, parameterized.TestCase):
     @parameterized.named_parameters(
         ("jit_compile_false", False), ("jit_compile_true", True)
     )
-    def test_compilation(self, jit_compile):
+    def test_generate(self, jit_compile):
         # Tensor input.
         self.causal_lm.compile(jit_compile=jit_compile)
         self.causal_lm.generate(

--- a/keras_nlp/samplers/beam_sampler.py
+++ b/keras_nlp/samplers/beam_sampler.py
@@ -73,8 +73,8 @@ class BeamSampler(Sampler):
         self,
         next,
         prompt,
-        index=0,
         state=None,
+        index=0,
         mask=None,
         end_token_id=None,
     ):

--- a/keras_nlp/samplers/beam_sampler.py
+++ b/keras_nlp/samplers/beam_sampler.py
@@ -129,7 +129,7 @@ class BeamSampler(Sampler):
             next_token = flatten(indices % vocab_size)
             # We need `ensure_shape` as `top_k` will change the static shape.
             next_log_probs = flatten(next_log_probs)
-            log_probs = tf.ensure_shape(log_probs, log_probs.shape)
+            log_probs = tf.ensure_shape(next_log_probs, log_probs.shape)
 
             def gather_beams(x):
                 x = unflatten(x)

--- a/keras_nlp/samplers/beam_sampler.py
+++ b/keras_nlp/samplers/beam_sampler.py
@@ -19,14 +19,11 @@ from tensorflow import keras
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.samplers.sampler import Sampler
-from keras_nlp.samplers.sampler import base_sampler_args_docstring
 from keras_nlp.samplers.sampler import call_args_docstring
 from keras_nlp.utils.python_utils import format_docstring
 
 
-@format_docstring(
-    base_sampler_args=base_sampler_args_docstring, call_args=call_args_docstring
-)
+@format_docstring(call_args=call_args_docstring)
 @keras_nlp_export("keras_nlp.samplers.BeamSampler")
 class BeamSampler(Sampler):
     """Beam Sampler class.
@@ -39,7 +36,6 @@ class BeamSampler(Sampler):
     Args:
         num_beams: int. The number of beams that should be kept at each
             time-step. `num_beams` should be strictly positive.
-        {{base_sampler_args}}
 
     Call Args:
         {{call_args}}

--- a/keras_nlp/samplers/beam_sampler_test.py
+++ b/keras_nlp/samplers/beam_sampler_test.py
@@ -32,8 +32,8 @@ class BeamSamplerTest(tf.test.TestCase, parameterized.TestCase):
 
         def next(prompt, state, index):
             # Return a probability distribution favoring the next char in state.
-            probs = tf.one_hot(state[:, index], self.vocab_size) * 1e9
-            return probs, state
+            logits = tf.one_hot(state[:, index], self.vocab_size) * 1e9
+            return logits, state
 
         self.next = next
         self.sampler = BeamSampler(num_beams=5)
@@ -44,9 +44,9 @@ class BeamSamplerTest(tf.test.TestCase, parameterized.TestCase):
     def test_stateless(self):
         def next(prompt, state, index):
             # Return a probability distribution favoring the first index.
-            probs = np.zeros((self.batch_size, self.vocab_size))
-            probs[:, 0] = 1e9
-            return tf.constant(probs, dtype="float32"), state
+            logits = np.zeros((self.batch_size, self.vocab_size))
+            logits[:, 0] = 1e9
+            return tf.constant(logits, dtype="float32"), state
 
         prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
         output = self.sampler(

--- a/keras_nlp/samplers/beam_sampler_test.py
+++ b/keras_nlp/samplers/beam_sampler_test.py
@@ -31,7 +31,7 @@ class BeamSamplerTest(tf.test.TestCase, parameterized.TestCase):
         self.vocab_size = len(self.int_lookup)
 
         def next(prompt, state, index):
-            # Return a probability distribution favoring the next char in state.
+            # Return a distribution favoring the next char in state.
             logits = tf.one_hot(state[:, index], self.vocab_size) * 1e9
             return logits, state
 
@@ -41,9 +41,9 @@ class BeamSamplerTest(tf.test.TestCase, parameterized.TestCase):
     def join_as_string(self, x):
         return ["".join([self.int_lookup[i] for i in s]) for s in x.numpy()]
 
-    def test_stateless(self):
+    def test_stateless_call(self):
         def next(prompt, state, index):
-            # Return a probability distribution favoring the first index.
+            # Return a distribution favoring the first token in the vocab.
             logits = np.zeros((self.batch_size, self.vocab_size))
             logits[:, 0] = 1e9
             return tf.constant(logits, dtype="float32"), state
@@ -56,7 +56,7 @@ class BeamSamplerTest(tf.test.TestCase, parameterized.TestCase):
         )
         self.assertEqual(self.join_as_string(output), ["zzzzzaaaaaaa"])
 
-    def test_stateful(self):
+    def test_stateful_call(self):
         state_chars = list("sequentially")
         state = tf.constant([[self.char_lookup[c] for c in state_chars]])
         prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])

--- a/keras_nlp/samplers/beam_sampler_test.py
+++ b/keras_nlp/samplers/beam_sampler_test.py
@@ -13,136 +13,83 @@
 # limitations under the License.
 """Tests for Beam sampler."""
 
-import random
-
+import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
 from keras_nlp.samplers.beam_sampler import BeamSampler
-from keras_nlp.samplers.greedy_sampler import GreedySampler
 
 
 class BeamSamplerTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
         super().setUp()
-        self.vocab_size = 10
-        self.feature_size = 16
+        # Use a simple alphabet of lowercase characters to [0, 26).
+        self.int_lookup = {i: chr(i + ord("a")) for i in range(26)}
+        self.char_lookup = {v: k for k, v in self.int_lookup.items()}
+        self.batch_size = 1
+        self.length = 12
+        self.vocab_size = len(self.int_lookup)
 
-        # Create a dummy model to predict the next token.
-        model = keras.Sequential(
-            [
-                keras.Input(shape=[None]),
-                keras.layers.Embedding(
-                    input_dim=self.vocab_size,
-                    output_dim=self.feature_size,
-                ),
-                keras.layers.Dense(self.vocab_size),
-            ]
+        def next(prompt, state, index):
+            # Return a probability distribution favoring the next char in state.
+            probs = tf.one_hot(state[:, index], self.vocab_size) * 1e9
+            return probs, state
+
+        self.next = next
+        self.sampler = BeamSampler(num_beams=5)
+
+    def join_as_string(self, x):
+        return ["".join([self.int_lookup[i] for i in s]) for s in x.numpy()]
+
+    def test_stateless(self):
+        def next(prompt, state, index):
+            # Return a probability distribution favoring the first index.
+            probs = np.zeros((self.batch_size, self.vocab_size))
+            probs[:, 0] = 1e9
+            return tf.constant(probs, dtype="float32"), state
+
+        prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
+        output = self.sampler(
+            next=next,
+            prompt=prompt,
+            index=5,
         )
+        self.assertEqual(self.join_as_string(output), ["zzzzzaaaaaaa"])
 
-        def token_probability_fn(inputs, mask):
-            return model(inputs)
+    def test_stateful(self):
+        state_chars = list("sequentially")
+        state = tf.constant([[self.char_lookup[c] for c in state_chars]])
+        prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
+        output = self.sampler(
+            next=self.next,
+            prompt=prompt,
+            state=state,
+        )
+        self.assertEqual(self.join_as_string(output), ["sequentially"])
 
-        self.token_probability_fn = token_probability_fn
-        self.sampler = BeamSampler(num_beams=2)
-
-    def test_generate_with_1d_prompt(self):
-        inputs = tf.constant([1])
-        outputs = self.sampler(inputs, self.token_probability_fn, max_length=5)
-        self.assertEqual(outputs.shape, [5])
-
-    def test_generate_with_2d_prompt(self):
-        inputs = tf.constant([[1], [1]])
-        outputs = self.sampler(inputs, self.token_probability_fn, max_length=5)
-        self.assertEqual(outputs.shape, [2, 5])
-
-    def test_generate_with_list_prompt(self):
-        inputs = [[1], [1]]
-        outputs = self.sampler(inputs, self.token_probability_fn, max_length=5)
-        self.assertEqual(outputs.shape, [2, 5])
-
-    def test_generate_with_ragged_prompt(self):
-        def token_probability_fn(inputs, mask):
-            batch_size, seq_length = tf.shape(inputs)[0], tf.shape(inputs)[1]
-            prob = tf.constant([[[0.0, 0.0, 0.0, 1.0]]])
-            return tf.tile(prob, [batch_size, seq_length, 1])
-
-        inputs = tf.ragged.constant([[1], [2, 1, 2]])
-        outputs = self.sampler(inputs, token_probability_fn, max_length=5)
-        self.assertEqual(outputs.shape, [2, 5])
-
-    def test_one_beam_generation(self):
-        for _ in range(5):
-            inputs = tf.constant([random.randint(0, 9)])
-            beam_sampler = BeamSampler(num_beams=1)
-            greedy_sampler = GreedySampler()
-            beam_output = beam_sampler(
-                inputs,
-                self.token_probability_fn,
-                max_length=5,
-            )
-            greedy_output = greedy_sampler(
-                inputs,
-                self.token_probability_fn,
-                max_length=5,
-            )
-            self.assertAllEqual(beam_output, greedy_output)
+    def test_early_stopping(self):
+        state_chars = list("sequentially")
+        state = tf.constant([[self.char_lookup[c] for c in state_chars]])
+        prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
+        output = self.sampler(
+            next=self.next,
+            prompt=prompt,
+            state=state,
+            end_token_id=self.char_lookup["t"],
+        )
+        self.assertEqual(self.join_as_string(output), ["sequentzzzzz"])
 
     @parameterized.named_parameters(
-        ("xla_graph", True, False),
-        ("non_xla_graph", False, False),
-        ("eager", False, True),
+        ("jit_compile_false", False), ("jit_compile_true", True)
     )
-    def test_assert_generation_is_correct(self, jit_compile, run_eagerly):
-        def token_probability_fn(inputs, mask):
-            batch_size, seq_length = tf.shape(inputs)[0], tf.shape(inputs)[1]
-            prob = tf.constant([[[0.0, 0.0, 0.0, 1.0]]])
-            return tf.tile(prob, [batch_size, seq_length, 1])
+    def test_compilation(self, jit_compile):
+        state_chars = list("sequentially")
+        state = tf.constant([[self.char_lookup[c] for c in state_chars]])
+        prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
 
-        batch_size = 10
-        inputs = 3 * tf.ones([batch_size, 1], dtype=tf.int32)
-        max_length = 3
-        for i in range(1, 5):
-            sampler = BeamSampler(
-                num_beams=i,
-                jit_compile=jit_compile,
-                run_eagerly=run_eagerly,
-            )
-            outputs = sampler(
-                inputs,
-                token_probability_fn,
-                max_length=max_length,
-            )
-            self.assertAllEqual(
-                outputs, 3 * tf.ones(shape=[batch_size, max_length])
-            )
+        @tf.function(jit_compile=jit_compile)
+        def generate(prompt, state):
+            return self.sampler(self.next, prompt=prompt, state=state)
 
-    def test_end_token_id(self):
-        def token_probability_fn(inputs, mask):
-            batch_size, seq_length = tf.shape(inputs)[0], tf.shape(inputs)[1]
-            prob = tf.constant([[[0.0, 0.0, 0.0, 1.0]]])
-            return tf.tile(prob, [batch_size, seq_length, 1])
-
-        max_length = 4
-        inputs = tf.constant([[0, 1], [1, 2]])
-        outputs = self.sampler(
-            inputs,
-            token_probability_fn,
-            max_length=max_length,
-            end_token_id=2,
-        )
-        # end_token in prompt does not trigger truncation.
-        expected_outputs = tf.ragged.constant([[0, 1, 3, 3], [1, 2, 3, 3]])
-        self.assertAllEqual(outputs, expected_outputs)
-
-        max_length = 4
-        inputs = tf.constant([[0, 1], [1, 3]])
-        outputs = self.sampler(
-            inputs,
-            token_probability_fn,
-            max_length=max_length,
-            end_token_id=3,
-        )
-        expected_outputs = tf.ragged.constant([[0, 1], [1, 3]])
-        self.assertAllEqual(outputs, expected_outputs)
+        output = generate(prompt, state)
+        self.assertEqual(self.join_as_string(output), ["sequentially"])

--- a/keras_nlp/samplers/greedy_sampler.py
+++ b/keras_nlp/samplers/greedy_sampler.py
@@ -41,8 +41,8 @@ class GreedySampler(Sampler):
 
     def next(prompt, state, index):
         # return a uniform distribution over our alphabet.
-        probs = tf.ones((batch_size, vocab_size))
-        return probs, state
+        logits = tf.ones((batch_size, vocab_size))
+        return logits, state
 
     output = keras_nlp.samplers.GreedySampler()(
         next=next,
@@ -57,5 +57,5 @@ class GreedySampler(Sampler):
     def __init__(self):
         super().__init__()
 
-    def get_next_token(self, probs):
-        return tf.argmax(probs, axis=-1)
+    def get_next_token(self, probabilities):
+        return tf.argmax(probabilities, axis=-1)

--- a/keras_nlp/samplers/greedy_sampler.py
+++ b/keras_nlp/samplers/greedy_sampler.py
@@ -17,23 +17,17 @@ import tensorflow as tf
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.samplers.sampler import Sampler
-from keras_nlp.samplers.sampler import base_sampler_args_docstring
 from keras_nlp.samplers.sampler import call_args_docstring
 from keras_nlp.utils.python_utils import format_docstring
 
 
-@format_docstring(
-    base_sampler_args=base_sampler_args_docstring, call_args=call_args_docstring
-)
+@format_docstring(call_args=call_args_docstring)
 @keras_nlp_export("keras_nlp.samplers.GreedySampler")
 class GreedySampler(Sampler):
     """Greedy sampler class.
 
     This sampler is implemented on greedy search, i.e., always picking up the
     token of the largest probability as the next token.
-
-    Args:
-        {{base_sampler_args}}
 
     Call Args:
         {{call_args}}
@@ -67,12 +61,8 @@ class GreedySampler(Sampler):
     ```
     """
 
-    def __init__(
-        self,
-        jit_compile=True,
-        run_eagerly=False,
-    ):
-        super().__init__(jit_compile=jit_compile, run_eagerly=run_eagerly)
+    def __init__(self):
+        super().__init__()
 
-    def get_next_token(self, next_token_probs):
-        return tf.argmax(next_token_probs, axis=-1)
+    def get_next_token(self, probs):
+        return tf.argmax(probs, axis=-1)

--- a/keras_nlp/samplers/greedy_sampler.py
+++ b/keras_nlp/samplers/greedy_sampler.py
@@ -34,30 +34,23 @@ class GreedySampler(Sampler):
 
     Examples:
     ```python
-    VOCAB_SIZE = 10
+    # Use a simple alphabet of lowercase characters to [0, 26).
+    int_lookup = {i: chr(i + ord('a')) for i in range(26)}
+    char_lookup = {v: k for k, v in int_lookup.items()}
+    batch_size, length, vocab_size = 1, 12, len(int_lookup)
 
-    # Create a dummy model to predict the next token.
-    model = keras.Sequential(
-        [
-            keras.Input(shape=[None]),
-            keras.layers.Embedding(
-                input_dim=VOCAB_SIZE,
-                output_dim=16,
-            ),
-            keras.layers.Dense(VOCAB_SIZE, activation="softmax"),
-        ]
+    def next(prompt, state, index):
+        # return a uniform distribution over our alphabet.
+        probs = tf.ones((batch_size, vocab_size))
+        return probs, state
+
+    output = keras_nlp.samplers.GreedySampler()(
+        next=next,
+        prompt=tf.fill((batch_size, length,), char_lookup['z']),
+        index=5,
     )
-
-    # Define a function that outputs the next token's probability for each token
-    # in the input sequence.
-    def token_probability_fn(inputs, mask):
-        return model(inputs)
-
-    prompt = tf.fill((8, 1), 1)
-
-    sampler = keras_nlp.samplers.GreedySampler()
-    # Print the generated sequence (token ids).
-    print(sampler(prompt, token_probability_fn, max_length=10))
+    print(["".join([int_lookup[i] for i in s]) for s in output.numpy()])
+    # >>> "zzzzzaaaaaaa"
     ```
     """
 

--- a/keras_nlp/samplers/greedy_sampler_test.py
+++ b/keras_nlp/samplers/greedy_sampler_test.py
@@ -31,7 +31,7 @@ class GreedySamplerTest(tf.test.TestCase, parameterized.TestCase):
         self.vocab_size = len(self.int_lookup)
 
         def next(prompt, state, index):
-            # Return a probability distribution favoring the next char in state.
+            # Return a distribution favoring the next char in state.
             logits = tf.one_hot(state[:, index], self.vocab_size) * 1e9
             return logits, state
 
@@ -41,9 +41,9 @@ class GreedySamplerTest(tf.test.TestCase, parameterized.TestCase):
     def join_as_string(self, x):
         return ["".join([self.int_lookup[i] for i in s]) for s in x.numpy()]
 
-    def test_stateless(self):
+    def test_stateless_call(self):
         def next(prompt, state, index):
-            # Return a probability distribution favoring the first index.
+            # Return a distribution favoring the first token in the vocab.
             logits = np.zeros((self.batch_size, self.vocab_size))
             logits[:, 0] = 1e9
             return tf.constant(logits), state
@@ -56,7 +56,7 @@ class GreedySamplerTest(tf.test.TestCase, parameterized.TestCase):
         )
         self.assertEqual(self.join_as_string(output), ["zzzzzaaaaaaa"])
 
-    def test_stateful(self):
+    def test_stateful_call(self):
         state_chars = list("sequentially")
         state = tf.constant([[self.char_lookup[c] for c in state_chars]])
         prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])

--- a/keras_nlp/samplers/greedy_sampler_test.py
+++ b/keras_nlp/samplers/greedy_sampler_test.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """Tests for Greedy sampler."""
 
+import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
 from keras_nlp.samplers.greedy_sampler import GreedySampler
 
@@ -23,116 +23,88 @@ from keras_nlp.samplers.greedy_sampler import GreedySampler
 class GreedySamplerTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
         super().setUp()
-        self.vocab_size = 10
-        self.feature_size = 16
+        # Use a simple alphabet of lowercase characters to [0, 26).
+        self.int_lookup = {i: chr(i + ord("a")) for i in range(26)}
+        self.char_lookup = {v: k for k, v in self.int_lookup.items()}
+        self.batch_size = 1
+        self.length = 12
+        self.vocab_size = len(self.int_lookup)
 
-        # Create a dummy model to predict the next token.
-        model = keras.Sequential(
-            [
-                keras.Input(shape=[None]),
-                keras.layers.Embedding(
-                    input_dim=self.vocab_size,
-                    output_dim=self.feature_size,
-                ),
-                keras.layers.Dense(self.vocab_size),
-                keras.layers.Softmax(),
-            ]
-        )
+        def next(prompt, state, index):
+            # Return a probability distribution favoring the next char in state.
+            probs = tf.one_hot(state[:, index], self.vocab_size) * 1e9
+            return probs, state
 
-        def token_probability_fn(inputs, mask):
-            return model(inputs)
-
-        self.token_probability_fn = token_probability_fn
-
+        self.next = next
         self.sampler = GreedySampler()
 
-    def test_generate_with_1d_prompt(self):
-        inputs = tf.constant([1])
-        outputs = self.sampler(inputs, self.token_probability_fn, max_length=5)
-        self.assertEqual(outputs.shape, [5])
+    def join_as_string(self, x):
+        return ["".join([self.int_lookup[i] for i in s]) for s in x.numpy()]
 
-    def test_generate_with_2d_prompt(self):
-        inputs = tf.constant([[1], [1]])
-        outputs = self.sampler(inputs, self.token_probability_fn, max_length=5)
-        self.assertEqual(outputs.shape, [2, 5])
+    def test_stateless(self):
+        def next(prompt, state, index):
+            # Return a probability distribution favoring the first index.
+            probs = np.zeros((self.batch_size, self.vocab_size))
+            probs[:, 0] = 1e9
+            return tf.constant(probs), state
 
-    def test_generate_with_list_prompt(self):
-        inputs = [[1], [1]]
-        outputs = self.sampler(inputs, self.token_probability_fn, max_length=5)
-        self.assertEqual(outputs.shape, [2, 5])
-
-    def test_generate_with_ragged_prompt(self):
-        max_length = 5
-
-        def token_probability_fn(inputs, mask):
-            # Assert that user function is passed only dense tensors.
-            self.assertIsInstance(inputs, tf.Tensor)
-            prob = tf.constant([[[0.0, 0.0, 0.0, 1.0]]])
-            return tf.repeat(tf.repeat(prob, 2, axis=0), max_length, axis=1)
-
-        inputs = tf.ragged.constant([[1], [2, 1, 2]])
-        outputs = self.sampler(inputs, token_probability_fn, max_length)
-        self.assertEqual(outputs.shape, [2, 5])
-
-    def test_assert_generation_is_correct(self):
-        batch_size = 10
-        max_length = 3
-
-        def token_probability_fn(inputs, mask):
-            prob = tf.constant([[[0.0, 0.0, 0.0, 1.0]]])
-            return tf.repeat(
-                tf.repeat(prob, batch_size, axis=0), max_length, axis=1
-            )
-
-        inputs = 3 * tf.ones([batch_size, 1], dtype=tf.int32)
-        outputs = self.sampler(
-            inputs, token_probability_fn, max_length=max_length
+        prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
+        output = self.sampler(
+            next=next,
+            prompt=prompt,
+            index=5,
         )
-        self.assertAllEqual(
-            outputs, 3 * tf.ones(shape=[batch_size, max_length])
+        self.assertEqual(self.join_as_string(output), ["zzzzzaaaaaaa"])
+
+    def test_stateful(self):
+        state_chars = list("sequentially")
+        state = tf.constant([[self.char_lookup[c] for c in state_chars]])
+        prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
+        output = self.sampler(
+            next=self.next,
+            prompt=prompt,
+            state=state,
         )
+        self.assertEqual(self.join_as_string(output), ["sequentially"])
 
-    def test_end_token_id(self):
-        def token_probability_fn(inputs, mask):
-            batch_size = tf.shape(inputs)[0]
-            prob = tf.constant([[[0.0, 0.0, 0.0, 1.0]]])
-            return tf.repeat(
-                tf.repeat(prob, batch_size, axis=0), max_length, axis=1
-            )
-
-        max_length = 4
-        sampler = GreedySampler()
-        inputs = tf.constant([[0, 1], [1, 2]])
-        outputs = sampler(
-            inputs,
-            token_probability_fn,
-            max_length=max_length,
-            end_token_id=2,
+    def test_early_stopping(self):
+        state_chars = list("sequentially")
+        state = tf.constant([[self.char_lookup[c] for c in state_chars]])
+        prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
+        output = self.sampler(
+            next=self.next,
+            prompt=prompt,
+            state=state,
+            end_token_id=self.char_lookup["t"],
         )
-        # end_token in prompt does not trigger truncation.
-        expected_outputs = tf.ragged.constant([[0, 1, 3, 3], [1, 2, 3, 3]])
-        self.assertAllEqual(outputs, expected_outputs)
+        self.assertEqual(self.join_as_string(output), ["sequentzzzzz"])
 
-        outputs = sampler(
-            inputs,
-            token_probability_fn,
-            max_length=max_length,
-            end_token_id=3,
+    def test_is_greedy(self):
+        def next(prompt, state, index):
+            # Return a distribution where each id is progressively less likely.
+            probs = self.vocab_size - tf.range(self.vocab_size, dtype="float32")
+            probs = tf.repeat(probs[tf.newaxis, :], self.batch_size, axis=0)
+            return probs, state
+
+        prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
+        output = self.sampler(
+            next=next,
+            prompt=prompt,
         )
-        # Generated end_token will be truncated.
-        expected_outputs = tf.ragged.constant([[0, 1], [1, 2]])
-        self.assertAllEqual(outputs, expected_outputs)
+        output_ids = set(output[0].numpy())
+        self.assertContainsSubset(output_ids, [0])
 
-    def test_compare_xla_noxla_results(self):
-        inputs = [[1], [1]]
-        xla_sampler = GreedySampler(jit_compile=True)
-        outputs_xla = xla_sampler(
-            inputs, self.token_probability_fn, max_length=5
-        )
+    @parameterized.named_parameters(
+        ("jit_compile_false", False), ("jit_compile_true", True)
+    )
+    def test_compilation(self, jit_compile):
+        state_chars = list("sequentially")
+        state = tf.constant([[self.char_lookup[c] for c in state_chars]])
+        prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
 
-        xla_sampler = GreedySampler(jit_compile=False)
-        outputs_no_xla = xla_sampler(
-            inputs, self.token_probability_fn, max_length=5
-        )
+        @tf.function(jit_compile=jit_compile)
+        def generate(prompt, state):
+            return self.sampler(self.next, prompt=prompt, state=state)
 
-        self.assertAllEqual(outputs_xla, outputs_no_xla)
+        output = generate(prompt, state)
+        self.assertEqual(self.join_as_string(output), ["sequentially"])

--- a/keras_nlp/samplers/sampler.py
+++ b/keras_nlp/samplers/sampler.py
@@ -22,11 +22,11 @@ from keras_nlp.utils.python_utils import format_docstring
 
 call_args_docstring = """
     next: A function which takes in the `prompt, state, index` of the
-        current generation loop, and outputs a tuple `logits, state` with the
+        current generation loop, and outputs a tuple `(logits, state)` with the
         probability for the next token and state for the next iteration.
     prompt: A 2D integer tensor with shape `(batch_size, max_length)`. This
         tensor will be iteratively updated column by column with new sampled
-        values.
+        values, starting at `index`.
     state: Optional. A tensor or nested structure of tensors that will be
         updated by each call to `next`. This can be used to cache computations
         from early iterations of the generative loop.

--- a/keras_nlp/samplers/sampler.py
+++ b/keras_nlp/samplers/sampler.py
@@ -20,83 +20,64 @@ from tensorflow.compiler.tf2xla.python.xla import dynamic_update_slice
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.utils.python_utils import format_docstring
 
-base_sampler_args_docstring = """
-    jit_compile: bool, defaults to True. If True, XLA compilation will be used.
-    run_eagerly: bool, defaults to False. If True, the sampler will run in
-        the eager mode.
-    """
-
 call_args_docstring = """
-    prompt: a list of integers or an integer Tensor, can be 1D or 2D. The
-        initial tokens to append generated tokens.
-    token_probability_fn: a function that generates the probability of
-        the next token over the whole vocabulary for each input token.
-    max_length: int. The max length of generated sequence.
-    mask: a tensor, defaults to None. The padding mask of the prompt.
-    end_token_id: int, defaults to None. The token marking the end of the
-        sequence, once encountered the generation is finished for the exact
-        sequence. If None, every sequence is generated up to `max_length`.
-        If set, all tokens after encountering `end_token_id` will be
-        replaced with `pad_token_id`.
-    from_logits: bool, defaults to True. Indicate if the `token_probability_fn`
-        returns logits. If False, `token_probability_fn` returns probability
-        distributions.
-    cache: a dense int tensor, a cache of intermediate key and value tensor
-        computed by each decoder self-attention layer. These values will only
-        be computed once for each new token in the generated sequence.
+    prompt: A 2D integer tensor with shape `(batch_size, max_length)`. This
+        tensor will be iteratively updated column by column with new sampled
+        values.
+    next: A function which takes in the `prompt, state, index` of the
+        current generation loop, and outputs a tuple `probs, state` with the
+        probability for the next token and state for the next iteration.
+    state: Optional. A tensor or nested structure of tensors that will be
+        updated by each call to `next`. This can be used to cache computations
+        from early iterations of the generative loop.
+    index: Optional. The first index to start sampling at.
+    mask: Optional. A 2D integer tensor with the same shape as `prompt`.
+        Locations which are `True` in the mask are never updated during
+        sampling. Often this will mark all ids in `prompt` which were present in
+        the original input.
+    end_token_id: Optional. The token marking the end of the sequence. If
+        specified, sampling will stop as soon as all sequences in the prompt
+        produce a `end_token_id` in a location where `mask` is `False`.
+    from_logits: Optional. Set to `True` if the `next` function return softmax
+        probabilities instead of logits.
     """
 
 
-@format_docstring(
-    base_sampler_args=base_sampler_args_docstring, call_args=call_args_docstring
-)
+@format_docstring(call_args=call_args_docstring)
 @keras_nlp_export("keras_nlp.samplers.Sampler")
 class Sampler:
     """Base sampler class.
 
-    Args:
-        {{base_sampler_args}}
-
     Call Args:
         {{call_args}}
 
-    The inputs and outputs of Sampler class are both token ids.
-
-    Subclassers should always implement the `get_next_token()` method, which
-    gets the next token based on probability distribution over vocab tokens.
-    Please check available subclass samplers for examples. If you need more
-    control over the sampling process, please implement `sample()` method
-    instead, see `keras_nlp.samplers.BeamSampler` for examples.
+    This base class can be extended to implement different auto-regressive
+    sampling methods. Subclasses can either:
+     - Override the `get_next_token()` method, which computes the next token
+       based on a probability distribution over all possible vocab entries.
+     - Override `__call__`, if the sampling method need additional state beyond
+       the next tokens probability distribution to sample a sequence.
+    Please check available subclass samplers for examples.
 
     Examples:
 
-    Basic usage:
     ```python
-    VOCAB_SIZE = 10
+    int_lookup = {i: chr(i + ord('a')) for i in range(26)}
+    char_lookup = {v: k for k, v in int_lookup.items()}
+    vocab_size = len(int_lookup)
+    batch_size = 1
 
-    # Create a dummy model to predict the next token. Note that the output is
-    # random without training, here we just demo how `samplers` works.
-    model = keras.Sequential(
-        [
-            keras.Input(shape=[None]),
-            keras.layers.Embedding(
-                input_dim=VOCAB_SIZE,
-                output_dim=16,
-            ),
-            keras.layers.Dense(VOCAB_SIZE, activation="softmax"),
-        ]
+    def next(prompt, state, index):
+        # return a uniform distribution over our alphabet.
+        probs = tf.ones((batch_size, vocab_size))
+        return probs, state
+
+    output = keras_nlp.samplers.TopKSampler(k=2)(
+        prompt=tf.zeros((batch_size, 12,)),
+        next=next,
     )
-
-    # Define a function that outputs the next token's probability for each token
-    # in the input sequence.
-    def token_probability_fn(inputs, mask):
-        return model(inputs)
-
-    prompt = tf.fill((8, 1), 1)
-
-    sampler = keras_nlp.samplers.GreedySampler()
-    # Print the generated sequence (token ids).
-    print(sampler(prompt, token_probability_fn, max_length=10, end_token_id=2))
+    print("".join([int_lookup[i] for i in output.numpy()[0].tolist()]))
+    # >>> "aaaaaaaaaaaa"
     ```
 
     Use with string inputs:
@@ -136,130 +117,58 @@ class Sampler:
     ```
     """
 
-    def __init__(
-        self,
-        jit_compile=True,
-        run_eagerly=False,
-    ):
-        if run_eagerly and jit_compile:
-            raise ValueError(
-                "XLA cannot be turned on under eager mode, received "
-                "`jit_compile=True` and `run_eagerly=True`. Please either set "
-                "`jit_compile=False` or set `run_eagerly=False`."
-            )
-        self.jit_compile = jit_compile
-        self.run_eagerly = run_eagerly
-
-    def _validate_prompt_and_mask(self, prompt, mask):
-        """Helper method to validate input prompt."""
-        if not isinstance(prompt, (list, tf.RaggedTensor, tf.Tensor)):
-            raise ValueError(
-                "`prompt` must be one of `list`, `tf.RaggedTensor` or "
-                f"`tf.Tensor`, but received: prompt={type(prompt)}."
-            )
-
-        if isinstance(prompt, tf.RaggedTensor):
-            if mask:
-                raise ValueError(
-                    "`mask` is only valid when `prompt` is a list or dense "
-                    f"tensor, but received type(prompt)={type(prompt)}."
-                )
-            return prompt, mask
-
-        if isinstance(prompt, list):
-            prompt = tf.convert_to_tensor(prompt)
-        if not mask:
-            mask = tf.cast(tf.ones_like(prompt), dtype=tf.bool)
-        prompt = tf.ragged.boolean_mask(prompt, mask)
-        return prompt, mask
-
-    def _pad_prompt(self, prompt, max_length):
-        """Pad prompt to `max_length`."""
-        mask = tf.ones_like(prompt, dtype=tf.bool)
-        mask = mask.to_tensor(shape=(None, max_length))
-        prompt = prompt.to_tensor(shape=(None, max_length))
-        return prompt, mask
-
-    def _mask_tokens_after_end_token(
-        self,
-        generated_result,
-        original_padding_mask,
-        max_length,
-        end_token_id,
-    ):
-        """Helper function to truncate the tokens after the end token."""
-        # Create a tensor with True for each end_token_id.
-        end_tokens = generated_result == end_token_id
-        # Remove all end_token_ids in the original input.
-        end_tokens = end_tokens & (original_padding_mask == tf.constant(False))
-        # Find index of first end_token_id.
-        end_indices = tf.math.argmax(end_tokens, -1)
-        # Use max_length if no `end_token_id` is found.
-        end_indices = tf.where(
-            end_indices == 0,
-            tf.cast(max_length, dtype=end_indices.dtype),
-            end_indices,
-        )
-        # Truncate out tokens after (including) the end token.
-        mask_indices = tf.sequence_mask(end_indices, maxlen=max_length)
-        return tf.ragged.boolean_mask(generated_result, mask_indices)
-
     def __call__(
         self,
         prompt,
-        token_probability_fn,
-        max_length,
+        next,
+        index=0,
+        state=None,
         mask=None,
         end_token_id=None,
         from_logits=True,
-        cache=None,
     ):
-        prompt, mask = self._validate_prompt_and_mask(prompt, mask)
-        self.token_probability_fn = token_probability_fn
-        input_is_1d = prompt.shape.rank == 1
-        if input_is_1d:
-            prompt = tf.RaggedTensor.from_tensor(prompt[tf.newaxis, :])
+        max_length = tf.shape(prompt)[-1]
+        mask = tf.zeros_like(prompt, dtype=tf.bool) if mask is None else mask
+        # `tf.while_loop` will not accept `None` as a value for `loop_vars`.
+        state = () if state is None else state
 
-        shortest_prompt_len = tf.reduce_min(prompt.row_lengths())
-        # Pad prompt to be a dense Tensor of shape [batch_size, max_length].
-        # This step is required for XLA compatibility because XLA requires a
-        # static shape, which means we cannot concatenate generated token to
-        # current prompt.
-        prompt, mask = self._pad_prompt(prompt, max_length)
-        original_padding_mask = tf.identity(mask)
+        def cond(prompt, state, index):
+            if end_token_id is None:
+                return True
+            # Stop if all sequences have produced a *new* end_token_id.
+            end_tokens = (prompt == end_token_id) & (~mask)
+            prompt_done = tf.reduce_any(end_tokens, axis=-1)
+            return not tf.reduce_all(prompt_done)
 
-        # Convert `sample` method to a `tf.function` if `self.run_eagerly=False`
-        # , and turn on `jit_compile` accordingly.
-        sample = self.sample
-        if not self.run_eagerly:
-            if self.jit_compile:
-                sample = self._sample_graph_xla
-            else:
-                sample = self._sample_graph
-        prompt = sample(
-            prompt,
-            mask,
-            max_length - shortest_prompt_len,
-            from_logits=from_logits,
-            end_token_id=end_token_id,
-            cache=cache,
+        def body(prompt, state, index):
+            # Compute the softmax distribution for the next token.
+            probs, state = next(prompt, state, index)
+            probs = keras.activations.softmax(probs) if from_logits else probs
+
+            # Compute the next token.
+            next_token = self.get_next_token(probs)
+            # Don't overwrite anywhere mask is True.
+            next_token = tf.cast(next_token, prompt.dtype)
+            next_token = tf.where(mask[:, index], prompt[:, index], next_token)
+            # Update the prompt with the next token.
+            next_token = next_token[:, tf.newaxis]
+            prompt = dynamic_update_slice(prompt, next_token, [0, index])
+            # Return the next prompt, state and incremented index.
+            return (prompt, state, index + 1)
+
+        prompt, _, _ = tf.while_loop(
+            cond=cond,
+            body=body,
+            loop_vars=(prompt, state, index),
+            maximum_iterations=(max_length - index),
         )
-        # Mask out tokens after `end_token_id`.
-        if end_token_id is not None:
-            prompt = self._mask_tokens_after_end_token(
-                prompt,
-                original_padding_mask,
-                max_length,
-                end_token_id,
-            )
+        return prompt
 
-        return tf.squeeze(prompt, axis=0) if input_is_1d else prompt
-
-    def get_next_token(self, next_token_probs):
+    def get_next_token(self, probs):
         """Get the next token.
 
         Args:
-            next_token_probs: a Tensor, the probability distribution for next
+            probs: a Tensor, the probability distribution for next
                 token over all vocab tokens.
 
         Get the next token based on given probability distribution over tokens.
@@ -267,158 +176,9 @@ class Sampler:
         """
         raise NotImplementedError
 
-    @tf.function
-    def _sample_graph(
-        self,
-        prompt,
-        mask,
-        num_steps,
-        from_logits=True,
-        end_token_id=None,
-        cache=None,
-    ):
-        """Wrapper of `sample` method to make it a non-XLA tf graph."""
-        return self.sample(
-            prompt, mask, num_steps, from_logits, end_token_id, cache
-        )
-
-    @tf.function(jit_compile=True)
-    def _sample_graph_xla(
-        self,
-        prompt,
-        mask,
-        num_steps,
-        from_logits=True,
-        end_token_id=None,
-        cache=None,
-    ):
-        """Wrapper of `sample` method to make it an XLA tf graph."""
-        return self.sample(
-            prompt, mask, num_steps, from_logits, end_token_id, cache
-        )
-
-    def sample(
-        self,
-        prompt,
-        mask,
-        num_steps,
-        from_logits=True,
-        end_token_id=None,
-        cache=None,
-    ):
-        """Sampling logic implementation.
-
-        Args:
-            prompt: a dense int Tensor of shape [batch_size, max_length]. The
-                placeholder for generated sequence.
-            token_probability_fn: a function that generates the probability of
-                the next token over the whole vocabulary for each input token.
-            mask: a dense bool Tensor of shape [batch_size, max_length]. The
-                mask of prompt.
-            num_steps: int. The remaining number of tokens to generate.
-            from_logits: bool, defaults to True. Indicate if the
-                `token_probability_fn` returns logits. If False,
-                `token_probability_fn` returns probability distributions.
-            end_token_id: int, defaults to None. The token marking the end of
-                the sequence, once encountered the generation is finished for
-                the exact sequence.
-            cache: a dense int tensor, the cache used in decoding. The cache
-                stores the key and value of each
-                `keras_nlp.layers.CachedMultiHeadAttention` layer to make the
-                decoding faster by avoiding duplicated computation.
-
-        Returns:
-            A dense int Tensor, representing the generated text in token id
-            space.
-        """
-        batch_size, max_length = tf.shape(prompt)[0], tf.shape(prompt)[1]
-        num_steps = tf.cast(num_steps, tf.int32)
-        max_length = tf.cast(max_length, tf.int32)
-        # The index of the last non-padding token in prompt. Since all sequences
-        # are aligned to the right side, the index is the same for all.
-        current_index = max_length - num_steps
-        original_padding_mask = tf.cast(tf.identity(mask), dtype=tf.int32)
-
-        def body(
-            current_index,
-            prompt,
-            mask,
-            cache=None,
-        ):
-            last_index = current_index - 1
-            if cache is not None:
-                probs, cache = self.token_probability_fn(
-                    prompt,
-                    mask,
-                    cache=cache,
-                    cache_index=last_index,
-                )
-                next_token_probs = tf.squeeze(probs, axis=1)
-            else:
-                probs = self.token_probability_fn(
-                    prompt,
-                    mask,
-                )
-                next_token_probs = tf.gather(
-                    probs,
-                    tf.repeat(current_index - 1, batch_size),
-                    axis=1,
-                    batch_dims=1,
-                )
-
-            if from_logits:
-                next_token_probs = keras.activations.softmax(
-                    next_token_probs, axis=-1
-                )
-            next_token = self.get_next_token(next_token_probs)
-            next_token = tf.cast(next_token, prompt.dtype)
-            next_token = tf.where(
-                mask[:, current_index],
-                prompt[:, current_index],
-                next_token,
-            )
-            next_token = next_token[:, tf.newaxis]
-            next_mask = tf.fill([batch_size, 1], True)
-            slice_start = [0, current_index]
-            mask = dynamic_update_slice(mask, next_mask, slice_start)
-            prompt = dynamic_update_slice(prompt, next_token, slice_start)
-            current_index = tf.add(current_index, 1)
-            if cache is None:
-                return current_index, prompt, mask
-            return current_index, prompt, mask, cache
-
-        def cond(current_index, prompt, mask, cache=None):
-            if end_token_id is None:
-                return True
-            end_token_seen = (prompt == end_token_id) & (
-                original_padding_mask == 0
-            )
-            sequence_done = tf.reduce_any(end_token_seen, axis=-1)
-            all_done = tf.reduce_all(sequence_done)
-            return not all_done
-
-        if cache is None:
-            _, prompt, _ = tf.while_loop(
-                cond=cond,
-                body=body,
-                loop_vars=(current_index, prompt, mask),
-                maximum_iterations=num_steps,
-            )
-            return prompt
-        # Run a while loop till `max_length` of tokens has been generated.
-        _, prompt, _, _ = tf.while_loop(
-            cond=cond,
-            body=body,
-            loop_vars=(current_index, prompt, mask, cache),
-            maximum_iterations=num_steps,
-        )
-        return prompt
-
     @classmethod
     def from_config(cls, config):
         return cls(**config)
 
     def get_config(self):
-        return {
-            "jit_compile": self.jit_compile,
-        }
+        return {}

--- a/keras_nlp/samplers/sampler.py
+++ b/keras_nlp/samplers/sampler.py
@@ -92,6 +92,8 @@ class Sampler:
         end_token_id=None,
     ):
         max_length = tf.shape(prompt)[-1]
+        # Make sure `max_length` and `index` are the same dtype.
+        index = tf.cast(index, max_length.dtype)
         mask = tf.zeros_like(prompt, dtype=tf.bool) if mask is None else mask
         # `tf.while_loop` will not accept `None` as a value for `loop_vars`.
         state = () if state is None else state

--- a/keras_nlp/samplers/sampler_test.py
+++ b/keras_nlp/samplers/sampler_test.py
@@ -16,7 +16,6 @@
 import tensorflow as tf
 
 import keras_nlp
-from keras_nlp.samplers.greedy_sampler import GreedySampler
 from keras_nlp.samplers.top_k_sampler import TopKSampler
 
 
@@ -30,12 +29,12 @@ class SamplerTest(tf.test.TestCase):
 
     def test_get(self):
         # Test get from string.
-        identifier = "greedy"
+        identifier = "top_k"
         sampler = keras_nlp.samplers.get(identifier)
-        self.assertIsInstance(sampler, GreedySampler)
+        self.assertIsInstance(sampler, TopKSampler)
 
         # Test dict identifier.
-        original_sampler = keras_nlp.samplers.GreedySampler(jit_compile=False)
+        original_sampler = keras_nlp.samplers.TopKSampler(k=7)
         config = keras_nlp.samplers.serialize(original_sampler)
         restored_sampler = keras_nlp.samplers.get(config)
         self.assertDictEqual(
@@ -44,6 +43,6 @@ class SamplerTest(tf.test.TestCase):
         )
 
         # Test identifier is already a sampler instance.
-        original_sampler = keras_nlp.samplers.GreedySampler(jit_compile=False)
+        original_sampler = keras_nlp.samplers.TopKSampler(k=7)
         restored_sampler = keras_nlp.samplers.get(original_sampler)
         self.assertEqual(original_sampler, restored_sampler)

--- a/keras_nlp/samplers/top_k_sampler.py
+++ b/keras_nlp/samplers/top_k_sampler.py
@@ -46,8 +46,8 @@ class TopKSampler(Sampler):
 
     def next(prompt, state, index):
         # A uniform distribution over our alphabet.
-        probs = tf.ones((batch_size, vocab_size))
-        return probs, state
+        logits = tf.ones((batch_size, vocab_size))
+        return logits, state
 
     output = keras_nlp.samplers.TopKSampler(k=3)(
         next=next,
@@ -68,9 +68,11 @@ class TopKSampler(Sampler):
         self.k = k
         self.seed = seed
 
-    def get_next_token(self, probs):
+    def get_next_token(self, probabilities):
         # Filter out top-k tokens.
-        top_k_pred, top_k_indices = tf.math.top_k(probs, k=self.k, sorted=False)
+        top_k_pred, top_k_indices = tf.math.top_k(
+            probabilities, k=self.k, sorted=False
+        )
         # Sample the next token from the probability distribution.
         next_token = tf.random.categorical(
             tf.math.log(top_k_pred), 1, seed=self.seed

--- a/keras_nlp/samplers/top_k_sampler.py
+++ b/keras_nlp/samplers/top_k_sampler.py
@@ -39,30 +39,23 @@ class TopKSampler(Sampler):
 
     Examples:
     ```python
-    VOCAB_SIZE = 10
+    # Use a simple alphabet of lowercase characters to [0, 26).
+    int_lookup = {i: chr(i + ord('a')) for i in range(26)}
+    char_lookup = {v: k for k, v in int_lookup.items()}
+    batch_size, length, vocab_size = 1, 12, len(int_lookup)
 
-    # Create a dummy model to predict the next token.
-    model = keras.Sequential(
-        [
-            keras.Input(shape=[None]),
-            keras.layers.Embedding(
-                input_dim=VOCAB_SIZE,
-                output_dim=16,
-            ),
-            keras.layers.Dense(VOCAB_SIZE, activation="softmax"),
-        ]
+    def next(prompt, state, index):
+        # A uniform distribution over our alphabet.
+        probs = tf.ones((batch_size, vocab_size))
+        return probs, state
+
+    output = keras_nlp.samplers.TopKSampler(k=3)(
+        next=next,
+        prompt=tf.fill((batch_size, length,), char_lookup['z']),
+        index=5,
     )
-
-    # Define a function that outputs the next token's probability for each token
-    # in the input sequence.
-    def token_probability_fn(inputs, mask):
-        return model(inputs)
-
-    prompt = tf.fill((8, 1), 1)
-
-    sampler = keras_nlp.samplers.TopKSampler(k=5)
-    # Print the generated sequence (token ids).
-    print(sampler(prompt, token_probability_fn, max_length=10))
+    print(["".join([int_lookup[i] for i in s]) for s in output.numpy()])
+    # >>> "zzzzzacbbcaa"
     ```
     """
 

--- a/keras_nlp/samplers/top_k_sampler.py
+++ b/keras_nlp/samplers/top_k_sampler.py
@@ -17,14 +17,11 @@ import tensorflow as tf
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.samplers.sampler import Sampler
-from keras_nlp.samplers.sampler import base_sampler_args_docstring
 from keras_nlp.samplers.sampler import call_args_docstring
 from keras_nlp.utils.python_utils import format_docstring
 
 
-@format_docstring(
-    base_sampler_args=base_sampler_args_docstring, call_args=call_args_docstring
-)
+@format_docstring(call_args=call_args_docstring)
 @keras_nlp_export("keras_nlp.samplers.TopKSampler")
 class TopKSampler(Sampler):
     """Top-K Sampler class.
@@ -36,7 +33,6 @@ class TopKSampler(Sampler):
     Args:
         k: int, the `k` value of top-k.
         seed: int, defaults to None. The random seed.
-        {{base_sampler_args}}
 
     Call Args:
         {{call_args}}
@@ -74,18 +70,14 @@ class TopKSampler(Sampler):
         self,
         k=5,
         seed=None,
-        jit_compile=True,
-        run_eagerly=False,
     ):
+        super().__init__()
         self.k = k
         self.seed = seed
-        super().__init__(jit_compile=jit_compile, run_eagerly=run_eagerly)
 
-    def get_next_token(self, next_token_probs):
+    def get_next_token(self, probs):
         # Filter out top-k tokens.
-        top_k_pred, top_k_indices = tf.math.top_k(
-            next_token_probs, k=self.k, sorted=False
-        )
+        top_k_pred, top_k_indices = tf.math.top_k(probs, k=self.k, sorted=False)
         # Sample the next token from the probability distribution.
         next_token = tf.random.categorical(
             tf.math.log(top_k_pred), 1, seed=self.seed
@@ -96,7 +88,6 @@ class TopKSampler(Sampler):
 
     def get_config(self):
         config = super().get_config()
-
         config.update(
             {
                 "k": self.k,

--- a/keras_nlp/samplers/top_k_sampler_test.py
+++ b/keras_nlp/samplers/top_k_sampler_test.py
@@ -31,7 +31,7 @@ class TopKSamplerTest(tf.test.TestCase, parameterized.TestCase):
         self.vocab_size = len(self.int_lookup)
 
         def next(prompt, state, index):
-            # Return a probability distribution favoring the next char in state.
+            # Return a distribution favoring the next char in state.
             logits = tf.one_hot(state[:, index], self.vocab_size) * 1e9
             return logits, state
 
@@ -41,9 +41,9 @@ class TopKSamplerTest(tf.test.TestCase, parameterized.TestCase):
     def join_as_string(self, x):
         return ["".join([self.int_lookup[i] for i in s]) for s in x.numpy()]
 
-    def test_stateless(self):
+    def test_stateless_call(self):
         def next(prompt, state, index):
-            # Return a probability distribution favoring the first index.
+            # Return a distribution favoring the first token in the vocab.
             logits = np.zeros((self.batch_size, self.vocab_size))
             logits[:, 0] = 1e9
             return tf.constant(logits), state
@@ -56,7 +56,7 @@ class TopKSamplerTest(tf.test.TestCase, parameterized.TestCase):
         )
         self.assertEqual(self.join_as_string(output), ["zzzzzaaaaaaa"])
 
-    def test_stateful(self):
+    def test_stateful_call(self):
         state_chars = list("sequentially")
         state = tf.constant([[self.char_lookup[c] for c in state_chars]])
         prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])

--- a/keras_nlp/samplers/top_k_sampler_test.py
+++ b/keras_nlp/samplers/top_k_sampler_test.py
@@ -16,7 +16,6 @@
 import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
 from keras_nlp.samplers.top_k_sampler import TopKSampler
 
@@ -24,148 +23,88 @@ from keras_nlp.samplers.top_k_sampler import TopKSampler
 class TopKSamplerTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
         super().setUp()
-        self.vocab_size = 10
-        self.feature_size = 16
+        # Use a simple alphabet of lowercase characters to [0, 26).
+        self.int_lookup = {i: chr(i + ord("a")) for i in range(26)}
+        self.char_lookup = {v: k for k, v in self.int_lookup.items()}
+        self.batch_size = 1
+        self.length = 12
+        self.vocab_size = len(self.int_lookup)
 
-        # Create a dummy model to predict the next token.
-        model = keras.Sequential(
-            [
-                keras.Input(shape=[None]),
-                keras.layers.Embedding(
-                    input_dim=self.vocab_size,
-                    output_dim=self.feature_size,
-                ),
-                keras.layers.Dense(self.vocab_size),
-                keras.layers.Softmax(),
-            ]
+        def next(prompt, state, index):
+            # Return a probability distribution favoring the next char in state.
+            probs = tf.one_hot(state[:, index], self.vocab_size) * 1e9
+            return probs, state
+
+        self.next = next
+        self.sampler = TopKSampler(k=5)
+
+    def join_as_string(self, x):
+        return ["".join([self.int_lookup[i] for i in s]) for s in x.numpy()]
+
+    def test_stateless(self):
+        def next(prompt, state, index):
+            # Return a probability distribution favoring the first index.
+            probs = np.zeros((self.batch_size, self.vocab_size))
+            probs[:, 0] = 1e9
+            return tf.constant(probs), state
+
+        prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
+        output = self.sampler(
+            next=next,
+            prompt=prompt,
+            index=5,
         )
+        self.assertEqual(self.join_as_string(output), ["zzzzzaaaaaaa"])
 
-        def token_probability_fn(inputs, mask):
-            return model(inputs)
-
-        self.token_probability_fn = token_probability_fn
-        self.sampler = TopKSampler(k=2)
-
-    def test_generate_with_1d_prompt(self):
-        inputs = tf.constant([1])
-
-        outputs = self.sampler(inputs, self.token_probability_fn, max_length=5)
-        self.assertEqual(outputs.shape, [5])
-
-    def test_generate_with_2d_prompt(self):
-        inputs = tf.constant([[1], [1]])
-        outputs = self.sampler(inputs, self.token_probability_fn, max_length=5)
-        self.assertEqual(outputs.shape, [2, 5])
-
-    def test_generate_with_list_prompt(self):
-        inputs = [[1], [1]]
-        outputs = self.sampler(inputs, self.token_probability_fn, max_length=5)
-        self.assertEqual(outputs.shape, [2, 5])
-
-    def test_generate_with_ragged_prompt(self):
-        def token_probability_fn(inputs, mask):
-            batch_size, seq_length = tf.shape(inputs)[0], tf.shape(inputs)[1]
-            prob = tf.constant([[[0.0, 0.0, 0.0, 1.0]]])
-            return tf.tile(prob, [batch_size, seq_length, 1])
-
-        inputs = tf.ragged.constant([[1], [2, 1, 2]])
-        outputs = self.sampler(
-            inputs,
-            token_probability_fn,
-            max_length=5,
-            from_logits=False,
+    def test_stateful(self):
+        state_chars = list("sequentially")
+        state = tf.constant([[self.char_lookup[c] for c in state_chars]])
+        prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
+        output = self.sampler(
+            next=self.next,
+            prompt=prompt,
+            state=state,
         )
-        self.assertEqual(outputs.shape, [2, 5])
+        self.assertEqual(self.join_as_string(output), ["sequentially"])
+
+    def test_early_stopping(self):
+        state_chars = list("sequentially")
+        state = tf.constant([[self.char_lookup[c] for c in state_chars]])
+        prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
+        output = self.sampler(
+            next=self.next,
+            prompt=prompt,
+            state=state,
+            end_token_id=self.char_lookup["t"],
+        )
+        self.assertEqual(self.join_as_string(output), ["sequentzzzzz"])
+
+    def test_outputs_in_top_k(self):
+        def next(prompt, state, index):
+            # Return a distribution where each id is progressively less likely.
+            probs = self.vocab_size - tf.range(self.vocab_size, dtype="float32")
+            probs = tf.repeat(probs[tf.newaxis, :], self.batch_size, axis=0)
+            return probs, state
+
+        prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
+        output = self.sampler(
+            next=next,
+            prompt=prompt,
+        )
+        output_ids = set(output[0].numpy())
+        self.assertContainsSubset(output_ids, range(5))
 
     @parameterized.named_parameters(
-        ("xla_graph", True, False),
-        ("non_xla_graph", False, False),
-        ("eager", False, True),
+        ("jit_compile_false", False), ("jit_compile_true", True)
     )
-    def test_assert_probability_distribution_generation_is_correct(
-        self, jit_compile, run_eagerly
-    ):
-        def token_probability_fn(inputs, mask):
-            batch_size, seq_length = tf.shape(inputs)[0], tf.shape(inputs)[1]
-            prob = tf.constant([[[0.0, 0.0, 0.0, 1.0]]])
-            return tf.tile(prob, [batch_size, seq_length, 1])
+    def test_compilation(self, jit_compile):
+        state_chars = list("sequentially")
+        state = tf.constant([[self.char_lookup[c] for c in state_chars]])
+        prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
 
-        batch_size = 10
-        inputs = 3 * tf.ones([batch_size, 1], dtype=tf.int32)
-        max_length = 3
+        @tf.function(jit_compile=jit_compile)
+        def generate(prompt, state):
+            return self.sampler(self.next, prompt=prompt, state=state)
 
-        outputs_count = np.array([0, 0, 0, 0])
-        tf.random.set_seed(42)
-        sampler = TopKSampler(
-            k=2,
-            seed=42,
-            run_eagerly=jit_compile,
-            jit_compile=run_eagerly,
-        )
-        for _ in range(8):
-            outputs = sampler(
-                inputs,
-                token_probability_fn,
-                max_length=max_length,
-                from_logits=False,
-            )
-            flatten_predictions = tf.reshape(outputs[:, 1:], [-1])
-            for pred in flatten_predictions:
-                outputs_count[pred] += 1
-        self.assertAllClose(
-            outputs_count / np.sum(outputs_count),
-            [0.0, 0.0, 0.0, 1.0],
-            rtol=0.2,
-        )
-
-    def test_only_choose_from_top_k_tokens(self):
-        # Test that there are only the top-k tokens in the output.
-        def token_probability_fn(inputs, mask):
-            batch_size, seq_length = tf.shape(inputs)[0], tf.shape(inputs)[1]
-            prob = tf.constant([[[0.4, 0.3, 0.2, 0.1]]])
-            return tf.tile(prob, [batch_size, seq_length, 1])
-
-        # Test that it only samples from top-k tokens.
-        for k in [1, 2, 3]:
-            inputs = tf.constant([[0, 0], [0, 0]])
-            sampler = TopKSampler(k=k)
-            for _ in range(10):
-                outputs = sampler(
-                    inputs,
-                    token_probability_fn,
-                    max_length=5,
-                    from_logits=False,
-                )
-                self.assertAllEqual(outputs < k, tf.ones_like(outputs))
-
-    def test_end_token_id(self):
-        def token_probability_fn(inputs, mask):
-            batch_size, seq_length = tf.shape(inputs)[0], tf.shape(inputs)[1]
-            prob = tf.constant([[[0.0, 0.0, 0.0, 1.0]]])
-            return tf.tile(prob, [batch_size, seq_length, 1])
-
-        tf.random.set_seed(42)
-        sampler = TopKSampler(k=4, seed=42)
-        max_length = 4
-        inputs = tf.constant([[0, 1], [1, 2]])
-        outputs = sampler(
-            inputs,
-            token_probability_fn,
-            max_length=max_length,
-            end_token_id=2,
-            from_logits=False,
-        )
-        # end_token in prompt does not trigger truncation.
-        expected_outputs = tf.ragged.constant([[0, 1, 3, 3], [1, 2, 3, 3]])
-        self.assertAllEqual(outputs, expected_outputs)
-
-        outputs = sampler(
-            inputs,
-            token_probability_fn,
-            max_length=max_length,
-            end_token_id=3,
-            from_logits=False,
-        )
-        # Generated end_token will be truncated.
-        expected_outputs = tf.ragged.constant([[0, 1], [1, 2]])
-        self.assertAllEqual(outputs, expected_outputs)
+        output = generate(prompt, state)
+        self.assertEqual(self.join_as_string(output), ["sequentially"])

--- a/keras_nlp/samplers/top_k_sampler_test.py
+++ b/keras_nlp/samplers/top_k_sampler_test.py
@@ -32,8 +32,8 @@ class TopKSamplerTest(tf.test.TestCase, parameterized.TestCase):
 
         def next(prompt, state, index):
             # Return a probability distribution favoring the next char in state.
-            probs = tf.one_hot(state[:, index], self.vocab_size) * 1e9
-            return probs, state
+            logits = tf.one_hot(state[:, index], self.vocab_size) * 1e9
+            return logits, state
 
         self.next = next
         self.sampler = TopKSampler(k=5)
@@ -44,9 +44,9 @@ class TopKSamplerTest(tf.test.TestCase, parameterized.TestCase):
     def test_stateless(self):
         def next(prompt, state, index):
             # Return a probability distribution favoring the first index.
-            probs = np.zeros((self.batch_size, self.vocab_size))
-            probs[:, 0] = 1e9
-            return tf.constant(probs), state
+            logits = np.zeros((self.batch_size, self.vocab_size))
+            logits[:, 0] = 1e9
+            return tf.constant(logits), state
 
         prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
         output = self.sampler(
@@ -82,9 +82,9 @@ class TopKSamplerTest(tf.test.TestCase, parameterized.TestCase):
     def test_outputs_in_top_k(self):
         def next(prompt, state, index):
             # Return a distribution where each id is progressively less likely.
-            probs = self.vocab_size - tf.range(self.vocab_size, dtype="float32")
-            probs = tf.repeat(probs[tf.newaxis, :], self.batch_size, axis=0)
-            return probs, state
+            logits = tf.range(self.vocab_size, 0, -1, dtype="float32")
+            logits = tf.repeat(logits[tf.newaxis, :], self.batch_size, axis=0)
+            return logits, state
 
         prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
         output = self.sampler(

--- a/keras_nlp/samplers/top_p_sampler.py
+++ b/keras_nlp/samplers/top_p_sampler.py
@@ -41,30 +41,23 @@ class TopPSampler(Sampler):
 
     Examples:
     ```python
-    VOCAB_SIZE = 10
+    # Use a simple alphabet of lowercase characters to [0, 26).
+    int_lookup = {i: chr(i + ord('a')) for i in range(26)}
+    char_lookup = {v: k for k, v in int_lookup.items()}
+    batch_size, length, vocab_size = 1, 12, len(int_lookup)
 
-    # Create a dummy model to predict the next token.
-    model = keras.Sequential(
-        [
-            keras.Input(shape=[None]),
-            keras.layers.Embedding(
-                input_dim=VOCAB_SIZE,
-                output_dim=16,
-            ),
-            keras.layers.Dense(VOCAB_SIZE, activation="softmax"),
-        ]
+    def next(prompt, state, index):
+        # A uniform distribution over our alphabet.
+        probs = tf.ones((batch_size, vocab_size))
+        return probs, state
+
+    output = keras_nlp.samplers.TopPSampler(p=0.1)(
+        next=next,
+        prompt=tf.fill((batch_size, length,), char_lookup['z']),
+        index=5,
     )
-
-    # Define a function that outputs the next token's probability for each token
-    # in the input sequence.
-    def token_probability_fn(inputs, mask):
-        return model(inputs)
-
-    prompt = tf.fill((8, 1), 1)
-
-    sampler = keras_nlp.samplers.TopPSampler(p=0.1)
-    # Print the generated sequence (token ids).
-    print(sampler(prompt, token_probability_fn, max_length=10))
+    print(["".join([int_lookup[i] for i in s]) for s in output.numpy()])
+    # >>> "zzzzzbabcccb"
     ```
     """
 

--- a/keras_nlp/samplers/top_p_sampler.py
+++ b/keras_nlp/samplers/top_p_sampler.py
@@ -48,8 +48,8 @@ class TopPSampler(Sampler):
 
     def next(prompt, state, index):
         # A uniform distribution over our alphabet.
-        probs = tf.ones((batch_size, vocab_size))
-        return probs, state
+        logits = tf.ones((batch_size, vocab_size))
+        return logits, state
 
     output = keras_nlp.samplers.TopPSampler(p=0.1)(
         next=next,
@@ -70,27 +70,27 @@ class TopPSampler(Sampler):
         self.p = p
         self.seed = seed
 
-    def get_next_token(self, probs):
+    def get_next_token(self, probabilities):
         # Sort preds in descending order.
         sorted_preds, sorted_indices = tf.math.top_k(
-            probs, k=tf.shape(probs)[1], sorted=True
+            probabilities, k=tf.shape(probabilities)[1], sorted=True
         )
         # Calculate cumulative probability distribution.
-        cumulative_probs = tf.math.cumsum(sorted_preds, axis=-1)
+        cumulative_probabilities = tf.math.cumsum(sorted_preds, axis=-1)
         # Create a mask for the tokens to keep.
-        keep_mask = cumulative_probs <= self.p
+        keep_mask = cumulative_probabilities <= self.p
         # Shift to include the last token that exceed p.
         shifted_keep_mask = tf.concat(
             [tf.ones_like(keep_mask[:, :1]), keep_mask[:, :-1]], axis=-1
         )
         # Filter out unmasked tokens and sample from filtered distribution.
-        probs = tf.where(
+        probabilities = tf.where(
             shifted_keep_mask,
             sorted_preds,
-            tf.zeros(tf.shape(probs), dtype=sorted_preds.dtype),
+            tf.zeros(tf.shape(probabilities), dtype=sorted_preds.dtype),
         )
         sorted_next_token = tf.random.categorical(
-            tf.math.log(probs), 1, seed=self.seed
+            tf.math.log(probabilities), 1, seed=self.seed
         )
         return tf.gather_nd(sorted_indices, sorted_next_token, batch_dims=1)
 

--- a/keras_nlp/samplers/top_p_sampler_test.py
+++ b/keras_nlp/samplers/top_p_sampler_test.py
@@ -32,8 +32,8 @@ class TopPSamplerTest(tf.test.TestCase, parameterized.TestCase):
 
         def next(prompt, state, index):
             # Return a probability distribution favoring the next char in state.
-            probs = tf.one_hot(state[:, index], self.vocab_size) * 1e9
-            return probs, state
+            logits = tf.one_hot(state[:, index], self.vocab_size) * 1e9
+            return logits, state
 
         self.next = next
         self.sampler = TopPSampler(p=0.1)
@@ -44,9 +44,9 @@ class TopPSamplerTest(tf.test.TestCase, parameterized.TestCase):
     def test_stateless(self):
         def next(prompt, state, index):
             # Return a probability distribution favoring the first index.
-            probs = np.zeros((self.batch_size, self.vocab_size))
-            probs[:, 0] = 1e9
-            return tf.constant(probs), state
+            logits = np.zeros((self.batch_size, self.vocab_size))
+            logits[:, 0] = 1e9
+            return tf.constant(logits), state
 
         prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
         output = self.sampler(
@@ -82,15 +82,14 @@ class TopPSamplerTest(tf.test.TestCase, parameterized.TestCase):
     def test_outputs_in_top_p(self):
         def next(prompt, state, index):
             # Return a probability distribution favoring the first index.
-            probs = np.zeros((self.batch_size, self.vocab_size))
-            probs[:, 0:2] = 0.1
-            return tf.constant(probs), state
+            probabilities = np.zeros((self.batch_size, self.vocab_size)) + -1e9
+            probabilities[:, 0:3] = 0.1
+            return tf.math.log(probabilities), state
 
         prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
         output = TopPSampler(p=0.3)(
             next=next,
             prompt=prompt,
-            from_logits=False,
         )
         output_ids = set(output[0].numpy())
         self.assertContainsSubset(output_ids, range(3))

--- a/keras_nlp/samplers/top_p_sampler_test.py
+++ b/keras_nlp/samplers/top_p_sampler_test.py
@@ -31,7 +31,7 @@ class TopPSamplerTest(tf.test.TestCase, parameterized.TestCase):
         self.vocab_size = len(self.int_lookup)
 
         def next(prompt, state, index):
-            # Return a probability distribution favoring the next char in state.
+            # Return a distribution favoring the next char in state.
             logits = tf.one_hot(state[:, index], self.vocab_size) * 1e9
             return logits, state
 
@@ -41,9 +41,9 @@ class TopPSamplerTest(tf.test.TestCase, parameterized.TestCase):
     def join_as_string(self, x):
         return ["".join([self.int_lookup[i] for i in s]) for s in x.numpy()]
 
-    def test_stateless(self):
+    def test_stateless_call(self):
         def next(prompt, state, index):
-            # Return a probability distribution favoring the first index.
+            # Return a distribution favoring the first token in the vocab.
             logits = np.zeros((self.batch_size, self.vocab_size))
             logits[:, 0] = 1e9
             return tf.constant(logits), state
@@ -56,7 +56,7 @@ class TopPSamplerTest(tf.test.TestCase, parameterized.TestCase):
         )
         self.assertEqual(self.join_as_string(output), ["zzzzzaaaaaaa"])
 
-    def test_stateful(self):
+    def test_stateful_call(self):
         state_chars = list("sequentially")
         state = tf.constant([[self.char_lookup[c] for c in state_chars]])
         prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])

--- a/keras_nlp/samplers/top_p_sampler_test.py
+++ b/keras_nlp/samplers/top_p_sampler_test.py
@@ -16,7 +16,6 @@
 import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
 from keras_nlp.samplers.top_p_sampler import TopPSampler
 
@@ -24,148 +23,89 @@ from keras_nlp.samplers.top_p_sampler import TopPSampler
 class TopPSamplerTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
         super().setUp()
-        self.vocab_size = 10
-        self.feature_size = 16
+        # Use a simple alphabet of lowercase characters to [0, 26).
+        self.int_lookup = {i: chr(i + ord("a")) for i in range(26)}
+        self.char_lookup = {v: k for k, v in self.int_lookup.items()}
+        self.batch_size = 1
+        self.length = 12
+        self.vocab_size = len(self.int_lookup)
 
-        # Create a dummy model to predict the next token.
-        model = keras.Sequential(
-            [
-                keras.Input(shape=[None]),
-                keras.layers.Embedding(
-                    input_dim=self.vocab_size,
-                    output_dim=self.feature_size,
-                ),
-                keras.layers.Dense(self.vocab_size),
-                keras.layers.Softmax(),
-            ]
-        )
+        def next(prompt, state, index):
+            # Return a probability distribution favoring the next char in state.
+            probs = tf.one_hot(state[:, index], self.vocab_size) * 1e9
+            return probs, state
 
-        def token_probability_fn(inputs, mask):
-            return model(inputs)
-
-        self.token_probability_fn = token_probability_fn
+        self.next = next
         self.sampler = TopPSampler(p=0.1)
 
-    def test_generate_with_1d_prompt(self):
-        inputs = tf.constant([1])
+    def join_as_string(self, x):
+        return ["".join([self.int_lookup[i] for i in s]) for s in x.numpy()]
 
-        outputs = self.sampler(inputs, self.token_probability_fn, max_length=5)
-        self.assertEqual(outputs.shape, [5])
+    def test_stateless(self):
+        def next(prompt, state, index):
+            # Return a probability distribution favoring the first index.
+            probs = np.zeros((self.batch_size, self.vocab_size))
+            probs[:, 0] = 1e9
+            return tf.constant(probs), state
 
-    def test_generate_with_2d_prompt(self):
-        inputs = tf.constant([[1], [1]])
-        outputs = self.sampler(inputs, self.token_probability_fn, max_length=5)
-        self.assertEqual(outputs.shape, [2, 5])
+        prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
+        output = self.sampler(
+            next=next,
+            prompt=prompt,
+            index=5,
+        )
+        self.assertEqual(self.join_as_string(output), ["zzzzzaaaaaaa"])
 
-    def test_generate_with_list_prompt(self):
-        inputs = [[1], [1]]
-        outputs = self.sampler(inputs, self.token_probability_fn, max_length=5)
-        self.assertEqual(outputs.shape, [2, 5])
+    def test_stateful(self):
+        state_chars = list("sequentially")
+        state = tf.constant([[self.char_lookup[c] for c in state_chars]])
+        prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
+        output = self.sampler(
+            next=self.next,
+            prompt=prompt,
+            state=state,
+        )
+        self.assertEqual(self.join_as_string(output), ["sequentially"])
 
-    def test_generate_with_ragged_prompt(self):
-        def token_probability_fn(inputs, mask):
-            batch_size, seq_length = tf.shape(inputs)[0], tf.shape(inputs)[1]
-            prob = tf.constant([[[0.0, 0.0, 0.0, 1.0]]])
-            return tf.tile(prob, [batch_size, seq_length, 1])
+    def test_early_stopping(self):
+        state_chars = list("sequentially")
+        state = tf.constant([[self.char_lookup[c] for c in state_chars]])
+        prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
+        output = self.sampler(
+            next=self.next,
+            prompt=prompt,
+            state=state,
+            end_token_id=self.char_lookup["t"],
+        )
+        self.assertEqual(self.join_as_string(output), ["sequentzzzzz"])
 
-        inputs = tf.ragged.constant([[1], [2, 1, 2]])
-        outputs = self.sampler(
-            inputs,
-            token_probability_fn,
-            max_length=5,
+    def test_outputs_in_top_p(self):
+        def next(prompt, state, index):
+            # Return a probability distribution favoring the first index.
+            probs = np.zeros((self.batch_size, self.vocab_size))
+            probs[:, 0:2] = 0.1
+            return tf.constant(probs), state
+
+        prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
+        output = TopPSampler(p=0.3)(
+            next=next,
+            prompt=prompt,
             from_logits=False,
         )
-        self.assertEqual(outputs.shape, [2, 5])
+        output_ids = set(output[0].numpy())
+        self.assertContainsSubset(output_ids, range(3))
 
     @parameterized.named_parameters(
-        ("xla_graph", True, False),
-        ("non_xla_graph", False, False),
-        ("eager", False, True),
+        ("jit_compile_false", False), ("jit_compile_true", True)
     )
-    def test_assert_probability_distribution_generation_is_correct(
-        self, jit_compile, run_eagerly
-    ):
-        def token_probability_fn(inputs, mask):
-            batch_size, seq_length = tf.shape(inputs)[0], tf.shape(inputs)[1]
-            prob = tf.constant([[[0.0, 0.0, 0.0, 1.0]]])
-            return tf.tile(prob, [batch_size, seq_length, 1])
+    def test_compilation(self, jit_compile):
+        state_chars = list("sequentially")
+        state = tf.constant([[self.char_lookup[c] for c in state_chars]])
+        prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
 
-        batch_size = 10
-        inputs = 3 * tf.ones([batch_size, 1], dtype=tf.int32)
-        max_length = 3
+        @tf.function(jit_compile=jit_compile)
+        def generate(prompt, state):
+            return self.sampler(self.next, prompt=prompt, state=state)
 
-        outputs_count = np.array([0, 0, 0, 0])
-        tf.random.set_seed(42)
-        sampler = TopPSampler(
-            p=0.1,
-            seed=42,
-            run_eagerly=jit_compile,
-            jit_compile=run_eagerly,
-        )
-        for _ in range(8):
-            outputs = sampler(
-                inputs,
-                token_probability_fn,
-                max_length=max_length,
-                from_logits=False,
-            )
-            flatten_predictions = tf.reshape(outputs[:, 1:], [-1])
-            for pred in flatten_predictions:
-                outputs_count[pred] += 1
-        self.assertAllClose(
-            outputs_count / np.sum(outputs_count),
-            [0.0, 0.0, 0.0, 1.0],
-            rtol=0.2,
-        )
-
-    def test_only_choose_from_top_p_tokens(self):
-        # Test that there are only the top-p tokens in the output.
-        def token_probability_fn(inputs, mask):
-            batch_size, seq_length = tf.shape(inputs)[0], tf.shape(inputs)[1]
-            prob = tf.constant([[[0.4, 0.3, 0.2, 0.1]]])
-            return tf.tile(prob, [batch_size, seq_length, 1])
-
-        # Test that it only samples from top-p tokens.
-        for i, p in enumerate([0.399, 0.699, 0.899]):
-            inputs = tf.constant([[0, 0], [0, 0]])
-            sampler = TopPSampler(p=p)
-            for _ in range(10):
-                outputs = sampler(
-                    inputs,
-                    token_probability_fn,
-                    max_length=5,
-                    from_logits=False,
-                )
-                self.assertAllEqual(outputs <= i, tf.ones_like(outputs))
-
-    def test_end_token_id(self):
-        def token_probability_fn(inputs, mask):
-            batch_size, seq_length = tf.shape(inputs)[0], tf.shape(inputs)[1]
-            prob = tf.constant([[[0.0, 0.0, 0.0, 1.0]]])
-            return tf.tile(prob, [batch_size, seq_length, 1])
-
-        tf.random.set_seed(42)
-        sampler = TopPSampler(p=0.1, seed=42)
-        max_length = 4
-        inputs = tf.constant([[0, 1], [1, 2]])
-        outputs = sampler(
-            inputs,
-            token_probability_fn,
-            max_length=max_length,
-            end_token_id=2,
-            from_logits=False,
-        )
-        # end_token in prompt does not trigger truncation.
-        expected_outputs = tf.ragged.constant([[0, 1, 3, 3], [1, 2, 3, 3]])
-        self.assertAllEqual(outputs, expected_outputs)
-
-        outputs = sampler(
-            inputs,
-            token_probability_fn,
-            max_length=max_length,
-            end_token_id=3,
-            from_logits=False,
-        )
-        # Generated end_token will be truncated.
-        expected_outputs = tf.ragged.constant([[0, 1], [1, 2]])
-        self.assertAllEqual(outputs, expected_outputs)
+        output = generate(prompt, state)
+        self.assertEqual(self.join_as_string(output), ["sequentially"])

--- a/keras_nlp/samplers/top_p_sampler_test.py
+++ b/keras_nlp/samplers/top_p_sampler_test.py
@@ -81,13 +81,11 @@ class TopPSamplerTest(tf.test.TestCase, parameterized.TestCase):
 
     def test_outputs_in_top_p(self):
         def next(prompt, state, index):
-            # Return a probability distribution favoring the first index.
-            probabilities = np.zeros((self.batch_size, self.vocab_size)) + -1e9
-            probabilities[:, 0:3] = 0.1
-            return tf.math.log(probabilities), state
+            logits = np.zeros((self.batch_size, self.vocab_size))
+            return tf.constant(logits), state
 
         prompt = tf.fill((self.batch_size, self.length), self.char_lookup["z"])
-        output = TopPSampler(p=0.3)(
+        output = TopPSampler(p=(2.0 / self.vocab_size))(
             next=next,
             prompt=prompt,
         )

--- a/keras_nlp/utils/tf_utils.py
+++ b/keras_nlp/utils/tf_utils.py
@@ -66,7 +66,7 @@ def tensor_to_string_list(inputs):
     return _decode_strings_to_utf8(list_outputs)
 
 
-def truncate_at(inputs, token, mask):
+def truncate_at_token(inputs, token, mask):
     """Truncate at first instance of `token`, ignoring `mask`."""
     matches = (inputs == token) & (~mask)
     end_indices = tf.cast(tf.math.argmax(matches, -1), "int32")

--- a/keras_nlp/utils/tf_utils.py
+++ b/keras_nlp/utils/tf_utils.py
@@ -66,6 +66,14 @@ def tensor_to_string_list(inputs):
     return _decode_strings_to_utf8(list_outputs)
 
 
+def truncate_at(inputs, end_token_id, mask):
+    """Truncates input to a ragged at first instance of end_token_id"""
+    end_tokens = (inputs == end_token_id) & (~mask)
+    end_indices = tf.cast(tf.math.argmax(end_tokens, -1), "int32")
+    end_indices = tf.where(end_indices == 0, tf.shape(inputs)[-1], end_indices)
+    return tf.RaggedTensor.from_tensor(inputs, end_indices)
+
+
 def assert_tf_text_installed(symbol_name):
     """Detokenize and convert tensor to nested lists of python strings."""
     if tf_text is None:

--- a/keras_nlp/utils/tf_utils.py
+++ b/keras_nlp/utils/tf_utils.py
@@ -66,10 +66,10 @@ def tensor_to_string_list(inputs):
     return _decode_strings_to_utf8(list_outputs)
 
 
-def truncate_at(inputs, end_token_id, mask):
-    """Truncates input to a ragged at first instance of end_token_id"""
-    end_tokens = (inputs == end_token_id) & (~mask)
-    end_indices = tf.cast(tf.math.argmax(end_tokens, -1), "int32")
+def truncate_at(inputs, token, mask):
+    """Truncate at first instance of `token`, ignoring `mask`."""
+    matches = (inputs == token) & (~mask)
+    end_indices = tf.cast(tf.math.argmax(matches, -1), "int32")
     end_indices = tf.where(end_indices == 0, tf.shape(inputs)[-1], end_indices)
     return tf.RaggedTensor.from_tensor(inputs, end_indices)
 


### PR DESCRIPTION
This demos a fix for https://github.com/keras-team/keras-nlp/issues/779 by moving the compilation up to the causal_lm model, where we can most easily control the conditions for recompilation.

This has a few advantages:

 - We only need to tokenize once.
 - All forward passes on the model, including cache seeding, can live in the compiled function.
 - We expose compilation in a similar way to `keras.Model` train step. There is a overridable `make_generate_function` (similar to `make_train_function`) and a accessible `model.generate_function` property on the model.

Demo -> https://colab.research.google.com/gist/mattdangerw/ea205181ef56d1d95860e8b3f4a9db4d/generate-compile-demo.ipynb