### PR TITLE
Small fixes for special_tokens arg in BPE

### DIFF
--- a/keras_nlp/models/bart/bart_tokenizer.py
+++ b/keras_nlp/models/bart/bart_tokenizer.py
@@ -133,7 +133,7 @@ class BartTokenizer(BytePairTokenizer):
     def get_config(self):
         config = super().get_config()
         # In the constructor, we pass the list of special tokens to the
-        # `unsplittable_tokens` arg of the superclass. Hence, we delete it
-        # from the config here.
+        # `unsplittable_tokens` arg of the superclass' constructor. Hence, we
+        # delete it from the config here.
         del config["unsplittable_tokens"]
         return config

--- a/keras_nlp/models/bart/bart_tokenizer.py
+++ b/keras_nlp/models/bart/bart_tokenizer.py
@@ -92,16 +92,23 @@ class BartTokenizer(BytePairTokenizer):
         merges,
         **kwargs,
     ):
-        super().__init__(
-            vocabulary=vocabulary,
-            merges=merges,
-            **kwargs,
-        )
-
-        # Check for necessary special tokens.
+        # Special tokens.
         start_token = "<s>"
         pad_token = "<pad>"
         end_token = "</s>"
+
+        # BART does not have any other special tokens. So, we ignore any
+        # passed special tokens.
+        kwargs.pop("special_tokens_lst", None)
+
+        super().__init__(
+            vocabulary=vocabulary,
+            merges=merges,
+            special_tokens_lst=[start_token, pad_token, end_token],
+            **kwargs,
+        )
+
+        # Check whether special tokens are present in the vocabulary.
         for token in [start_token, pad_token, end_token]:
             if token not in self.get_vocabulary():
                 raise ValueError(
@@ -117,3 +124,8 @@ class BartTokenizer(BytePairTokenizer):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
+
+    def get_config(self):
+        config = super().get_config()
+        del config["special_tokens_lst"]
+        return config

--- a/keras_nlp/models/bart/bart_tokenizer.py
+++ b/keras_nlp/models/bart/bart_tokenizer.py
@@ -124,8 +124,3 @@ class BartTokenizer(BytePairTokenizer):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
-
-    def get_config(self):
-        config = super().get_config()
-        del config["special_tokens_lst"]
-        return config

--- a/keras_nlp/models/bart/bart_tokenizer.py
+++ b/keras_nlp/models/bart/bart_tokenizer.py
@@ -16,8 +16,6 @@
 
 import copy
 
-from absl import logging
-
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.models.bart.bart_presets import backbone_presets
 from keras_nlp.tokenizers.byte_pair_tokenizer import BytePairTokenizer
@@ -98,13 +96,6 @@ class BartTokenizer(BytePairTokenizer):
         start_token = "<s>"
         pad_token = "<pad>"
         end_token = "</s>"
-
-        if "unsplittable_tokens" in kwargs:
-            logging.warning(
-                "`unsplittable_tokens` is set to the list of special tokens, "
-                "and any passed value will be ignored."
-            )
-            del kwargs["unsplittable_tokens"]
 
         super().__init__(
             vocabulary=vocabulary,

--- a/keras_nlp/models/bart/bart_tokenizer.py
+++ b/keras_nlp/models/bart/bart_tokenizer.py
@@ -16,6 +16,8 @@
 
 import copy
 
+from absl import logging
+
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.models.bart.bart_presets import backbone_presets
 from keras_nlp.tokenizers.byte_pair_tokenizer import BytePairTokenizer
@@ -97,14 +99,17 @@ class BartTokenizer(BytePairTokenizer):
         pad_token = "<pad>"
         end_token = "</s>"
 
-        # BART does not have any other special tokens. So, we ignore any
-        # passed special tokens.
-        kwargs.pop("special_tokens_lst", None)
+        if "unsplittable_tokens" in kwargs:
+            logging.warning(
+                "`unsplittable_tokens` is set to the list of special tokens, "
+                "and any passed value will be ignored."
+            )
+            del kwargs["unsplittable_tokens"]
 
         super().__init__(
             vocabulary=vocabulary,
             merges=merges,
-            special_tokens_lst=[start_token, pad_token, end_token],
+            unsplittable_tokens=[start_token, pad_token, end_token],
             **kwargs,
         )
 
@@ -124,3 +129,11 @@ class BartTokenizer(BytePairTokenizer):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
+
+    def get_config(self):
+        config = super().get_config()
+        # In the constructor, we pass the list of special tokens to the
+        # `unsplittable_tokens` arg of the superclass. Hence, we delete it
+        # from the config here.
+        del config["unsplittable_tokens"]
+        return config

--- a/keras_nlp/models/bart/bart_tokenizer_test.py
+++ b/keras_nlp/models/bart/bart_tokenizer_test.py
@@ -52,6 +52,11 @@ class BartTokenizerTest(tf.test.TestCase, parameterized.TestCase):
         output = self.tokenizer(input_data)
         self.assertAllEqual(output, [3, 4, 5, 3, 6])
 
+    def test_tokenize_special_tokens(self):
+        input_data = "<s> airplane at airport</s><pad>"
+        output = self.tokenizer(input_data)
+        self.assertAllEqual(output, [0, 3, 4, 5, 3, 6, 0, 1])
+
     def test_tokenize_batch(self):
         input_data = tf.constant([" airplane at airport", " kohli is the best"])
         output = self.tokenizer(input_data)

--- a/keras_nlp/models/gpt2/gpt2_tokenizer.py
+++ b/keras_nlp/models/gpt2/gpt2_tokenizer.py
@@ -99,7 +99,7 @@ class GPT2Tokenizer(BytePairTokenizer):
 
         # GPT-2 does not have any other special tokens. So, we ignore any
         # passed special tokens.
-        kwargs.pop("special_tokens_list", None)
+        kwargs.pop("special_tokens_lst", None)
 
         super().__init__(
             vocabulary=vocabulary,
@@ -125,8 +125,3 @@ class GPT2Tokenizer(BytePairTokenizer):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
-
-    def get_config(self):
-        config = super().get_config()
-        del config["special_tokens_lst"]
-        return config

--- a/keras_nlp/models/gpt2/gpt2_tokenizer.py
+++ b/keras_nlp/models/gpt2/gpt2_tokenizer.py
@@ -100,7 +100,7 @@ class GPT2Tokenizer(BytePairTokenizer):
         super().__init__(
             vocabulary=vocabulary,
             merges=merges,
-            special_tokens=[end_token],
+            special_tokens_lst=[end_token],
             **kwargs,
         )
 

--- a/keras_nlp/models/gpt2/gpt2_tokenizer.py
+++ b/keras_nlp/models/gpt2/gpt2_tokenizer.py
@@ -96,12 +96,15 @@ class GPT2Tokenizer(BytePairTokenizer):
     ):
         # Check for necessary special tokens.
         end_token = "<|endoftext|>"
-        other_special_tokens = kwargs.pop("special_tokens_list", [])
- 
+
+        # GPT-2 does not have any other special tokens. So, we ignore any
+        # passed special tokens.
+        kwargs.pop("special_tokens_list", None)
+
         super().__init__(
             vocabulary=vocabulary,
             merges=merges,
-            special_tokens_lst=[end_token] + other_special_tokens,
+            special_tokens_lst=[end_token],
             **kwargs,
         )
 

--- a/keras_nlp/models/gpt2/gpt2_tokenizer.py
+++ b/keras_nlp/models/gpt2/gpt2_tokenizer.py
@@ -15,8 +15,6 @@
 
 import copy
 
-from absl import logging
-
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.models.gpt2.gpt2_presets import backbone_presets
 from keras_nlp.tokenizers.byte_pair_tokenizer import BytePairTokenizer
@@ -98,13 +96,6 @@ class GPT2Tokenizer(BytePairTokenizer):
     ):
         # Special tokens.
         end_token = "<|endoftext|>"
-
-        if "unsplittable_tokens" in kwargs:
-            logging.warning(
-                "`unsplittable_tokens` is set to the list of special tokens, "
-                "and any passed value will be ignored."
-            )
-            del kwargs["unsplittable_tokens"]
 
         super().__init__(
             vocabulary=vocabulary,

--- a/keras_nlp/models/gpt2/gpt2_tokenizer.py
+++ b/keras_nlp/models/gpt2/gpt2_tokenizer.py
@@ -134,7 +134,7 @@ class GPT2Tokenizer(BytePairTokenizer):
     def get_config(self):
         config = super().get_config()
         # In the constructor, we pass the list of special tokens to the
-        # `unsplittable_tokens` arg of the superclass. Hence, we delete it
-        # from the config here.
+        # `unsplittable_tokens` arg of the superclass' constructor. Hence, we
+        # delete it from the config here.
         del config["unsplittable_tokens"]
         return config

--- a/keras_nlp/models/gpt2/gpt2_tokenizer.py
+++ b/keras_nlp/models/gpt2/gpt2_tokenizer.py
@@ -96,11 +96,12 @@ class GPT2Tokenizer(BytePairTokenizer):
     ):
         # Check for necessary special tokens.
         end_token = "<|endoftext|>"
-
+        other_special_tokens = kwargs.pop("special_tokens_list", [])
+ 
         super().__init__(
             vocabulary=vocabulary,
             merges=merges,
-            special_tokens_lst=[end_token],
+            special_tokens_lst=[end_token] + other_special_tokens,
             **kwargs,
         )
 

--- a/keras_nlp/models/gpt2/gpt2_tokenizer.py
+++ b/keras_nlp/models/gpt2/gpt2_tokenizer.py
@@ -94,7 +94,7 @@ class GPT2Tokenizer(BytePairTokenizer):
         merges,
         **kwargs,
     ):
-        # Check for necessary special tokens.
+        # Special tokens.
         end_token = "<|endoftext|>"
 
         # GPT-2 does not have any other special tokens. So, we ignore any
@@ -108,12 +108,14 @@ class GPT2Tokenizer(BytePairTokenizer):
             **kwargs,
         )
 
+        # Check whether special tokens are present in the vocabulary.
         if end_token not in self.get_vocabulary():
             raise ValueError(
                 f"Cannot find token `'{end_token}'` in the provided "
                 f"`vocabulary`. Please provide `'{end_token}'` in your "
                 "`vocabulary` or use a pretrained `vocabulary` name."
             )
+
         self.end_token_id = self.token_to_id(end_token)
         # GPT2 uses the same start and pad token as end token, i.e.,
         # "<|endoftext|>".

--- a/keras_nlp/models/gpt2/gpt2_tokenizer.py
+++ b/keras_nlp/models/gpt2/gpt2_tokenizer.py
@@ -123,3 +123,8 @@ class GPT2Tokenizer(BytePairTokenizer):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
+
+    def get_config(self):
+        config = super().get_config()
+        del config["special_tokens_lst"]
+        return config

--- a/keras_nlp/models/opt/opt_tokenizer.py
+++ b/keras_nlp/models/opt/opt_tokenizer.py
@@ -89,7 +89,7 @@ class OPTTokenizer(BytePairTokenizer):
         merges,
         **kwargs,
     ):
-        # Special tokens.We use `"</s>"` as both a start and end token, as OPT
+        # Special tokens. We use `"</s>"` as both a start and end token, as OPT
         # was only pre-trained with `"</s>"` marking document boundaries.
         start_token = "</s>"
         pad_token = "<pad>"

--- a/keras_nlp/models/opt/opt_tokenizer.py
+++ b/keras_nlp/models/opt/opt_tokenizer.py
@@ -131,7 +131,7 @@ class OPTTokenizer(BytePairTokenizer):
     def get_config(self):
         config = super().get_config()
         # In the constructor, we pass the list of special tokens to the
-        # `unsplittable_tokens` arg of the superclass. Hence, we delete it
-        # from the config here.
+        # `unsplittable_tokens` arg of the superclass' constructor. Hence, we
+        # delete it from the config here.
         del config["unsplittable_tokens"]
         return config

--- a/keras_nlp/models/opt/opt_tokenizer.py
+++ b/keras_nlp/models/opt/opt_tokenizer.py
@@ -16,8 +16,6 @@
 
 import copy
 
-from absl import logging
-
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.models.opt.opt_presets import backbone_presets
 from keras_nlp.tokenizers.byte_pair_tokenizer import BytePairTokenizer
@@ -96,13 +94,6 @@ class OPTTokenizer(BytePairTokenizer):
         start_token = "</s>"
         pad_token = "<pad>"
         end_token = "</s>"
-
-        if "unsplittable_tokens" in kwargs:
-            logging.warning(
-                "`unsplittable_tokens` is set to the list of special tokens, "
-                "and any passed value will be ignored."
-            )
-            del kwargs["unsplittable_tokens"]
 
         super().__init__(
             vocabulary=vocabulary,

--- a/keras_nlp/models/opt/opt_tokenizer.py
+++ b/keras_nlp/models/opt/opt_tokenizer.py
@@ -120,8 +120,3 @@ class OPTTokenizer(BytePairTokenizer):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
-
-    def get_config(self):
-        config = super().get_config()
-        del config["special_tokens_lst"]
-        return config

--- a/keras_nlp/models/opt/opt_tokenizer.py
+++ b/keras_nlp/models/opt/opt_tokenizer.py
@@ -89,17 +89,22 @@ class OPTTokenizer(BytePairTokenizer):
         merges,
         **kwargs,
     ):
-        super().__init__(
-            vocabulary=vocabulary,
-            merges=merges,
-            **kwargs,
-        )
-
-        # We use `"</s>"` as both a start and end token, as OPT was only
-        # pre-trained with `"</s>"` marking document boundaries.
+        # Special tokens.We use `"</s>"` as both a start and end token, as OPT
+        # was only pre-trained with `"</s>"` marking document boundaries.
         start_token = "</s>"
         pad_token = "<pad>"
         end_token = "</s>"
+
+        kwargs.pop("special_tokens_lst", None)
+
+        super().__init__(
+            vocabulary=vocabulary,
+            merges=merges,
+            special_tokens_lst=[start_token, pad_token, end_token],
+            **kwargs,
+        )
+
+        # Check whether special tokens are present in the vocabulary.
         for token in [start_token, pad_token, end_token]:
             if token not in self.get_vocabulary():
                 raise ValueError(
@@ -115,3 +120,8 @@ class OPTTokenizer(BytePairTokenizer):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
+
+    def get_config(self):
+        config = super().get_config()
+        del config["special_tokens_lst"]
+        return config

--- a/keras_nlp/models/opt/opt_tokenizer_test.py
+++ b/keras_nlp/models/opt/opt_tokenizer_test.py
@@ -27,18 +27,17 @@ from keras_nlp.models.opt.opt_tokenizer import OPTTokenizer
 class OPTTokenizerTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
         self.vocab = {
-            "<s>": 0,
-            "<pad>": 1,
-            "</s>": 2,
-            "Ġair": 3,
-            "plane": 4,
-            "Ġat": 5,
-            "port": 6,
-            "Ġkoh": 7,
-            "li": 8,
-            "Ġis": 9,
-            "Ġthe": 10,
-            "Ġbest": 11,
+            "<pad>": 0,
+            "</s>": 1,
+            "Ġair": 2,
+            "plane": 3,
+            "Ġat": 4,
+            "port": 5,
+            "Ġkoh": 6,
+            "li": 7,
+            "Ġis": 8,
+            "Ġthe": 9,
+            "Ġbest": 10,
         }
 
         merges = ["Ġ a", "Ġ t", "Ġ k", "Ġ i", "Ġ b", "Ġa i", "p l", "n e"]
@@ -52,20 +51,25 @@ class OPTTokenizerTest(tf.test.TestCase, parameterized.TestCase):
     def test_tokenize(self):
         input_data = " airplane at airport"
         output = self.tokenizer(input_data)
-        self.assertAllEqual(output, [3, 4, 5, 3, 6])
+        self.assertAllEqual(output, [2, 3, 4, 2, 5])
+
+    def test_tokenize_special_tokens(self):
+        input_data = "</s> airplane at airport</s><pad>"
+        output = self.tokenizer(input_data)
+        self.assertAllEqual(output, [1, 2, 3, 4, 2, 5, 1, 0])
 
     def test_tokenize_batch(self):
         input_data = tf.constant([" airplane at airport", " kohli is the best"])
         output = self.tokenizer(input_data)
-        self.assertAllEqual(output, [[3, 4, 5, 3, 6], [7, 8, 9, 10, 11]])
+        self.assertAllEqual(output, [[2, 3, 4, 2, 5], [6, 7, 8, 9, 10]])
 
     def test_detokenize(self):
-        input_tokens = [3, 4, 5, 3, 6]
+        input_tokens = [2, 3, 4, 2, 5]
         output = self.tokenizer.detokenize(input_tokens)
         self.assertEqual(output, " airplane at airport")
 
     def test_vocabulary_size(self):
-        self.assertEqual(self.tokenizer.vocabulary_size(), 12)
+        self.assertEqual(self.tokenizer.vocabulary_size(), 11)
 
     def test_errors_missing_special_tokens(self):
         with self.assertRaises(ValueError):

--- a/keras_nlp/models/roberta/roberta_tokenizer.py
+++ b/keras_nlp/models/roberta/roberta_tokenizer.py
@@ -16,8 +16,6 @@
 
 import copy
 
-from absl import logging
-
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.models.roberta.roberta_presets import backbone_presets
 from keras_nlp.tokenizers.byte_pair_tokenizer import BytePairTokenizer
@@ -90,13 +88,6 @@ class RobertaTokenizer(BytePairTokenizer):
         pad_token = "<pad>"
         end_token = "</s>"
         mask_token = "<mask>"
-
-        if "unsplittable_tokens" in kwargs:
-            logging.warning(
-                "`unsplittable_tokens` is set to the list of special tokens, "
-                "and any passed value will be ignored."
-            )
-            del kwargs["unsplittable_tokens"]
 
         super().__init__(
             vocabulary=vocabulary,

--- a/keras_nlp/models/roberta/roberta_tokenizer.py
+++ b/keras_nlp/models/roberta/roberta_tokenizer.py
@@ -117,8 +117,3 @@ class RobertaTokenizer(BytePairTokenizer):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
-
-    def get_config(self):
-        config = super().get_config()
-        del config["special_tokens_lst"]
-        return config

--- a/keras_nlp/models/roberta/roberta_tokenizer.py
+++ b/keras_nlp/models/roberta/roberta_tokenizer.py
@@ -126,7 +126,7 @@ class RobertaTokenizer(BytePairTokenizer):
     def get_config(self):
         config = super().get_config()
         # In the constructor, we pass the list of special tokens to the
-        # `unsplittable_tokens` arg of the superclass. Hence, we delete it
-        # from the config here.
+        # `unsplittable_tokens` arg of the superclass' constructor. Hence, we
+        # delete it from the config here.
         del config["unsplittable_tokens"]
         return config

--- a/keras_nlp/models/roberta/roberta_tokenizer.py
+++ b/keras_nlp/models/roberta/roberta_tokenizer.py
@@ -83,17 +83,24 @@ class RobertaTokenizer(BytePairTokenizer):
         merges,
         **kwargs,
     ):
-        super().__init__(
-            vocabulary=vocabulary,
-            merges=merges,
-            **kwargs,
-        )
-
-        # Check for necessary special tokens.
+        # Special tokens.
         start_token = "<s>"
         pad_token = "<pad>"
         end_token = "</s>"
         mask_token = "<mask>"
+
+        # RoBERTa does not have any other special tokens. So, we ignore any
+        # passed special tokens.
+        kwargs.pop("special_tokens_lst", None)
+
+        super().__init__(
+            vocabulary=vocabulary,
+            merges=merges,
+            special_tokens_lst=[start_token, pad_token, end_token, mask_token],
+            **kwargs,
+        )
+
+        # Check whether special tokens are present in the vocabulary.
         for token in [start_token, pad_token, end_token, mask_token]:
             if token not in self.get_vocabulary():
                 raise ValueError(
@@ -110,3 +117,8 @@ class RobertaTokenizer(BytePairTokenizer):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
+
+    def get_config(self):
+        config = super().get_config()
+        del config["special_tokens_lst"]
+        return config

--- a/keras_nlp/models/roberta/roberta_tokenizer.py
+++ b/keras_nlp/models/roberta/roberta_tokenizer.py
@@ -16,6 +16,8 @@
 
 import copy
 
+from absl import logging
+
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.models.roberta.roberta_presets import backbone_presets
 from keras_nlp.tokenizers.byte_pair_tokenizer import BytePairTokenizer
@@ -89,14 +91,17 @@ class RobertaTokenizer(BytePairTokenizer):
         end_token = "</s>"
         mask_token = "<mask>"
 
-        # RoBERTa does not have any other special tokens. So, we ignore any
-        # passed special tokens.
-        kwargs.pop("special_tokens_lst", None)
+        if "unsplittable_tokens" in kwargs:
+            logging.warning(
+                "`unsplittable_tokens` is set to the list of special tokens, "
+                "and any passed value will be ignored."
+            )
+            del kwargs["unsplittable_tokens"]
 
         super().__init__(
             vocabulary=vocabulary,
             merges=merges,
-            special_tokens_lst=[start_token, pad_token, end_token, mask_token],
+            unsplittable_tokens=[start_token, pad_token, end_token, mask_token],
             **kwargs,
         )
 
@@ -117,3 +122,11 @@ class RobertaTokenizer(BytePairTokenizer):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
+
+    def get_config(self):
+        config = super().get_config()
+        # In the constructor, we pass the list of special tokens to the
+        # `unsplittable_tokens` arg of the superclass. Hence, we delete it
+        # from the config here.
+        del config["unsplittable_tokens"]
+        return config

--- a/keras_nlp/models/roberta/roberta_tokenizer_test.py
+++ b/keras_nlp/models/roberta/roberta_tokenizer_test.py
@@ -54,6 +54,11 @@ class RobertaTokenizerTest(tf.test.TestCase, parameterized.TestCase):
         output = self.tokenizer(input_data)
         self.assertAllEqual(output, [3, 4, 5, 3, 6])
 
+    def test_tokenize_special_tokens(self):
+        input_data = "<s> airplane at airport</s><pad>"
+        output = self.tokenizer(input_data)
+        self.assertAllEqual(output, [0, 3, 4, 5, 3, 6, 0, 1])
+
     def test_tokenize_batch(self):
         input_data = tf.constant([" airplane at airport", " kohli is the best"])
         output = self.tokenizer(input_data)

--- a/keras_nlp/tokenizers/byte_pair_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer.py
@@ -233,7 +233,8 @@ class BytePairTokenizer(tokenizer.Tokenizer):
             never be split during the word-level splitting applied before the
             byte-pair encoding. This can be used to ensure special tokens map to
             unique indices in the vocabulary, even if these special tokens
-            contain splittable characters such as punctuation.
+            contain splittable characters such as punctuation. Special tokens
+            must still be included in `vocabulary`.
 
     Examples:
 

--- a/keras_nlp/tokenizers/byte_pair_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer.py
@@ -55,14 +55,14 @@ SPLIT_PATTERN_1 = SPLIT_PATTERN_1.replace(
 SPLIT_PATTERN_2 = rf"""[\s६{SPECIAL_WHITESPACES}]$"""
 
 
-def create_alts_for_special_tokens(special_tokens_lst):
+def create_alts_for_unsplittable_tokens(unsplittable_tokens):
     # Create alternates for all special tokens that will be not split during
     # tokenization.
     alts = []
     prefix = "Ĵ"
     # Trim out splitters.
     replace_pattern = r"'|\s+|[^\p{L}\p{N}]+"
-    for token in special_tokens_lst:
+    for token in unsplittable_tokens:
         token = re.sub(replace_pattern, "", token)
         alts.append(prefix + token)
     return alts
@@ -100,7 +100,7 @@ def remove_strings_from_inputs(tensor, string_to_remove):
     return result
 
 
-def split_strings_for_bpe(inputs, special_tokens_lst=None):
+def split_strings_for_bpe(inputs, unsplittable_tokens=None):
     # We need to recreate the exact behavior of token presplitting in the
     # original gpt2 tokenizer which uses a lookahead. As re2 does not
     # support lookahead match, we are using an alternative insert a special
@@ -112,9 +112,9 @@ def split_strings_for_bpe(inputs, special_tokens_lst=None):
     inputs = tf.strings.regex_replace(
         inputs, rf"(\s{SPECIAL_WHITESPACES})$", r"\1६"
     )
-    if special_tokens_lst:
-        alts = create_alts_for_special_tokens(special_tokens_lst)
-        for token, alt in zip(special_tokens_lst, alts):
+    if unsplittable_tokens:
+        alts = create_alts_for_unsplittable_tokens(unsplittable_tokens)
+        for token, alt in zip(unsplittable_tokens, alts):
             escaped_token = re.escape(token)
             inputs = tf_text.regex_split(inputs, escaped_token, escaped_token)
             inputs = tf.strings.regex_replace(inputs, escaped_token, alt)
@@ -123,9 +123,9 @@ def split_strings_for_bpe(inputs, special_tokens_lst=None):
     raw_tokens = tf_text.regex_split(
         raw_tokens, SPLIT_PATTERN_2, SPLIT_PATTERN_2
     )
-    if special_tokens_lst:
+    if unsplittable_tokens:
         # Replace special tokens alternate with originals.
-        for token, alt in zip(special_tokens_lst, alts):
+        for token, alt in zip(unsplittable_tokens, alts):
             escaped_alt = re.escape(alt)
             raw_tokens = tf.strings.regex_replace(
                 raw_tokens, escaped_alt, token
@@ -229,9 +229,11 @@ class BytePairTokenizer(tokenizer.Tokenizer):
             and will tokenize a word with a leading space differently. Adding
             a prefix space to the first word will cause it to be tokenized
             equivalently to all subsequent words in the sequence.
-        special_tokens_lst: list, defaults to None. List of special tokens.
-            These tokens will not be split before tokenization, and will be
-            treated as a whole.
+        unsplittable_tokens: list, defaults to None. A list of strings that will
+            never be split during the word-level splitting applied before the
+            byte-pair encoding. This can be used to ensure special tokens map to
+            unique indices in the vocabulary, even if these special tokens
+            contain splittable characters such as punctuation.
 
     Examples:
 
@@ -267,7 +269,7 @@ class BytePairTokenizer(tokenizer.Tokenizer):
         merges,
         sequence_length=None,
         add_prefix_space=False,
-        special_tokens_lst=None,
+        unsplittable_tokens=None,
         **kwargs,
     ) -> None:
         assert_tf_text_installed(self.__class__.__name__)
@@ -307,7 +309,7 @@ class BytePairTokenizer(tokenizer.Tokenizer):
             )
         self.sequence_length = sequence_length
         self.add_prefix_space = add_prefix_space
-        self.special_tokens_lst = special_tokens_lst
+        self.unsplittable_tokens = unsplittable_tokens
 
         # Create byte <=> unicode mapping. This is useful for handling
         # whitespace tokens.
@@ -320,10 +322,10 @@ class BytePairTokenizer(tokenizer.Tokenizer):
         )
 
         self.cache = BytePairTokenizerCache()
-        if special_tokens_lst:
+        if unsplittable_tokens:
             # Put special tokens into cache, so it won't be further split and
             # merged.
-            self.cache.insert(special_tokens_lst, special_tokens_lst)
+            self.cache.insert(unsplittable_tokens, unsplittable_tokens)
 
         # Create mapping between string tokens to int ids, and vice versa.
         byte_pairs = [x[0] for x in self.vocabulary.items()]
@@ -383,7 +385,7 @@ class BytePairTokenizer(tokenizer.Tokenizer):
                 "merges": self.merges,
                 "sequence_length": self.sequence_length,
                 "add_prefix_space": self.add_prefix_space,
-                "special_tokens_lst": self.special_tokens_lst,
+                "unsplittable_tokens": self.unsplittable_tokens,
             }
         )
         return config
@@ -504,7 +506,7 @@ class BytePairTokenizer(tokenizer.Tokenizer):
         if scalar_input:
             inputs = tf.expand_dims(inputs, 0)
 
-        raw_tokens = split_strings_for_bpe(inputs, self.special_tokens_lst)
+        raw_tokens = split_strings_for_bpe(inputs, self.unsplittable_tokens)
         token_row_splits = raw_tokens.row_splits
         flat_tokens = raw_tokens.flat_values
 

--- a/keras_nlp/tokenizers/byte_pair_tokenizer_test.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer_test.py
@@ -71,7 +71,7 @@ class BytePairTokenizerTest(tf.test.TestCase, parameterized.TestCase):
         tokenizer = BytePairTokenizer(
             vocabulary=vocab,
             merges=merges,
-            special_tokens=["s", "p"],
+            special_tokens_lst=["s", "p"],
         )
         output = tokenizer("sp")
         self.assertAllEqual(output, [1, 2])

--- a/keras_nlp/tokenizers/byte_pair_tokenizer_test.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer_test.py
@@ -71,7 +71,7 @@ class BytePairTokenizerTest(tf.test.TestCase, parameterized.TestCase):
         tokenizer = BytePairTokenizer(
             vocabulary=vocab,
             merges=merges,
-            special_tokens_lst=["s", "p"],
+            unsplittable_tokens=["s", "p"],
         )
         output = tokenizer("sp")
         self.assertAllEqual(output, [1, 2])


### PR DESCRIPTION
- Renamed arg to `special_tokens_lst` (since subclass WhisperTokenizer also has the same `special_tokens` arg). Open to suggestions.
- Added doc-string for `special_tokens_lst` (open to a better explanation).
- Added missing `__init__` args to `get_config()`.