### PR TITLE
Update BytePairTokenizerCache to have similar dtypes for x and y in self.factors.

### DIFF
--- a/keras_nlp/tokenizers/byte_pair_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer.py
@@ -129,7 +129,7 @@ class BytePairTokenizerCache(tf.Module):
         # string mapping. So we first convert to string to an integer key, and
         # use the integer key to find the value.
         self.factors = tf.pow(
-            tf.constant([256], dtype=tf.int64), tf.range(0, 8, dtype=tf.int64)
+            tf.constant(256, dtype=tf.int64), tf.range(0, 8, dtype=tf.int64)
         )
         self.id2value = tf.lookup.experimental.MutableHashTable(
             tf.int64, tf.string, ""

--- a/keras_nlp/tokenizers/byte_pair_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer.py
@@ -128,7 +128,9 @@ class BytePairTokenizerCache(tf.Module):
         # `tf.lookup.experimental.MutableHashTable` does not support string to
         # string mapping. So we first convert to string to an integer key, and
         # use the integer key to find the value.
-        self.factors = tf.pow(256, tf.range(0, 8, dtype=tf.int64))
+        self.factors = tf.pow(
+            tf.constant([256], dtype=tf.int64), tf.range(0, 8, dtype=tf.int64)
+        )
         self.id2value = tf.lookup.experimental.MutableHashTable(
             tf.int64, tf.string, ""
         )


### PR DESCRIPTION
Fix for issue #870. `tf.pow` was invoked with different dtypes resulting in errors when executing in graph mode. Setting the dtype to tf.int64 fixes the issue.

