### PR TITLE
Speed up generation preprocessing by many orders of magnitude

### DIFF
--- a/keras_nlp/models/gpt2/gpt2_causal_lm_preprocessor.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm_preprocessor.py
@@ -127,6 +127,7 @@ class GPT2CausalLMPreprocessor(GPT2Preprocessor):
         y, sample_weight = token_ids[..., 1:], padding_mask[..., 1:]
         return pack_x_y_sample_weight(x, y, sample_weight)
 
+    @tf.function
     def generate_preprocess(
         self,
         x,
@@ -153,6 +154,7 @@ class GPT2CausalLMPreprocessor(GPT2Preprocessor):
             "padding_mask": padding_mask,
         }
 
+    @tf.function
     def generate_postprocess(
         self,
         x,

--- a/keras_nlp/models/opt/opt_causal_lm.py
+++ b/keras_nlp/models/opt/opt_causal_lm.py
@@ -478,23 +478,27 @@ class OPTCausalLM(Task):
         def postprocess(x):
             return self.preprocessor.generate_postprocess(x)
 
-        # Normalize inputs, apply our three passes, and normalize outputs.
-        inputs, input_is_scalar = self._normalize_generate_inputs(inputs)
+        # Run preprocessing on CPU only.
+        with tf.device("cpu"):
+            # Normalize inputs, apply our three passes, and normalize outputs.
+            inputs, input_is_scalar = self._normalize_generate_inputs(inputs)
 
-        if self.preprocessor is not None:
-            if isinstance(inputs, tf.data.Dataset):
-                inputs = inputs.map(preprocess, tf.data.AUTOTUNE)
-                inputs = inputs.prefetch(tf.data.AUTOTUNE)
-            else:
-                # Fast path for non-dataset, single-batch input.
-                inputs = [preprocess(x) for x in inputs]
+            if self.preprocessor is not None:
+                if isinstance(inputs, tf.data.Dataset):
+                    inputs = inputs.map(preprocess, tf.data.AUTOTUNE)
+                    inputs = inputs.prefetch(tf.data.AUTOTUNE)
+                else:
+                    # Fast path for non-dataset, single-batch input.
+                    inputs = [preprocess(x) for x in inputs]
 
         outputs = [generate(x) for x in inputs]
 
-        if self.preprocessor is not None:
-            outputs = [postprocess(x) for x in outputs]
+        # Run postprocessing on CPU only.
+        with tf.device("cpu"):
+            if self.preprocessor is not None:
+                outputs = [postprocess(x) for x in outputs]
 
-        return self._normalize_generate_outputs(outputs, input_is_scalar)
+            return self._normalize_generate_outputs(outputs, input_is_scalar)
 
     @classmethod
     def create_layout_map(cls, mesh):

--- a/keras_nlp/models/opt/opt_causal_lm_preprocessor.py
+++ b/keras_nlp/models/opt/opt_causal_lm_preprocessor.py
@@ -128,6 +128,7 @@ class OPTCausalLMPreprocessor(OPTPreprocessor):
         y, sample_weight = token_ids[..., 1:], padding_mask[..., 1:]
         return pack_x_y_sample_weight(x, y, sample_weight)
 
+    @tf.function
     def generate_preprocess(
         self,
         x,
@@ -154,6 +155,7 @@ class OPTCausalLMPreprocessor(OPTPreprocessor):
             "padding_mask": padding_mask,
         }
 
+    @tf.function
     def generate_postprocess(
         self,
         x,


### PR DESCRIPTION
Not exactly where this should live, but I believe our slowdowns for pre and post preprocessing stem from over copying data back and forth from CPU -> GPU.

In a benchmark tokenizing and padding 2 sequences to length 256, 25 times. The time spent pre and postprocesesing is dramatic (this is excluding the first call).

- Before change: 4.6s
- After change: 0.03s