### PR TITLE
Add checkpoints for GPT2 on chinese poetry

### DIFF
--- a/keras_nlp/models/gpt2/gpt2_presets.py
+++ b/keras_nlp/models/gpt2/gpt2_presets.py
@@ -154,4 +154,31 @@ backbone_presets = {
         "merges_url": "https://storage.googleapis.com/keras-nlp/models/gpt2_base_en_news/v1/merges.txt",
         "merges_hash": "75a37753dd7a28a2c5df80c28bf06e4e",
     },
+    "gpt2_base_cn_poetry": {
+        "metadata": {
+            "description": (
+                "12-layer GPT-2 model, finetuned on the Chinese poetry dataset "
+                "全唐诗(https://github.com/chinese-poetry/chinese-poetry/tree/master/quan_tang_shi)."
+            ),
+            "params": 124439808,
+            "official_name": "GPT-2",
+            "path": "gpt2",
+        },
+        "config": {
+            "vocabulary_size": 50257,
+            "num_layers": 12,
+            "num_heads": 12,
+            "hidden_dim": 768,
+            "intermediate_dim": 3072,
+            "dropout": 0.1,
+            "max_sequence_length": 1024,
+        },
+        "preprocessor_config": {},
+        "weights_url": "https://storage.googleapis.com/keras-nlp/models/gpt2_base_cn_poetry/v1/model.h5",
+        "weights_hash": "ef68d8940bc108d02e53318bd905925d",
+        "vocabulary_url": "https://storage.googleapis.com/keras-nlp/models/gpt2_base_cn_poetry/v1/vocab.json",
+        "vocabulary_hash": "dffec25a898b1f5e569bec4dffd7e5c0",
+        "merges_url": "https://storage.googleapis.com/keras-nlp/models/gpt2_base_cn_poetry/v1/merges.txt",
+        "merges_hash": "75a37753dd7a28a2c5df80c28bf06e4e",
+    },
 }

--- a/tools/checkpoint_training/gpt2_base_cn_poetry_training.ipynb
+++ b/tools/checkpoint_training/gpt2_base_cn_poetry_training.ipynb
@@ -1,0 +1,340 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 0,
+ "metadata": {
+  "colab": {
+   "provenance": [],
+   "machine_shape": "hm"
+  },
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "accelerator": "GPU",
+  "gpuClass": "premium"
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Install KerasNLP and Import Dependencies."
+   ],
+   "metadata": {
+    "id": "AmJ2n25CtdiL"
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "fDG7RavCK0cq",
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "outputId": "a5d28081-e73c-4ca3-b0c2-8744bda75ce6"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Preparing metadata (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.8/5.8 MB\u001b[0m \u001b[31m49.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h  Building wheel for keras-nlp (setup.py) ... \u001b[?25l\u001b[?25hdone\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install -q -U git+https://github.com/keras-team/keras-nlp.git@master"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "import keras_nlp\n",
+    "import tensorflow as tf\n",
+    "from tensorflow import keras"
+   ],
+   "metadata": {
+    "id": "w-cqlGMjZcnr"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Load `GPT2CausalLM` from KerasNLP.\n",
+    "\n",
+    "`GPT2CausalLM` is basically a GPT2 model, followed by multiplying the outputs by the embedding matrix."
+   ],
+   "metadata": {
+    "id": "cUNLW0dmfztt"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# To speed up, we use preprocessor of length 256 instead of full length 1024.\n",
+    "preprocessor = keras_nlp.models.GPT2CausalLMPreprocessor.from_preset(\n",
+    "    \"gpt2_base_en\",\n",
+    "    sequence_length=256,\n",
+    "    add_end_token=True,\n",
+    ")\n",
+    "gpt2_lm = keras_nlp.models.GPT2CausalLM.from_preset(\n",
+    "    \"gpt2_base_en\", preprocessor=preprocessor\n",
+    ")"
+   ],
+   "metadata": {
+    "id": "g8K-J0MSaCHs",
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "outputId": "0b83ef4f-e3e5-4741-c40c-1cba48dda629"
+   },
+   "execution_count": null,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Downloading data from https://storage.googleapis.com/keras-nlp/models/gpt2_base_en/v1/vocab.json\n",
+      "1042301/1042301 [==============================] - 0s 0us/step\n",
+      "Downloading data from https://storage.googleapis.com/keras-nlp/models/gpt2_base_en/v1/merges.txt\n",
+      "456318/456318 [==============================] - 0s 0us/step\n",
+      "Downloading data from https://storage.googleapis.com/keras-nlp/models/gpt2_base_en/v1/model.h5\n",
+      "497986112/497986112 [==============================] - 4s 0us/step\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "WARNING:tensorflow:The following Variables were used in a Lambda layer's call (tf.linalg.matmul), but are not present in its tracked objects:   <tf.Variable 'token_embedding/embeddings:0' shape=(50257, 768) dtype=float32>. This is a strong indication that the Lambda layer should be rewritten as a subclassed Layer.\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Finetune on Chinese Poem Dataset\n",
+    "\n",
+    "We can also finetune GPT2 on non-English datasets. For readers knowing Chinese, this part illustrates how to finetung GPT2 on Chinese poem dataset to teach our model to become a poet!"
+   ],
+   "metadata": {
+    "id": "TsQYq2AutrC7"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# Load chinese poetry dataset.\n",
+    "!git clone https://github.com/chinese-poetry/chinese-poetry.git"
+   ],
+   "metadata": {
+    "id": "pj7FPbW_b76j",
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "outputId": "b07344be-550d-45fb-93f3-1c126738196c"
+   },
+   "execution_count": null,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Cloning into 'chinese-poetry'...\n",
+      "remote: Enumerating objects: 7210, done.\u001b[K\n",
+      "remote: Counting objects: 100% (15/15), done.\u001b[K\n",
+      "remote: Compressing objects: 100% (11/11), done.\u001b[K\n",
+      "remote: Total 7210 (delta 3), reused 13 (delta 3), pack-reused 7195\u001b[K\n",
+      "Receiving objects: 100% (7210/7210), 197.74 MiB | 35.88 MiB/s, done.\n",
+      "Resolving deltas: 100% (5292/5292), done.\n",
+      "Updating files: 100% (2282/2282), done.\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "import os\n",
+    "import json\n",
+    "\n",
+    "poem_collection = []\n",
+    "for file in os.listdir(\"chinese-poetry/quan_tang_shi/json\"):\n",
+    "    full_filename = \"%s/%s\" % (\"chinese-poetry/quan_tang_shi/json\", file)\n",
+    "    with open(full_filename, \"r\") as f:\n",
+    "        content = json.load(f)\n",
+    "        poem_collection.extend(content)"
+   ],
+   "metadata": {
+    "id": "tOi15fJ2opst"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "paragraphs = [\"\".join(data[\"paragraphs\"]) for data in poem_collection]\n",
+    "print(paragraphs[0])"
+   ],
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "L5l4GbUIorCy",
+    "outputId": "84cd1752-d47b-4d39-9b04-f92e0fbe37f8"
+   },
+   "execution_count": null,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "數萼初含雪，孤標畫本難。香中別有韻，清極不知寒。橫笛和愁聽，斜枝倚病看。朔風如解意，容易莫摧殘。\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "train_ds = (\n",
+    "    tf.data.Dataset.from_tensor_slices(paragraphs)\n",
+    "    .batch(16)\n",
+    "    .prefetch(tf.data.AUTOTUNE)\n",
+    ")\n",
+    "train_ds = train_ds.take(2000)"
+   ],
+   "metadata": {
+    "id": "4q9kp3MgzROf"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "num_epochs = 3\n",
+    "\n",
+    "lr = tf.keras.optimizers.schedules.PolynomialDecay(\n",
+    "    5e-4,\n",
+    "    decay_steps=train_ds.cardinality() * num_epochs,\n",
+    "    end_learning_rate=0.0,\n",
+    ")\n",
+    "loss = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)\n",
+    "gpt2_lm.compile(\n",
+    "    optimizer=keras.optimizers.Adam(lr),\n",
+    "    loss=loss,\n",
+    "    weighted_metrics=[\"accuracy\"],\n",
+    ")\n",
+    "\n",
+    "gpt2_lm.fit(train_ds, epochs=num_epochs)"
+   ],
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "ZOiiQ_NBos72",
+    "outputId": "1be08fc5-2882-4b2e-8c62-f8e69e31add8"
+   },
+   "execution_count": null,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "WARNING:tensorflow:From /usr/local/lib/python3.9/dist-packages/tensorflow/python/autograph/pyct/static_analysis/liveness.py:83: Analyzer.lamba_check (from tensorflow.python.autograph.pyct.static_analysis.liveness) is deprecated and will be removed after 2023-09-23.\n",
+      "Instructions for updating:\n",
+      "Lambda fuctions will be no more assumed to be used in the statement where they are used, or at least in the same block. https://github.com/tensorflow/tensorflow/issues/56089\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Epoch 1/3\n",
+      "2000/2000 [==============================] - 667s 311ms/step - loss: 1.2548 - accuracy: 0.3422\n",
+      "Epoch 2/3\n",
+      "2000/2000 [==============================] - 624s 312ms/step - loss: 1.1010 - accuracy: 0.4073\n",
+      "Epoch 3/3\n",
+      "2000/2000 [==============================] - 626s 313ms/step - loss: 1.0125 - accuracy: 0.4487\n"
+     ]
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "<keras.callbacks.History at 0x7f0bdc0f3a30>"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 9
+    }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "output = gpt2_lm.generate(\"昨夜雨疏风骤\", max_length=200)\n",
+    "print(output.numpy().decode(\"utf-8\"))"
+   ],
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "D9Pa5gfPo0hR",
+    "outputId": "fa066323-1265-4a35-8754-06eab8ca8a66"
+   },
+   "execution_count": null,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "昨夜雨疏风骤清，今朝暗見鶴悠悠。獨攜清淨深芳院，欹歌白鶴應頻別，獨自長江獨不同。\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Not bad 😀"
+   ],
+   "metadata": {
+    "id": "mw4_j_7vFIPG"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# You can save the weights for future usage.\n",
+    "gpt2_lm.backbone.save_weights(\"/content/model.h5\")"
+   ],
+   "metadata": {
+    "id": "7jZdveEHGbZw"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "!md5sum /content/model.h5"
+   ],
+   "metadata": {
+    "id": "4M-Ux8IKsAx4"
+   },
+   "execution_count": null,
+   "outputs": []
+  }
+ ]
+}


### PR DESCRIPTION
Finetuned on Chinese poetry dataset. This could draw some interest in our Chinese community. 

To play with the preset, install this branch:
```
!pip install -q -U git+https://github.com/chenmoneygithub/keras-nlp.git@cn-poetry-preset
```

Then use the code below:
```
import keras_nlp

gpt2_lm = keras_nlp.models.GPT2CausalLM.from_preset("gpt2_base_zh_poetry")
output = gpt2_lm.generate(
    "兔子老虎鸡",
    max_length=30,
)
print(output.numpy().decode("utf-8"))
```

I got this as sample output:
```
'兔子老虎鸡，群峰絕山青。'
```