### PR TITLE
Speed up default FNet testing speedups.

### DIFF
--- a/keras_nlp/layers/masked_lm_mask_generator.py
+++ b/keras_nlp/layers/masked_lm_mask_generator.py
@@ -148,11 +148,7 @@ class MaskedLMMaskGenerator(keras.layers.Layer):
             # convert dense to ragged.
             inputs = tf.RaggedTensor.from_tensor(inputs)
 
-        (
-            token_ids,
-            mask_positions,
-            mask_ids,
-        ) = tf_text.mask_language_model(
+        (token_ids, mask_positions, mask_ids,) = tf_text.mask_language_model(
             inputs,
             item_selector=self._random_selector,
             mask_values_chooser=self._mask_values_chooser,

--- a/keras_nlp/layers/masked_lm_mask_generator.py
+++ b/keras_nlp/layers/masked_lm_mask_generator.py
@@ -148,7 +148,11 @@ class MaskedLMMaskGenerator(keras.layers.Layer):
             # convert dense to ragged.
             inputs = tf.RaggedTensor.from_tensor(inputs)
 
-        (token_ids, mask_positions, mask_ids,) = tf_text.mask_language_model(
+        (
+            token_ids,
+            mask_positions,
+            mask_ids,
+        ) = tf_text.mask_language_model(
             inputs,
             item_selector=self._random_selector,
             mask_values_chooser=self._mask_values_chooser,

--- a/keras_nlp/models/f_net/f_net_backbone_test.py
+++ b/keras_nlp/models/f_net/f_net_backbone_test.py
@@ -26,7 +26,7 @@ from keras_nlp.models.f_net.f_net_backbone import FNetBackbone
 class FNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
         self.backbone = FNetBackbone(
-            vocabulary_size=100,
+            vocabulary_size=10,
             num_layers=2,
             hidden_dim=2,
             intermediate_dim=4,

--- a/keras_nlp/models/f_net/f_net_backbone_test.py
+++ b/keras_nlp/models/f_net/f_net_backbone_test.py
@@ -26,7 +26,7 @@ from keras_nlp.models.f_net.f_net_backbone import FNetBackbone
 class FNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
         self.backbone = FNetBackbone(
-            vocabulary_size=1000,
+            vocabulary_size=100,
             num_layers=2,
             hidden_dim=2,
             intermediate_dim=4,
@@ -93,7 +93,7 @@ class FNetBackboneTPUTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
         with self.tpu_strategy.scope():
             self.backbone = FNetBackbone(
-                vocabulary_size=1000,
+                vocabulary_size=100,
                 num_layers=2,
                 hidden_dim=16,
                 intermediate_dim=32,

--- a/keras_nlp/models/f_net/f_net_backbone_test.py
+++ b/keras_nlp/models/f_net/f_net_backbone_test.py
@@ -59,18 +59,17 @@ class FNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
     def test_predict(self):
         self.backbone.predict(self.input_batch)
         self.backbone.predict(self.input_dataset)
-    
+
     def test_serialization(self):
         new_backbone = keras.utils.deserialize_keras_object(
             keras.utils.serialize_keras_object(self.backbone)
         )
         self.assertEqual(new_backbone.get_config(), self.backbone.get_config())
-    
+
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),
     )
-
     @pytest.mark.large
     def test_saved_model(self, save_format, filename):
         model_output = self.backbone(self.input_batch)

--- a/keras_nlp/models/f_net/f_net_backbone_test.py
+++ b/keras_nlp/models/f_net/f_net_backbone_test.py
@@ -25,22 +25,17 @@ from keras_nlp.models.f_net.f_net_backbone import FNetBackbone
 
 class FNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
-        self.model = FNetBackbone(
+        self.backbone = FNetBackbone(
             vocabulary_size=1000,
             num_layers=2,
-            hidden_dim=16,
-            intermediate_dim=32,
-            max_sequence_length=128,
+            hidden_dim=2,
+            intermediate_dim=4,
+            max_sequence_length=5,
             num_segments=4,
         )
-        self.batch_size = 8
         self.input_batch = {
-            "token_ids": tf.ones(
-                (self.batch_size, self.model.max_sequence_length), dtype="int32"
-            ),
-            "segment_ids": tf.ones(
-                (self.batch_size, self.model.max_sequence_length), dtype="int32"
-            ),
+            "token_ids": tf.ones((2, 5), dtype="int32"),
+            "segment_ids": tf.ones((2, 5), dtype="int32"),
         }
 
         self.input_dataset = tf.data.Dataset.from_tensor_slices(
@@ -48,45 +43,39 @@ class FNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         ).batch(2)
 
     def test_valid_call_f_net(self):
-        self.model(self.input_batch)
+        self.backbone(self.input_batch)
 
         # Check default name passed through
-        self.assertRegexpMatches(self.model.name, "f_net_backbone")
+        self.assertRegexpMatches(self.backbone.name, "f_net_backbone")
 
     def test_variable_sequence_length_call_f_net(self):
-        for seq_length in (25, 50, 75):
+        for seq_length in (2, 3, 4):
             input_data = {
-                "token_ids": tf.ones(
-                    (self.batch_size, seq_length), dtype="int32"
-                ),
-                "segment_ids": tf.ones(
-                    (self.batch_size, seq_length), dtype="int32"
-                ),
+                "token_ids": tf.ones((2, seq_length), dtype="int32"),
+                "segment_ids": tf.ones((2, seq_length), dtype="int32"),
             }
-            self.model(input_data)
+            self.backbone(input_data)
 
-    @parameterized.named_parameters(
-        ("jit_compile_false", False), ("jit_compile_true", True)
-    )
-    def test_compile(self, jit_compile):
-        self.model.compile(jit_compile=jit_compile)
-        self.model.predict(self.input_batch)
-
-    @parameterized.named_parameters(
-        ("jit_compile_false", False), ("jit_compile_true", True)
-    )
-    def test_compile_batched_ds(self, jit_compile):
-        self.model.compile(jit_compile=jit_compile)
-        self.model.predict(self.input_dataset)
-
+    def test_predict(self):
+        self.backbone.predict(self.input_batch)
+        self.backbone.predict(self.input_dataset)
+    
+    def test_serialization(self):
+        new_backbone = keras.utils.deserialize_keras_object(
+            keras.utils.serialize_keras_object(self.backbone)
+        )
+        self.assertEqual(new_backbone.get_config(), self.backbone.get_config())
+    
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),
     )
+
+    @pytest.mark.large
     def test_saved_model(self, save_format, filename):
-        model_output = self.model(self.input_batch)
+        model_output = self.backbone(self.input_batch)
         save_path = os.path.join(self.get_temp_dir(), filename)
-        self.model.save(save_path, save_format=save_format)
+        self.backbone.save(save_path, save_format=save_format)
         restored_model = keras.models.load_model(save_path)
 
         # Check we got the real object back.
@@ -104,7 +93,7 @@ class FNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
 class FNetBackboneTPUTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
         with self.tpu_strategy.scope():
-            self.model = FNetBackbone(
+            self.backbone = FNetBackbone(
                 vocabulary_size=1000,
                 num_layers=2,
                 hidden_dim=16,
@@ -121,5 +110,5 @@ class FNetBackboneTPUTest(tf.test.TestCase, parameterized.TestCase):
         ).batch(2)
 
     def test_predict(self):
-        self.model.compile()
-        self.model.predict(self.input_dataset)
+        self.backbone.compile()
+        self.backbone.predict(self.input_dataset)

--- a/keras_nlp/models/f_net/f_net_classifier_test.py
+++ b/keras_nlp/models/f_net/f_net_classifier_test.py
@@ -61,7 +61,6 @@ class FNetClassifierTest(tf.test.TestCase, parameterized.TestCase):
         self.backbone = FNetBackbone(
             vocabulary_size=self.preprocessor.tokenizer.vocabulary_size(),
             num_layers=2,
-            num_heads=2,
             hidden_dim=2,
             intermediate_dim=4,
             max_sequence_length=self.preprocessor.packer.sequence_length,
@@ -99,6 +98,7 @@ class FNetClassifierTest(tf.test.TestCase, parameterized.TestCase):
         self.classifier.fit(self.preprocessed_dataset)
 
     def test_classifier_fit_no_xla(self):
+        self.classifier.preprocessor = None
         self.classifier.compile(
             loss=keras.losses.SparseCategoricalCrossentropy(from_logits=False),
             jit_compile=False,

--- a/keras_nlp/models/f_net/f_net_classifier_test.py
+++ b/keras_nlp/models/f_net/f_net_classifier_test.py
@@ -93,7 +93,6 @@ class FNetClassifierTest(tf.test.TestCase, parameterized.TestCase):
         self.classifier.preprocessor = None
         self.classifier.predict(self.preprocessed_batch)
 
-    
     def test_fnet_classifier_fit(self):
         self.classifier.fit(self.raw_dataset)
         self.classifier.preprocessor = None
@@ -113,6 +112,7 @@ class FNetClassifierTest(tf.test.TestCase, parameterized.TestCase):
             new_classifier.get_config(),
             self.classifier.get_config(),
         )
+
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),

--- a/keras_nlp/models/f_net/f_net_classifier_test.py
+++ b/keras_nlp/models/f_net/f_net_classifier_test.py
@@ -16,6 +16,7 @@
 import io
 import os
 
+import pytest
 import sentencepiece
 import tensorflow as tf
 from absl.testing import parameterized
@@ -29,15 +30,7 @@ from keras_nlp.models.f_net.f_net_tokenizer import FNetTokenizer
 
 class FNetClassifierTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
-        self.backbone = FNetBackbone(
-            vocabulary_size=1000,
-            num_layers=2,
-            hidden_dim=64,
-            intermediate_dim=128,
-            max_sequence_length=128,
-            name="encoder",
-        )
-
+        # Setup Model
         bytes_io = io.BytesIO()
         vocab_data = tf.data.Dataset.from_tensor_slices(
             ["the quick brown fox", "the earth is round"]
@@ -63,78 +56,68 @@ class FNetClassifierTest(tf.test.TestCase, parameterized.TestCase):
 
         self.preprocessor = FNetPreprocessor(
             tokenizer=FNetTokenizer(proto=self.proto),
-            sequence_length=12,
+            sequence_length=8,
         )
-
+        self.backbone = FNetBackbone(
+            vocabulary_size=self.preprocessor.tokenizer.vocabulary_size(),
+            num_layers=2,
+            num_heads=2,
+            hidden_dim=2,
+            intermediate_dim=4,
+            max_sequence_length=self.preprocessor.packer.sequence_length,
+        )
         self.classifier = FNetClassifier(
             self.backbone,
             4,
             preprocessor=self.preprocessor,
         )
-        self.classifier_no_preprocessing = FNetClassifier(
-            self.backbone,
-            4,
-            preprocessor=None,
-        )
 
+        # Setup data.
         self.raw_batch = tf.constant(
             [
                 "the quick brown fox.",
                 "the slow brown fox.",
-                "the smelly brown fox.",
-                "the old brown fox.",
             ]
         )
         self.preprocessed_batch = self.preprocessor(self.raw_batch)
         self.raw_dataset = tf.data.Dataset.from_tensor_slices(
-            (self.raw_batch, tf.ones((4,)))
+            (self.raw_batch, tf.ones((2,)))
         ).batch(2)
         self.preprocessed_dataset = self.raw_dataset.map(self.preprocessor)
 
     def test_valid_call_classifier(self):
         self.classifier(self.preprocessed_batch)
 
-    @parameterized.named_parameters(
-        ("jit_compile_false", False), ("jit_compile_true", True)
-    )
-    def test_fnet_classifier_predict(self, jit_compile):
-        self.classifier.compile(jit_compile=jit_compile)
+    def test_classifier_predict(self):
         self.classifier.predict(self.raw_batch)
+        self.classifier.preprocessor = None
+        self.classifier.predict(self.preprocessed_batch)
 
-    @parameterized.named_parameters(
-        ("jit_compile_false", False), ("jit_compile_true", True)
-    )
-    def test_fnet_classifier_predict_no_preprocessing(self, jit_compile):
-        self.classifier_no_preprocessing.compile(jit_compile=jit_compile)
-        self.classifier_no_preprocessing.predict(self.preprocessed_batch)
-
-    def test_fnet_classifier_fit_default_compile(self):
+    
+    def test_fnet_classifier_fit(self):
         self.classifier.fit(self.raw_dataset)
+        self.classifier.preprocessor = None
+        self.classifier.fit(self.preprocessed_dataset)
 
-    @parameterized.named_parameters(
-        ("jit_compile_false", False), ("jit_compile_true", True)
-    )
-    def test_fnet_classifier_fit(self, jit_compile):
+    def test_classifier_fit_no_xla(self):
         self.classifier.compile(
-            loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
-            jit_compile=jit_compile,
+            loss=keras.losses.SparseCategoricalCrossentropy(from_logits=False),
+            jit_compile=False,
         )
-        self.classifier.fit(self.raw_dataset)
+        self.classifier.fit(self.preprocessed_dataset)
 
-    @parameterized.named_parameters(
-        ("jit_compile_false", False), ("jit_compile_true", True)
-    )
-    def test_fnet_classifier_fit_no_preprocessing(self, jit_compile):
-        self.classifier_no_preprocessing.compile(
-            loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
-            jit_compile=jit_compile,
+    def test_serialization(self):
+        config = keras.utils.serialize_keras_object(self.classifier)
+        new_classifier = keras.utils.deserialize_keras_object(config)
+        self.assertEqual(
+            new_classifier.get_config(),
+            self.classifier.get_config(),
         )
-        self.classifier_no_preprocessing.fit(self.preprocessed_dataset)
-
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),
     )
+    @pytest.mark.large
     def test_saved_model(self, save_format, filename):
         model_output = self.classifier.predict(self.raw_batch)
         save_path = os.path.join(self.get_temp_dir(), filename)

--- a/keras_nlp/models/f_net/f_net_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/f_net/f_net_masked_lm_preprocessor_test.py
@@ -14,6 +14,7 @@
 import io
 import os
 
+import pytest
 import sentencepiece
 import tensorflow as tf
 from absl.testing import parameterized
@@ -120,10 +121,19 @@ class FNetMaskedLMPreprocessorTest(tf.test.TestCase, parameterized.TestCase):
         self.assertAllEqual(y, [0, 0, 0, 0])
         self.assertAllEqual(sw, [0.0, 0.0, 0.0, 0.0])
 
+    def test_serialization(self):
+        config = keras.utils.serialize_keras_object(self.preprocessor)
+        new_preprocessor = keras.utils.deserialize_keras_object(config)
+        self.assertEqual(
+            new_preprocessor.get_config(),
+            self.preprocessor.get_config(),
+        )
+    
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),
     )
+    @pytest.mark.large
     def test_saved_model(self, save_format, filename):
         input_data = tf.constant(["the quick brown fox"])
 

--- a/keras_nlp/models/f_net/f_net_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/f_net/f_net_masked_lm_preprocessor_test.py
@@ -128,7 +128,7 @@ class FNetMaskedLMPreprocessorTest(tf.test.TestCase, parameterized.TestCase):
             new_preprocessor.get_config(),
             self.preprocessor.get_config(),
         )
-    
+
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),

--- a/keras_nlp/models/f_net/f_net_masked_lm_test.py
+++ b/keras_nlp/models/f_net/f_net_masked_lm_test.py
@@ -85,13 +85,12 @@ class FNetMaskedLMTest(tf.test.TestCase, parameterized.TestCase):
         self.masked_lm(self.preprocessed_batch)
         self.masked_lm.preprocessor = None
         self.masked_lm.predict(self.preprocessed_batch[0])
-        
+
     def test_classifier_predict(self, jit_compile):
         self.masked_lm.predict(self.raw_batch)
         self.masked_lm.preprocessor = None
         self.masked_lm.predict(self.preprocessed_batch[0])
 
-    
     def test_classifier_fit(self):
         self.masked_lm.fit(self.raw_dataset)
         self.masked_lm.preprocessor = None

--- a/keras_nlp/models/f_net/f_net_masked_lm_test.py
+++ b/keras_nlp/models/f_net/f_net_masked_lm_test.py
@@ -14,6 +14,7 @@
 import io
 import os
 
+import pytest
 import sentencepiece
 import tensorflow as tf
 from absl.testing import parameterized
@@ -29,16 +30,10 @@ from keras_nlp.models.f_net.f_net_tokenizer import FNetTokenizer
 
 class FNetMaskedLMTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
-        self.backbone = FNetBackbone(
-            vocabulary_size=1000,
-            num_layers=2,
-            hidden_dim=16,
-            intermediate_dim=32,
-            max_sequence_length=128,
-        )
+        # Setup Model.
         bytes_io = io.BytesIO()
         vocab_data = tf.data.Dataset.from_tensor_slices(
-            ["the quick brown fox", "the earth is round", "an eagle flew"]
+            ["the quick brown fox", "the earth is round"]
         )
         sentencepiece.SentencePieceTrainer.train(
             sentence_iterator=vocab_data.as_numpy_iterator(),
@@ -58,24 +53,26 @@ class FNetMaskedLMTest(tf.test.TestCase, parameterized.TestCase):
         self.proto = bytes_io.getvalue()
         self.preprocessor = FNetMaskedLMPreprocessor(
             FNetTokenizer(proto=self.proto),
-            sequence_length=10,
-            mask_selection_length=4,
+            sequence_length=5,
+            mask_selection_length=2,
+        )
+        self.backbone = FNetBackbone(
+            vocabulary_size=self.preprocessor.tokenizer.vocabulary_size(),
+            num_layers=2,
+            num_heads=2,
+            hidden_dim=2,
+            intermediate_dim=4,
+            max_sequence_length=self.preprocessor.packer.sequence_length,
         )
         self.masked_lm = FNetMaskedLM(
             self.backbone,
             preprocessor=self.preprocessor,
         )
-        self.masked_lm_no_preprocessing = FNetMaskedLM(
-            self.backbone,
-            preprocessor=None,
-        )
 
         self.raw_batch = tf.constant(
             [
-                "quick brown fox",
-                "eagle flew over fox",
-                "the eagle flew quick",
-                "a brown eagle",
+                "the quick brown fox",
+                "the slow brown fox",
             ]
         )
         self.preprocessed_batch = self.preprocessor(self.raw_batch)[0]
@@ -84,51 +81,44 @@ class FNetMaskedLMTest(tf.test.TestCase, parameterized.TestCase):
         ).batch(2)
         self.preprocessed_dataset = self.raw_dataset.map(self.preprocessor)
 
-    def test_valid_call_masked_lm(self):
+    def test_valid_call_classifier(self):
         self.masked_lm(self.preprocessed_batch)
-
-    def test_fnet_masked_lm_fit_default_compile(self):
-        self.masked_lm.fit(self.raw_dataset)
-
-    @parameterized.named_parameters(
-        ("jit_compile_false", False), ("jit_compile_true", True)
-    )
-    def test_f_net_masked_lm_predict(self, jit_compile):
-        self.masked_lm.compile(jit_compile=jit_compile)
+        self.masked_lm.preprocessor = None
+        self.masked_lm.predict(self.preprocessed_batch[0])
+        
+    def test_classifier_predict(self, jit_compile):
         self.masked_lm.predict(self.raw_batch)
+        self.masked_lm.preprocessor = None
+        self.masked_lm.predict(self.preprocessed_batch[0])
 
-    @parameterized.named_parameters(
-        ("jit_compile_false", False), ("jit_compile_true", True)
-    )
-    def test_f_net_masked_lm_predict_no_preprocessing(self, jit_compile):
-        self.masked_lm_no_preprocessing.compile(jit_compile=jit_compile)
-        self.masked_lm_no_preprocessing.predict(self.preprocessed_batch)
-
-    @parameterized.named_parameters(
-        ("jit_compile_false", False), ("jit_compile_true", True)
-    )
-    def test_f_net_masked_lm_fit(self, jit_compile):
-        self.masked_lm.compile(
-            loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
-            jit_compile=jit_compile,
-        )
+    
+    def test_classifier_fit(self):
         self.masked_lm.fit(self.raw_dataset)
+        self.masked_lm.preprocessor = None
+        self.masked_lm.fit(self.preprocessed_dataset)
 
-    @parameterized.named_parameters(
-        ("jit_compile_false", False), ("jit_compile_true", True)
-    )
-    def test_f_net_masked_lm_fit_no_preprocessing(self, jit_compile):
-        self.masked_lm_no_preprocessing.compile(
-            loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
-            jit_compile=jit_compile,
+    def test_classifier_fit_no_xla(self):
+        self.masked_lm.compile(
+            loss=keras.losses.SparseCategoricalCrossentropy(from_logits=False),
+            jit_compile=False,
         )
-        self.masked_lm_no_preprocessing.fit(self.preprocessed_dataset)
+        self.masked_lm.fit(self.preprocessed_dataset)
+
+    def test_serialization(self):
+        config = keras.utils.serialize_keras_object(self.masked_lm)
+        new_classifier = keras.utils.deserialize_keras_object(config)
+        self.assertEqual(
+            new_classifier.get_config(),
+            self.masked_lm.get_config(),
+        )
 
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),
     )
+    @pytest.mark.large
     def test_saved_model(self, save_format, filename):
+        model_output = self.masked_lm.predict(self.raw_batch)
         save_path = os.path.join(self.get_temp_dir(), filename)
         self.masked_lm.save(save_path, save_format=save_format)
         restored_model = keras.models.load_model(save_path)
@@ -136,7 +126,6 @@ class FNetMaskedLMTest(tf.test.TestCase, parameterized.TestCase):
         # Check we got the real object back.
         self.assertIsInstance(restored_model, FNetMaskedLM)
 
-        model_output = self.masked_lm(self.preprocessed_batch)
-        restored_output = restored_model(self.preprocessed_batch)
-
+        # Check that output matches.
+        restored_output = restored_model.predict(self.raw_batch)
         self.assertAllClose(model_output, restored_output)

--- a/keras_nlp/models/f_net/f_net_preprocessor_test.py
+++ b/keras_nlp/models/f_net/f_net_preprocessor_test.py
@@ -152,7 +152,6 @@ class FNetPreprocessorTest(tf.test.TestCase, parameterized.TestCase):
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),
     )
-
     @pytest.mark.large
     def test_saved_model(self, save_format, filename):
         input_data = tf.constant(["the quick brown fox"])

--- a/keras_nlp/models/f_net/f_net_preprocessor_test.py
+++ b/keras_nlp/models/f_net/f_net_preprocessor_test.py
@@ -17,6 +17,7 @@
 import io
 import os
 
+import pytest
 import sentencepiece
 import tensorflow as tf
 from absl.testing import parameterized
@@ -139,10 +140,20 @@ class FNetPreprocessorTest(tf.test.TestCase, parameterized.TestCase):
         with self.assertRaises(ValueError):
             self.preprocessor(ambiguous_input)
 
+    def test_serialization(self):
+        config = keras.utils.serialize_keras_object(self.preprocessor)
+        new_preprocessor = keras.utils.deserialize_keras_object(config)
+        self.assertEqual(
+            new_preprocessor.get_config(),
+            self.preprocessor.get_config(),
+        )
+
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),
     )
+
+    @pytest.mark.large
     def test_saved_model(self, save_format, filename):
         input_data = tf.constant(["the quick brown fox"])
         inputs = keras.Input(dtype="string", shape=())

--- a/keras_nlp/models/f_net/f_net_tokenizer_test.py
+++ b/keras_nlp/models/f_net/f_net_tokenizer_test.py
@@ -17,6 +17,7 @@
 import io
 import os
 
+import pytest
 import sentencepiece
 import tensorflow as tf
 from absl.testing import parameterized
@@ -82,10 +83,19 @@ class FNetTokenizerTest(tf.test.TestCase, parameterized.TestCase):
         with self.assertRaises(ValueError):
             FNetTokenizer(proto=bytes_io.getvalue())
 
+    def test_serialization(self):
+        config = keras.utils.serialize_keras_object(self.tokenizer)
+        new_tokenizer = keras.utils.deserialize_keras_object(config)
+        self.assertEqual(
+            new_tokenizer.get_config(),
+            self.tokenizer.get_config(),
+        )
+
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),
     )
+    @pytest.mark.large
     def test_saved_model(self, save_format, filename):
         input_data = tf.constant(["the quick brown fox"])
 


### PR DESCRIPTION
Partially fixes: #866 

- [x] Add a serialization test for all classes.
- [x] Mark the saved model testing as "large" for all classes.
- [x]  Make the backbone sizes as small as possible while still testing all logic (e.g. num_layers=2).
- [x] Only run a single jit_compile=False test per model class. E.g. test_classifier_fit_no_xla.
- [x] Other minor readability and efficiency improvements (check the original PR carefully).