### PR TITLE
Throw an error if when changing activation for classifier presets

### DIFF
--- a/keras_nlp/models/bert/bert_presets.py
+++ b/keras_nlp/models/bert/bert_presets.py
@@ -304,6 +304,7 @@ classifier_presets = {
             },
             "num_classes": 2,
             "dropout": 0.1,
+            "activation": None,
         },
         "preprocessor_config": {
             "lowercase": True,

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -139,6 +139,19 @@ class Task(PipelineModel):
         # Otherwise must be one of class presets
         metadata = cls.presets[preset]
         config = metadata["config"]
+        if (
+            "activation" in config
+            and "activation" in kwargs
+            and config["activation"] != kwargs["activation"]
+        ):
+            config_activation = config["activation"]
+            kwargs_activation = kwargs["activation"]
+            raise ValueError(
+                f"`activation` cannot be changed for preset '{preset}' which "
+                f"was trained with `activation` of `{config_activation}`. "
+                "Please do not specify the argument. Received `activation` of "
+                f"`{kwargs_activation}`"
+            )
         model = cls.from_config({**config, **kwargs})
 
         if not load_weights:


### PR DESCRIPTION
This would not work, more friendly to raise an error.