### PR TITLE
Modify generate() method in GPT2CausalLM to support chatbot 

### DIFF
--- a/keras_nlp/models/gpt2/gpt2_causal_lm.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm.py
@@ -275,6 +275,7 @@ class GPT2CausalLM(Task):
         prompt,
         max_length,
         sampler="top_k",
+        append_end_token=False,
     ):
         """Generate text.
 


### PR DESCRIPTION
Modify generate() method in GPT2CausalLM to support chatbot #844

The gap we have is about the end_token_id. In a chatbot system like DialoGPT , the user prompt needs to be concatenated by an end_token before generation, otherwise it will just generate end_token and stop. One simple fix is to add an argument to generate() method, e.g., append_end_token=False, when which is True the prompt will be appended by an end_token before calling our sampler.



cc:  @chenmoneygithub 