### PR TITLE
Fix program crash for id_to_token() method in SentencePieceTokenizer

### DIFF
--- a/keras_nlp/models/xlm_roberta/xlm_roberta_tokenizer.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_tokenizer.py
@@ -121,10 +121,16 @@ class XLMRobertaTokenizer(SentencePieceTokenizer):
         if id == self.mask_token_id:
             return "<mask>"
 
-        if id < len(self._vocabulary_prefix):
+        if id < len(self._vocabulary_prefix) and id >= 0:
             return self._vocabulary_prefix[id]
 
-        return tensor_to_string_list(self._sentence_piece.id_to_string(id - 1))
+        if id-1 >= super().vocabulary_size() or id-1 < 0:
+            raise ValueError(
+                f"`id` must be in range [0, {self.vocabulary_size() - 1}]. "
+                f"Recieved: {id}"
+            )
+
+        return tensor_to_string_list(self._sentence_piece.id_to_string(id-1))
 
     def token_to_id(self, token):
         """Convert a string token to an integer id."""

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_tokenizer.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_tokenizer.py
@@ -124,13 +124,13 @@ class XLMRobertaTokenizer(SentencePieceTokenizer):
         if id < len(self._vocabulary_prefix) and id >= 0:
             return self._vocabulary_prefix[id]
 
-        if id-1 >= super().vocabulary_size() or id-1 < 0:
+        if id - 1 >= super().vocabulary_size() or id - 1 < 0:
             raise ValueError(
                 f"`id` must be in range [0, {self.vocabulary_size() - 1}]. "
-                f"Recieved: {id}"
+                f"Received: {id}"
             )
 
-        return tensor_to_string_list(self._sentence_piece.id_to_string(id-1))
+        return tensor_to_string_list(self._sentence_piece.id_to_string(id - 1))
 
     def token_to_id(self, token):
         """Convert a string token to an integer id."""

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_tokenizer_test.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_tokenizer_test.py
@@ -94,6 +94,12 @@ class XLMRobertaTokenizerTest(tf.test.TestCase, parameterized.TestCase):
         self.assertEqual(self.tokenizer.id_to_token(9), "▁quick")
         self.assertEqual(self.tokenizer.id_to_token(5), "▁brown")
 
+    def test_error_id_out_of_vocabulary(self):
+        with self.assertRaises(ValueError):
+            self.tokenizer.id_to_token(self.tokenizer.vocabulary_size())
+        with self.assertRaises(ValueError):
+            self.tokenizer.id_to_token(-1)
+
     def test_token_to_id(self):
         self.assertEqual(self.tokenizer.token_to_id("▁the"), 4)
         self.assertEqual(self.tokenizer.token_to_id("▁round"), 10)

--- a/keras_nlp/tokenizers/byte_pair_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer.py
@@ -369,7 +369,7 @@ class BytePairTokenizer(tokenizer.Tokenizer):
         for token in keys:
             if self.vocabulary[token] == id:
                 return token
-        return None
+        raise ValueError("Recieved `id` is out of the vocabulary")
 
     def token_to_id(self, token: str) -> int:
         """Convert a string token to an integer id."""

--- a/keras_nlp/tokenizers/byte_pair_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer.py
@@ -369,7 +369,7 @@ class BytePairTokenizer(tokenizer.Tokenizer):
         for token in keys:
             if self.vocabulary[token] == id:
                 return token
-        raise ValueError("Recieved `id` is out of the vocabulary")
+        raise ValueError(f"`id` is out of the vocabulary. Received: {id}")
 
     def token_to_id(self, token: str) -> int:
         """Convert a string token to an integer id."""

--- a/keras_nlp/tokenizers/byte_pair_tokenizer_test.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer_test.py
@@ -119,6 +119,12 @@ class BytePairTokenizerTest(tf.test.TestCase, parameterized.TestCase):
         decoded = self.tokenizer.detokenize(encoded)
         self.assertAllEqual(input_data, decoded)
 
+    def test_error_id_out_of_vocabulary(self):
+        with self.assertRaises(ValueError):
+            self.tokenizer.id_to_token(self.tokenizer.vocabulary_size())
+        with self.assertRaises(ValueError):
+            self.tokenizer.id_to_token(-1)
+
     def test_whitespace_split(self):
         input_data = "\n\n\n  s"
         encoded = self.tokenizer(input_data)

--- a/keras_nlp/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/sentence_piece_tokenizer.py
@@ -171,7 +171,7 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
         """Convert an integer id to a string token."""
         if id >= self.vocabulary_size() or id < 0:
             raise ValueError(
-                f"id must be in range [0, {self.vocabulary_size()-1}], "
+                f"`id` must be in range [0, {self.vocabulary_size()-1}], "
                 f"recieved {id}"
             )
         return tensor_to_string_list(self._sentence_piece.id_to_string(id))

--- a/keras_nlp/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/sentence_piece_tokenizer.py
@@ -169,6 +169,11 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
 
     def id_to_token(self, id: int) -> str:
         """Convert an integer id to a string token."""
+        if id >= self.vocabulary_size() or id < 0:
+            raise ValueError(
+                f"id must be in range [0, {self.vocabulary_size()-1}], "
+                f"recieved {id}"
+            )
         return tensor_to_string_list(self._sentence_piece.id_to_string(id))
 
     def token_to_id(self, token: str) -> int:

--- a/keras_nlp/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/sentence_piece_tokenizer.py
@@ -172,7 +172,7 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
         if id >= self.vocabulary_size() or id < 0:
             raise ValueError(
                 f"`id` must be in range [0, {self.vocabulary_size() - 1}]. "
-                f"Recieved: {id}"
+                f"Received: {id}"
             )
         return tensor_to_string_list(self._sentence_piece.id_to_string(id))
 

--- a/keras_nlp/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/sentence_piece_tokenizer.py
@@ -171,8 +171,8 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
         """Convert an integer id to a string token."""
         if id >= self.vocabulary_size() or id < 0:
             raise ValueError(
-                f"`id` must be in range [0, {self.vocabulary_size()-1}], "
-                f"recieved {id}"
+                f"`id` must be in range [0, {self.vocabulary_size() - 1}]. "
+                f"Recieved: {id}"
             )
         return tensor_to_string_list(self._sentence_piece.id_to_string(id))
 

--- a/keras_nlp/tokenizers/sentence_piece_tokenizer_test.py
+++ b/keras_nlp/tokenizers/sentence_piece_tokenizer_test.py
@@ -116,7 +116,7 @@ class SentencePieceTokenizerTest(tf.test.TestCase, parameterized.TestCase):
             tokenizer.id_to_token(tokenizer.vocabulary_size())
         with self.assertRaises(ValueError):
             tokenizer.id_to_token(-1)
-            
+
     def test_functional_model(self):
         input_data = tf.constant(["the quick brown fox."])
         tokenizer = SentencePieceTokenizer(

--- a/keras_nlp/tokenizers/sentence_piece_tokenizer_test.py
+++ b/keras_nlp/tokenizers/sentence_piece_tokenizer_test.py
@@ -108,6 +108,15 @@ class SentencePieceTokenizerTest(tf.test.TestCase, parameterized.TestCase):
         self.assertEqual(tokenizer.token_to_id("▁quick"), 5)
         self.assertEqual(type(tokenizer.token_to_id("<unk>")), int)
 
+    def test_error_id_out_of_vocabulary(self):
+        tokenizer = SentencePieceTokenizer(
+            proto=self.proto,
+        )
+        with self.assertRaises(ValueError):
+            tokenizer.id_to_token(tokenizer.vocabulary_size())
+        with self.assertRaises(ValueError):
+            tokenizer.id_to_token(-1)
+            
     def test_functional_model(self):
         input_data = tf.constant(["the quick brown fox."])
         tokenizer = SentencePieceTokenizer(

--- a/keras_nlp/tokenizers/word_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer.py
@@ -359,6 +359,11 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
 
     def id_to_token(self, id: int) -> str:
         """Convert an integer id to a string token."""
+        if id >= self.vocabulary_size() or id < 0:
+            raise ValueError(
+                f"`id` must be in range [0, {self.vocabulary_size() - 1}]. "
+                f"Recieved: {id}"
+            )
         return self.vocabulary[id]
 
     def token_to_id(self, token: str) -> int:

--- a/keras_nlp/tokenizers/word_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer.py
@@ -362,7 +362,7 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
         if id >= self.vocabulary_size() or id < 0:
             raise ValueError(
                 f"`id` must be in range [0, {self.vocabulary_size() - 1}]. "
-                f"Recieved: {id}"
+                f"Received: {id}"
             )
         return self.vocabulary[id]
 

--- a/keras_nlp/tokenizers/word_piece_tokenizer_test.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer_test.py
@@ -72,6 +72,15 @@ class WordPieceTokenizerTest(tf.test.TestCase, parameterized.TestCase):
         self.assertEqual(tokenizer.token_to_id("[UNK]"), 0)
         self.assertEqual(tokenizer.token_to_id("fox"), 6)
 
+    def test_error_id_out_of_vocabulary(self):
+        input_data = ["the quick brown fox."]
+        vocab_data = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox", "."]
+        tokenizer = WordPieceTokenizer(vocabulary=vocab_data)
+        with self.assertRaises(ValueError):
+            tokenizer.id_to_token(tokenizer.vocabulary_size())
+        with self.assertRaises(ValueError):
+            tokenizer.id_to_token(-1)
+
     def test_special_tokens(self):
         input_data = ["quick brown whale"]
         vocab_data = ["@UNK@", "qu", "@@ick", "br", "@@own", "fox"]

--- a/keras_nlp/tokenizers/word_piece_tokenizer_test.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer_test.py
@@ -73,7 +73,6 @@ class WordPieceTokenizerTest(tf.test.TestCase, parameterized.TestCase):
         self.assertEqual(tokenizer.token_to_id("fox"), 6)
 
     def test_error_id_out_of_vocabulary(self):
-        input_data = ["the quick brown fox."]
         vocab_data = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox", "."]
         tokenizer = WordPieceTokenizer(vocabulary=vocab_data)
         with self.assertRaises(ValueError):


### PR DESCRIPTION
I have mentioned the problem in #1036.
I added a value error if the id is out of range for SentencePieceTokenizer.id_to_token(id) method.
