### PR TITLE
Init `_backbone`, `_tokenizer` and `_preprocessor` in Task

### DIFF
--- a/keras_nlp/models/preprocessor.py
+++ b/keras_nlp/models/preprocessor.py
@@ -22,6 +22,10 @@ from keras_nlp.utils.python_utils import format_docstring
 class Preprocessor(keras.layers.Layer):
     """Base class for model preprocessors."""
 
+    def __init__(self, *args, **kwargs):
+        self._tokenizer = None
+        super().__init__(*args, **kwargs)
+
     @property
     def tokenizer(self):
         """The tokenizer used to tokenize strings."""

--- a/keras_nlp/models/preprocessor.py
+++ b/keras_nlp/models/preprocessor.py
@@ -23,8 +23,8 @@ class Preprocessor(keras.layers.Layer):
     """Base class for model preprocessors."""
 
     def __init__(self, *args, **kwargs):
-        self._tokenizer = None
         super().__init__(*args, **kwargs)
+        self._tokenizer = None
 
     @property
     def tokenizer(self):

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -25,12 +25,12 @@ from keras_nlp.utils.python_utils import format_docstring
 @keras.utils.register_keras_serializable(package="keras_nlp")
 class Task(PipelineModel):
     """Base class for Task models."""
-  
+
     def __init__(self, *args, **kwargs):
         self._backbone = None
         self._preprocessor = None
         super().__init__(*args, **kwargs)
-    
+
     def preprocess_samples(self, x, y=None, sample_weight=None):
         return self.preprocessor(x, y=y, sample_weight=sample_weight)
 

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -27,9 +27,9 @@ class Task(PipelineModel):
     """Base class for Task models."""
 
     def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._backbone = None
         self._preprocessor = None
-        super().__init__(*args, **kwargs)
 
     def preprocess_samples(self, x, y=None, sample_weight=None):
         return self.preprocessor(x, y=y, sample_weight=sample_weight)

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -25,7 +25,11 @@ from keras_nlp.utils.python_utils import format_docstring
 @keras.utils.register_keras_serializable(package="keras_nlp")
 class Task(PipelineModel):
     """Base class for Task models."""
-
+  
+    def __init__(self, *args, **kwargs):
+        self._backbone = None
+        super().__init__(*args, **kwargs)
+    
     def preprocess_samples(self, x, y=None, sample_weight=None):
         return self.preprocessor(x, y=y, sample_weight=sample_weight)
 

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -28,6 +28,7 @@ class Task(PipelineModel):
   
     def __init__(self, *args, **kwargs):
         self._backbone = None
+        self._preprocessor = None
         super().__init__(*args, **kwargs)
     
     def preprocess_samples(self, x, y=None, sample_weight=None):


### PR DESCRIPTION
This fixes an annoying corner case where the `backbone` property references a `_backbone` attribute that itself is never initalized.

Initializing this properly allows the base class to set `self.backbone = None` by default as intended instead of throwing an `AttributeError`.

We do the same for `preprocessor` and `tokenizer`.