### PR TITLE
List out all model inputs when retracing

### DIFF
--- a/examples/bert_pretraining/bert_pretrain.py
+++ b/examples/bert_pretraining/bert_pretrain.py
@@ -387,12 +387,23 @@ def main(_):
     dataset = dataset.repeat()
 
     with strategy.scope():
+        inputs = {
+            "token_ids": keras.Input(
+                shape=(None,), dtype="int32", name="token_ids"
+            ),
+            "segment_ids": keras.Input(
+                shape=(None,), dtype="int32", name="segment_ids"
+            ),
+            "padding_mask": keras.Input(
+                shape=(None,), dtype="int32", name="padding_mask"
+            ),
+        }
         # Create a Bert model the input config.
         encoder = keras_nlp.models.BertBackbone(
             vocabulary_size=len(vocab), **model_config
         )
         # Make sure model has been called.
-        encoder(encoder.inputs)
+        encoder(inputs)
         encoder.summary()
 
         # Allow overriding train steps from the command line for quick testing.

--- a/keras_nlp/models/albert/albert_classifier.py
+++ b/keras_nlp/models/albert/albert_classifier.py
@@ -161,7 +161,17 @@ class AlbertClassifier(Task):
         dropout=0.1,
         **kwargs,
     ):
-        inputs = backbone.input
+        inputs = {
+            "token_ids": keras.Input(
+                shape=(None,), dtype="int32", name="token_ids"
+            ),
+            "segment_ids": keras.Input(
+                shape=(None,), dtype="int32", name="segment_ids"
+            ),
+            "padding_mask": keras.Input(
+                shape=(None,), dtype="int32", name="padding_mask"
+            ),
+        }
         pooled = backbone(inputs)["pooled_output"]
         pooled = keras.layers.Dropout(dropout)(pooled)
         outputs = keras.layers.Dense(

--- a/keras_nlp/models/albert/albert_masked_lm.py
+++ b/keras_nlp/models/albert/albert_masked_lm.py
@@ -105,13 +105,20 @@ class AlbertMaskedLM(Task):
 
     def __init__(self, backbone, preprocessor=None, **kwargs):
         inputs = {
-            **backbone.input,
+            "token_ids": keras.Input(
+                shape=(None,), dtype="int32", name="token_ids"
+            ),
+            "segment_ids": keras.Input(
+                shape=(None,), dtype="int32", name="segment_ids"
+            ),
+            "padding_mask": keras.Input(
+                shape=(None,), dtype="int32", name="padding_mask"
+            ),
             "mask_positions": keras.Input(
                 shape=(None,), dtype="int32", name="mask_positions"
             ),
         }
-
-        backbone_outputs = backbone(backbone.input)
+        backbone_outputs = backbone(inputs)
         outputs = MaskedLMHead(
             vocabulary_size=backbone.vocabulary_size,
             embedding_weights=backbone.token_embedding.embeddings,

--- a/keras_nlp/models/bart/bart_seq_2_seq_lm.py
+++ b/keras_nlp/models/bart/bart_seq_2_seq_lm.py
@@ -190,7 +190,20 @@ class BartSeq2SeqLM(Task):
         preprocessor=None,
         **kwargs,
     ):
-        inputs = backbone.input
+        inputs = {
+            "encoder_token_ids": keras.Input(
+                shape=(None,), dtype="int32", name="encoder_token_ids"
+            ),
+            "encoder_padding_mask": keras.Input(
+                shape=(None,), dtype="int32", name="encoder_padding_mask"
+            ),
+            "decoder_token_ids": keras.Input(
+                shape=(None,), dtype="int32", name="decoder_token_ids"
+            ),
+            "decoder_padding_mask": keras.Input(
+                shape=(None,), dtype="int32", name="decoder_padding_mask"
+            ),
+        }
         x = backbone(inputs)["decoder_sequence_output"]
         # Use token embedding weights to project from the token representation
         # to vocabulary logits.

--- a/keras_nlp/models/bert/bert_classifier.py
+++ b/keras_nlp/models/bert/bert_classifier.py
@@ -146,7 +146,17 @@ class BertClassifier(Task):
         dropout=0.1,
         **kwargs,
     ):
-        inputs = backbone.input
+        inputs = {
+            "token_ids": keras.Input(
+                shape=(None,), dtype="int32", name="token_ids"
+            ),
+            "segment_ids": keras.Input(
+                shape=(None,), dtype="int32", name="segment_ids"
+            ),
+            "padding_mask": keras.Input(
+                shape=(None,), dtype="int32", name="padding_mask"
+            ),
+        }
         pooled = backbone(inputs)["pooled_output"]
         pooled = keras.layers.Dropout(dropout)(pooled)
         outputs = keras.layers.Dense(

--- a/keras_nlp/models/bert/bert_masked_lm.py
+++ b/keras_nlp/models/bert/bert_masked_lm.py
@@ -109,12 +109,20 @@ class BertMaskedLM(Task):
         **kwargs,
     ):
         inputs = {
-            **backbone.input,
+            "token_ids": keras.Input(
+                shape=(None,), dtype="int32", name="token_ids"
+            ),
+            "segment_ids": keras.Input(
+                shape=(None,), dtype="int32", name="segment_ids"
+            ),
+            "padding_mask": keras.Input(
+                shape=(None,), dtype="int32", name="padding_mask"
+            ),
             "mask_positions": keras.Input(
                 shape=(None,), dtype="int32", name="mask_positions"
             ),
         }
-        backbone_outputs = backbone(backbone.input)
+        backbone_outputs = backbone(inputs)
         outputs = MaskedLMHead(
             vocabulary_size=backbone.vocabulary_size,
             embedding_weights=backbone.token_embedding.embeddings,

--- a/keras_nlp/models/deberta_v3/deberta_v3_classifier.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_classifier.py
@@ -167,7 +167,14 @@ class DebertaV3Classifier(Task):
         dropout=0.0,
         **kwargs,
     ):
-        inputs = backbone.input
+        inputs = {
+            "token_ids": keras.Input(
+                shape=(None,), dtype="int32", name="token_ids"
+            ),
+            "padding_mask": keras.Input(
+                shape=(None,), dtype="int32", name="padding_mask"
+            ),
+        }
         hidden_dim = hidden_dim or backbone.hidden_dim
 
         x = backbone(inputs)[:, backbone.start_token_index, :]

--- a/keras_nlp/models/deberta_v3/deberta_v3_masked_lm.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_masked_lm.py
@@ -112,12 +112,17 @@ class DebertaV3MaskedLM(Task):
         **kwargs,
     ):
         inputs = {
-            **backbone.input,
+            "token_ids": keras.Input(
+                shape=(None,), dtype="int32", name="token_ids"
+            ),
+            "padding_mask": keras.Input(
+                shape=(None,), dtype="int32", name="padding_mask"
+            ),
             "mask_positions": keras.Input(
                 shape=(None,), dtype="int32", name="mask_positions"
             ),
         }
-        backbone_outputs = backbone(backbone.input)
+        backbone_outputs = backbone(inputs)
         outputs = MaskedLMHead(
             vocabulary_size=backbone.vocabulary_size,
             embedding_weights=backbone.token_embedding.embeddings,

--- a/keras_nlp/models/distil_bert/distil_bert_classifier.py
+++ b/keras_nlp/models/distil_bert/distil_bert_classifier.py
@@ -153,7 +153,14 @@ class DistilBertClassifier(Task):
         dropout=0.2,
         **kwargs,
     ):
-        inputs = backbone.input
+        inputs = {
+            "token_ids": keras.Input(
+                shape=(None,), dtype="int32", name="token_ids"
+            ),
+            "padding_mask": keras.Input(
+                shape=(None,), dtype="int32", name="padding_mask"
+            ),
+        }
         hidden_dim = hidden_dim or backbone.hidden_dim
 
         x = backbone(inputs)[:, backbone.cls_token_index, :]

--- a/keras_nlp/models/distil_bert/distil_bert_masked_lm.py
+++ b/keras_nlp/models/distil_bert/distil_bert_masked_lm.py
@@ -112,12 +112,17 @@ class DistilBertMaskedLM(Task):
         **kwargs,
     ):
         inputs = {
-            **backbone.input,
+            "token_ids": keras.Input(
+                shape=(None,), dtype="int32", name="token_ids"
+            ),
+            "padding_mask": keras.Input(
+                shape=(None,), dtype="int32", name="padding_mask"
+            ),
             "mask_positions": keras.Input(
                 shape=(None,), dtype="int32", name="mask_positions"
             ),
         }
-        backbone_outputs = backbone(backbone.input)
+        backbone_outputs = backbone(inputs)
         outputs = MaskedLMHead(
             vocabulary_size=backbone.vocabulary_size,
             embedding_weights=backbone.token_embedding.embeddings,

--- a/keras_nlp/models/f_net/f_net_classifier.py
+++ b/keras_nlp/models/f_net/f_net_classifier.py
@@ -114,6 +114,14 @@ class FNetClassifier(Task):
         dropout=0.1,
         **kwargs,
     ):
+        inputs = {
+            "token_ids": keras.Input(
+                shape=(None,), dtype="int32", name="token_ids"
+            ),
+            "segment_ids": keras.Input(
+                shape=(None,), dtype="int32", name="segment_ids"
+            ),
+        }
         inputs = backbone.input
         pooled = backbone(inputs)["pooled_output"]
         pooled = keras.layers.Dropout(dropout)(pooled)

--- a/keras_nlp/models/f_net/f_net_masked_lm.py
+++ b/keras_nlp/models/f_net/f_net_masked_lm.py
@@ -107,12 +107,17 @@ class FNetMaskedLM(Task):
         **kwargs,
     ):
         inputs = {
-            **backbone.input,
+            "token_ids": keras.Input(
+                shape=(None,), dtype="int32", name="token_ids"
+            ),
+            "segment_ids": keras.Input(
+                shape=(None,), dtype="int32", name="segment_ids"
+            ),
             "mask_positions": keras.Input(
                 shape=(None,), dtype="int32", name="mask_positions"
             ),
         }
-        backbone_outputs = backbone(backbone.input)
+        backbone_outputs = backbone(inputs)
         outputs = MaskedLMHead(
             vocabulary_size=backbone.vocabulary_size,
             embedding_weights=backbone.token_embedding.embeddings,

--- a/keras_nlp/models/gpt2/gpt2_causal_lm.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm.py
@@ -160,7 +160,14 @@ class GPT2CausalLM(Task):
         preprocessor=None,
         **kwargs,
     ):
-        inputs = backbone.input
+        inputs = {
+            "token_ids": keras.Input(
+                shape=(None,), dtype="int32", name="token_ids"
+            ),
+            "padding_mask": keras.Input(
+                shape=(None,), dtype="int32", name="padding_mask"
+            ),
+        }
         x = backbone(inputs)
         # Use token embedding weights to project from the token representation
         # to vocabulary logits.

--- a/keras_nlp/models/opt/opt_causal_lm.py
+++ b/keras_nlp/models/opt/opt_causal_lm.py
@@ -160,7 +160,14 @@ class OPTCausalLM(Task):
         preprocessor=None,
         **kwargs,
     ):
-        inputs = backbone.input
+        inputs = {
+            "token_ids": keras.Input(
+                shape=(None,), dtype="int32", name="token_ids"
+            ),
+            "padding_mask": keras.Input(
+                shape=(None,), dtype="int32", name="padding_mask"
+            ),
+        }
         x = backbone(inputs)
         # Use token embedding weights to project from the token representation
         # to vocabulary logits.

--- a/keras_nlp/models/roberta/roberta_classifier.py
+++ b/keras_nlp/models/roberta/roberta_classifier.py
@@ -149,7 +149,14 @@ class RobertaClassifier(Task):
         dropout=0.0,
         **kwargs,
     ):
-        inputs = backbone.input
+        inputs = {
+            "token_ids": keras.Input(
+                shape=(None,), dtype="int32", name="token_ids"
+            ),
+            "padding_mask": keras.Input(
+                shape=(None,), dtype="int32", name="padding_mask"
+            ),
+        }
         hidden_dim = hidden_dim or backbone.hidden_dim
 
         x = backbone(inputs)[:, backbone.start_token_index, :]

--- a/keras_nlp/models/roberta/roberta_masked_lm.py
+++ b/keras_nlp/models/roberta/roberta_masked_lm.py
@@ -111,12 +111,17 @@ class RobertaMaskedLM(Task):
         **kwargs,
     ):
         inputs = {
-            **backbone.input,
+            "token_ids": keras.Input(
+                shape=(None,), dtype="int32", name="token_ids"
+            ),
+            "padding_mask": keras.Input(
+                shape=(None,), dtype="int32", name="padding_mask"
+            ),
             "mask_positions": keras.Input(
                 shape=(None,), dtype="int32", name="mask_positions"
             ),
         }
-        backbone_outputs = backbone(backbone.input)
+        backbone_outputs = backbone(inputs)
         outputs = MaskedLMHead(
             vocabulary_size=backbone.vocabulary_size,
             embedding_weights=backbone.token_embedding.embeddings,

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_classifier.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_classifier.py
@@ -162,7 +162,14 @@ class XLMRobertaClassifier(Task):
         dropout=0.0,
         **kwargs,
     ):
-        inputs = backbone.input
+        inputs = {
+            "token_ids": keras.Input(
+                shape=(None,), dtype="int32", name="token_ids"
+            ),
+            "padding_mask": keras.Input(
+                shape=(None,), dtype="int32", name="padding_mask"
+            ),
+        }
         hidden_dim = hidden_dim or backbone.hidden_dim
 
         x = backbone(inputs)[:, backbone.start_token_index, :]

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_masked_lm.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_masked_lm.py
@@ -114,12 +114,17 @@ class XLMRobertaMaskedLM(Task):
         **kwargs,
     ):
         inputs = {
-            **backbone.input,
+            "token_ids": keras.Input(
+                shape=(None,), dtype="int32", name="token_ids"
+            ),
+            "padding_mask": keras.Input(
+                shape=(None,), dtype="int32", name="padding_mask"
+            ),
             "mask_positions": keras.Input(
                 shape=(None,), dtype="int32", name="mask_positions"
             ),
         }
-        backbone_outputs = backbone(backbone.input)
+        backbone_outputs = backbone(inputs)
         outputs = MaskedLMHead(
             vocabulary_size=backbone.vocabulary_size,
             embedding_weights=backbone.token_embedding.embeddings,


### PR DESCRIPTION
The input behavior for keras function is weird:
 - model.inputs is the flattened version of functional inputs, e.g. dicts are flatted into lists of values.
 - model.input is the unflattened version, but the single letter diff from inputs is confusing, and .input is not really documented.

Talked with Francois, and we decided better was just to be explicit about model inputs in all cases. Makes the code much more declarative about what should be passed to it, and not more `input` vs `inputs` gotchas.