### PR TITLE
Speeding the tests for T5

### DIFF
--- a/keras_nlp/models/t5/t5_tokenizer_test.py
+++ b/keras_nlp/models/t5/t5_tokenizer_test.py
@@ -17,6 +17,7 @@
 import io
 import os
 
+import pytest
 import sentencepiece
 import tensorflow as tf
 from absl.testing import parameterized
@@ -81,10 +82,19 @@ class T5TokenizerTest(tf.test.TestCase, parameterized.TestCase):
         with self.assertRaises(ValueError):
             T5Tokenizer(proto=bytes_io.getvalue())
 
+    def test_serialization(self):
+        config = keras.utils.serialize_keras_object(self.tokenizer)
+        new_tokenizer = keras.utils.deserialize_keras_object(config)
+        self.assertEqual(
+            new_tokenizer.get_config(),
+            self.tokenizer.get_config(),
+        )
+
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),
     )
+    @pytest.mark.large  # Saving is slow, so mark these large.
     def test_saved_model(self, save_format, filename):
         input_data = tf.constant(["the quick brown fox"])
 


### PR DESCRIPTION
What does this PR do?
This PR modifies tests as described in https://github.com/keras-team/keras-nlp/issues/866 for `T5`.

**Results**
before - 15 passed, 4 skipped in 23.48s
after - 14 passed, 6 skipped in 8.25s
 **2.84 times speedup(on my local machine)**

@mattdangerw @chenmoneygithub 