### PR TITLE
Convert string tensors to python strings in `generate()`

### DIFF
--- a/keras_nlp/models/gpt2/gpt2_causal_lm.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm.py
@@ -439,7 +439,8 @@ class GPT2CausalLM(Task):
 
         outputs = tf.concat(outputs, axis=0)
         outputs = tf.squeeze(outputs, 0) if input_is_scalar else outputs
-        # Convert all string output to python string for ease of use.
+        # Convert outputs to a friendly pythonic type. For numerical outputs
+        # that is numpy, for string outputs that is `list` and `str`.
         if outputs.dtype == tf.string:
             return tensor_to_string_list(outputs)
-        return outputs
+        return outputs.numpy()

--- a/keras_nlp/models/gpt2/gpt2_causal_lm.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm.py
@@ -28,6 +28,7 @@ from keras_nlp.models.task import Task
 from keras_nlp.samplers.serialization import get as get_sampler
 from keras_nlp.utils.keras_utils import is_xla_compatible
 from keras_nlp.utils.python_utils import classproperty
+from keras_nlp.utils.tf_utils import tensor_to_string_list
 from keras_nlp.utils.tf_utils import truncate_at_token
 
 
@@ -437,4 +438,8 @@ class GPT2CausalLM(Task):
             outputs.append(output)
 
         outputs = tf.concat(outputs, axis=0)
-        return tf.squeeze(outputs, 0) if input_is_scalar else outputs
+        outputs = tf.squeeze(outputs, 0) if input_is_scalar else outputs
+        # Convert all string output to python string for ease of use.
+        if outputs.dtype == tf.string:
+            return tensor_to_string_list(outputs)
+        return outputs

--- a/keras_nlp/models/gpt2/gpt2_causal_lm_test.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm_test.py
@@ -96,15 +96,11 @@ class GPT2CausalLMTest(tf.test.TestCase, parameterized.TestCase):
         # String input.
         prompt = " airplane"
         output = self.causal_lm.generate(" airplane")
-        self.assertTrue(prompt in output.numpy().decode("utf-8"))
+        self.assertTrue(prompt in output)
         # String tensor input.
-        self.assertDTypeEqual(
-            self.causal_lm.generate(self.raw_batch), tf.string
-        )
+        self.assertIsInstance(self.causal_lm.generate(self.raw_batch)[0], str)
         # String dataset input.
-        self.assertDTypeEqual(
-            self.causal_lm.generate(self.raw_dataset), tf.string
-        )
+        self.assertIsInstance(self.causal_lm.generate(self.raw_dataset)[0], str)
         # Int tensor input.
         self.causal_lm.preprocessor = None
         self.assertDTypeEqual(


### PR DESCRIPTION
There may be more to discuss on whether we put this in a preprocessor layer eventually, but for now just updating our `generate()` function to return python lists of python strings when preprocessing is attached.