### PR TITLE
Also strip padding token for opt

### DIFF
--- a/keras_nlp/models/opt/opt_causal_lm_preprocessor.py
+++ b/keras_nlp/models/opt/opt_causal_lm_preprocessor.py
@@ -168,5 +168,6 @@ class OPTCausalLMPreprocessor(OPTPreprocessor):
         # Strip any special tokens during detokenization (e.g. the start and
         # end markers). In the future we could make this configurable.
         padding_mask = padding_mask & (token_ids != self.tokenizer.end_token_id)
+        padding_mask = padding_mask & (token_ids != self.tokenizer.pad_token_id)
         token_ids = tf.ragged.boolean_mask(token_ids, padding_mask)
         return self.tokenizer.detokenize(token_ids)


### PR DESCRIPTION
Unlike GPT, OPT has a distinct token for padding. It is probably good practice to strip it out doing de-tokenization for generation.