### PR TITLE
Add a flag to restrict which docstring tests run

### DIFF
--- a/keras_nlp/conftest.py
+++ b/keras_nlp/conftest.py
@@ -64,7 +64,7 @@ def pytest_addoption(parser):
         "--docstring_module",
         action="store",
         default="",
-        help="restrict docs testing to modules who's name matches this flag",
+        help="restrict docs testing to modules whose name matches this flag",
     )
 
 

--- a/keras_nlp/conftest.py
+++ b/keras_nlp/conftest.py
@@ -60,6 +60,12 @@ def pytest_addoption(parser):
         default=False,
         help="run with mixed precision",
     )
+    parser.addoption(
+        "--docstring_module",
+        action="store",
+        default="",
+        help="restrict docs testing to modules who's name matches this flag",
+    )
 
 
 def pytest_configure(config):

--- a/keras_nlp/tests/doc_tests/docstring_test.py
+++ b/keras_nlp/tests/doc_tests/docstring_test.py
@@ -43,7 +43,12 @@ def find_modules():
     return keras_nlp_modules
 
 
-def test_docstrings():
+@pytest.fixture(scope="session")
+def docstring_module(pytestconfig):
+    return pytestconfig.getoption("docstring_module")
+
+
+def test_docstrings(docstring_module):
     keras_nlp_modules = find_modules()
     # As of this writing, it doesn't seem like pytest support load_tests
     # protocol for unittest:
@@ -52,6 +57,9 @@ def test_docstrings():
     runner = unittest.TextTestRunner()
     suite = unittest.TestSuite()
     for module in keras_nlp_modules:
+        if docstring_module and docstring_module not in module.__name__:
+            continue
+        print(f"Adding tests for docstrings in {module.__name__}")
         suite.addTest(
             doctest.DocTestSuite(
                 module,
@@ -83,17 +91,24 @@ def test_docstrings():
     astor is None,
     reason="This test requires `astor`. Please `pip install astor` to run.",
 )
-def test_fenced_docstrings():
+def test_fenced_docstrings(docstring_module):
     """Tests fenced code blocks in docstrings.
 
-    This can only be run manually. Run with:
+    This can only be run manually and will take many minutes. Run with:
     `pytest keras_nlp/tests/doc_tests/docstring_test.py --run_extra_large`
+
+    To restrict the docstring you test, you can pass an additional
+    --docstring_module flag. For example, to run only "bert" module tests:
+    `pytest keras_nlp/tests/doc_tests/docstring_test.py --run_extra_large --docstring_module "models.bert"`
     """
     keras_nlp_modules = find_modules()
 
     runner = unittest.TextTestRunner()
     suite = unittest.TestSuite()
     for module in keras_nlp_modules:
+        if docstring_module and docstring_module not in module.__name__:
+            continue
+        print(f"Adding tests for fenced docstrings in {module.__name__}")
         suite.addTest(
             doctest.DocTestSuite(
                 module,


### PR DESCRIPTION
Since our fenced docstring tests take so long to run (half an hour with a decent GPU), it is nice to be able to only run a subset (e.g. all docstring tests for a given model).

Currently our docstring testing operates by walking all sub-modules within `keras_nlp.`. This add a command line flag to match only certain modules when running testing.