### PR TITLE
Allow BPE to treat special tokens as one token

### DIFF
--- a/keras_nlp/models/gpt2/gpt2_tokenizer.py
+++ b/keras_nlp/models/gpt2/gpt2_tokenizer.py
@@ -97,6 +97,7 @@ class GPT2Tokenizer(BytePairTokenizer):
         super().__init__(
             vocabulary=vocabulary,
             merges=merges,
+            special_tokens=["<|endoftext|>"],
             **kwargs,
         )
 

--- a/keras_nlp/models/gpt2/gpt2_tokenizer.py
+++ b/keras_nlp/models/gpt2/gpt2_tokenizer.py
@@ -94,15 +94,15 @@ class GPT2Tokenizer(BytePairTokenizer):
         merges,
         **kwargs,
     ):
+        # Check for necessary special tokens.
+        end_token = "<|endoftext|>"
+
         super().__init__(
             vocabulary=vocabulary,
             merges=merges,
-            special_tokens=["<|endoftext|>"],
+            special_tokens=[end_token],
             **kwargs,
         )
-
-        # Check for necessary special tokens.
-        end_token = "<|endoftext|>"
 
         if end_token not in self.get_vocabulary():
             raise ValueError(
@@ -110,7 +110,6 @@ class GPT2Tokenizer(BytePairTokenizer):
                 f"`vocabulary`. Please provide `'{end_token}'` in your "
                 "`vocabulary` or use a pretrained `vocabulary` name."
             )
-
         self.end_token_id = self.token_to_id(end_token)
         # GPT2 uses the same start and pad token as end token, i.e.,
         # "<|endoftext|>".

--- a/keras_nlp/models/gpt2/gpt2_tokenizer_test.py
+++ b/keras_nlp/models/gpt2/gpt2_tokenizer_test.py
@@ -52,7 +52,7 @@ class GPT2TokenizerTest(tf.test.TestCase, parameterized.TestCase):
         input_data = " airplane at airport"
         output = self.tokenizer(input_data)
         self.assertAllEqual(output, [1, 2, 3, 1, 4])
-        
+
     def test_tokenize_end_token(self):
         input_data = " airplane at airport<|endoftext|>"
         output = self.tokenizer(input_data)
@@ -79,7 +79,6 @@ class GPT2TokenizerTest(tf.test.TestCase, parameterized.TestCase):
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),
     )
-    @pytest.mark.large
     def test_saved_model(self, save_format, filename):
         input_data = tf.constant([" airplane at airport"])
 

--- a/keras_nlp/models/gpt2/gpt2_tokenizer_test.py
+++ b/keras_nlp/models/gpt2/gpt2_tokenizer_test.py
@@ -52,6 +52,11 @@ class GPT2TokenizerTest(tf.test.TestCase, parameterized.TestCase):
         input_data = " airplane at airport"
         output = self.tokenizer(input_data)
         self.assertAllEqual(output, [1, 2, 3, 1, 4])
+        
+    def test_tokenize_end_token(self):
+        input_data = " airplane at airport<|endoftext|>"
+        output = self.tokenizer(input_data)
+        self.assertAllEqual(output, [1, 2, 3, 1, 4, 0])
 
     def test_tokenize_batch(self):
         input_data = tf.constant([" airplane at airport", " kohli is the best"])
@@ -74,6 +79,7 @@ class GPT2TokenizerTest(tf.test.TestCase, parameterized.TestCase):
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),
     )
+    @pytest.mark.large
     def test_saved_model(self, save_format, filename):
         input_data = tf.constant([" airplane at airport"])
 

--- a/keras_nlp/tokenizers/byte_pair_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer.py
@@ -56,6 +56,8 @@ SPLIT_PATTERN_2 = rf"""[\s६{SPECIAL_WHITESPACES}]$"""
 
 
 def create_alts_for_special_tokens(special_tokens):
+    # Create alternates for all special tokens that will be not split during
+    # tokenization.
     alts = []
     prefix = "Ĵ"
     # Trim out splitters.
@@ -122,7 +124,7 @@ def split_strings_for_bpe(inputs, special_tokens=None):
         raw_tokens, SPLIT_PATTERN_2, SPLIT_PATTERN_2
     )
     if special_tokens:
-        # Alternate special tokens back.
+        # Replace special tokens alternate with originals.
         for token, alt in zip(special_tokens, alts):
             escaped_alt = re.escape(alt)
             raw_tokens = tf.strings.regex_replace(

--- a/keras_nlp/tokenizers/byte_pair_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer.py
@@ -102,12 +102,12 @@ def split_strings_for_bpe(inputs, special_tokens=None):
         inputs, rf"(\s{SPECIAL_WHITESPACES})$", r"\1६"
     )
     if special_tokens:
+
         def build_alt(i):
             return " " + "I" * i + "IGuessIamAValidWord" + "d" * i
+
         # Alternate special tokens so that it won't be further split.
-        alts = [
-            build_alt(i) for i in range(len(special_tokens))
-        ]
+        alts = [build_alt(i) for i in range(len(special_tokens))]
         for token, alt in zip(special_tokens, alts):
             escaped_token = re.escape(token)
             inputs = tf_text.regex_split(inputs, escaped_token, escaped_token)

--- a/keras_nlp/tokenizers/byte_pair_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer.py
@@ -20,8 +20,8 @@ but is TF graph compatible.
 """
 
 import json
-import re
 import os
+import re
 from typing import Iterable
 from typing import List
 
@@ -88,13 +88,7 @@ def remove_strings_from_inputs(tensor, string_to_remove):
     )
     return result
 
-# def mask_special_tokens(inputs, special_tokens):
-#     alts = [" IGuessIamAValidWord" + "d" * i for i in range(len(special_tokens))]
-#     for token, alt in zip(special_tokens, alts):
-#         escaped_token = re.escape(token)
-#         inputs = tf.regex_replace(inputs, escaped_token, alt)
-#     return inputs, alts
-        
+
 def split_strings_for_bpe(inputs, special_tokens=None):
     # We need to recreate the exact behavior of token presplitting in the
     # original gpt2 tokenizer which uses a lookahead. As re2 does not
@@ -107,17 +101,29 @@ def split_strings_for_bpe(inputs, special_tokens=None):
     inputs = tf.strings.regex_replace(
         inputs, rf"(\s{SPECIAL_WHITESPACES})$", r"\1६"
     )
+    alts = [
+        " IGuessIamAValidWord" + "d" * i for i in range(len(special_tokens))
+    ]
     if special_tokens:
-        for token in special_tokens:
+        # Alternate special tokens so that it won't be further split.
+        for token, alt in zip(special_tokens, alts):
             escaped_token = re.escape(token)
             inputs = tf_text.regex_split(inputs, escaped_token, escaped_token)
-
+            inputs = tf.strings.regex_replace(inputs, escaped_token, alt)
     raw_tokens = tf_text.regex_split(inputs, SPLIT_PATTERN_1, SPLIT_PATTERN_1)
     # Second pass splits out the last whilespace char or "६".
     raw_tokens = tf_text.regex_split(
         raw_tokens, SPLIT_PATTERN_2, SPLIT_PATTERN_2
     )
-    if raw_tokens.shape.rank > 2:
+
+    if special_tokens:
+        # Alternate special tokens back.
+        for token, alt in zip(special_tokens, alts):
+            escaped_alt = re.escape(alt)
+            raw_tokens = tf.strings.regex_replace(
+                raw_tokens, escaped_alt, token
+            )
+    while raw_tokens.shape.rank > 2:
         raw_tokens = raw_tokens.merge_dims(1, 2)
     return remove_strings_from_inputs(raw_tokens, "६")
 
@@ -304,6 +310,9 @@ class BytePairTokenizer(tokenizer.Tokenizer):
         )
 
         self.cache = BytePairTokenizerCache()
+        # Put special tokens into cache, so it won't be further split and
+        # merged.
+        self.cache.insert(special_tokens, special_tokens)
 
         # Create mapping between string tokens to int ids, and vice versa.
         byte_pairs = [x[0] for x in self.vocabulary.items()]

--- a/keras_nlp/tokenizers/byte_pair_tokenizer_test.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer_test.py
@@ -35,7 +35,6 @@ MERGE_PATH = keras.utils.get_file(
 class BytePairTokenizerTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
         super().setUp()
-
         self.tokenizer = BytePairTokenizer(
             vocabulary=VOCAB_PATH, merges=MERGE_PATH
         )
@@ -65,6 +64,25 @@ class BytePairTokenizerTest(tf.test.TestCase, parameterized.TestCase):
             ]
         )
         self.assertAllEqual(call_output, expected)
+        
+    def test_tokenize_with_special_tokens(self):
+        vocab = {"sp": 0, "s": 1, "p": 2}
+        merges = ["s p"]
+        tokenizer = BytePairTokenizer(
+            vocabulary=vocab,
+            merges=merges,
+            special_tokens=["s", "p"],
+        )
+        output = tokenizer("sp")
+        self.assertAllEqual(output, [1, 2])
+        
+        # If not setting special tokens, "sp" is one token.
+        tokenizer = BytePairTokenizer(
+            vocabulary=vocab,
+            merges=merges,
+        )
+        output = tokenizer("sp")
+        self.assertEqual(output, [0])
 
     def test_tokenize_prefix_space(self):
         input_data = ["brown.", "black."]

--- a/keras_nlp/tokenizers/byte_pair_tokenizer_test.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer_test.py
@@ -64,7 +64,7 @@ class BytePairTokenizerTest(tf.test.TestCase, parameterized.TestCase):
             ]
         )
         self.assertAllEqual(call_output, expected)
-        
+
     def test_tokenize_with_special_tokens(self):
         vocab = {"sp": 0, "s": 1, "p": 2}
         merges = ["s p"]
@@ -75,7 +75,7 @@ class BytePairTokenizerTest(tf.test.TestCase, parameterized.TestCase):
         )
         output = tokenizer("sp")
         self.assertAllEqual(output, [1, 2])
-        
+
         # If not setting special tokens, "sp" is one token.
         tokenizer = BytePairTokenizer(
             vocabulary=vocab,


### PR DESCRIPTION
There are some cases that BPE needs to treat special tokens as one token, e.g., `"<|endoftext|>"` in GPT2. 