### PR TITLE
Clean up dtype handling for preprocessing layers

### DIFF
--- a/keras_nlp/layers/masked_lm_mask_generator.py
+++ b/keras_nlp/layers/masked_lm_mask_generator.py
@@ -16,7 +16,7 @@ import tensorflow as tf
 from tensorflow import keras
 
 from keras_nlp.api_export import keras_nlp_export
-from keras_nlp.utils.tf_utils import assert_tf_text_installed
+from keras_nlp.utils.tensor_utils import assert_tf_text_installed
 
 try:
     import tensorflow_text as tf_text

--- a/keras_nlp/layers/multi_segment_packer.py
+++ b/keras_nlp/layers/multi_segment_packer.py
@@ -18,7 +18,7 @@ import tensorflow as tf
 from tensorflow import keras
 
 from keras_nlp.api_export import keras_nlp_export
-from keras_nlp.utils.tf_utils import assert_tf_text_installed
+from keras_nlp.utils.tensor_utils import assert_tf_text_installed
 
 try:
     import tensorflow_text as tf_text

--- a/keras_nlp/layers/random_deletion.py
+++ b/keras_nlp/layers/random_deletion.py
@@ -17,6 +17,8 @@ import tensorflow as tf
 from tensorflow import keras
 
 from keras_nlp.api_export import keras_nlp_export
+from keras_nlp.utils.tensor_utils import is_integer_dtype
+from keras_nlp.utils.tensor_utils import is_string_dtype
 
 
 @keras_nlp_export("keras_nlp.layers.RandomDeletion")
@@ -115,20 +117,16 @@ class RandomDeletion(keras.layers.Layer):
         skip_py_fn=None,
         seed=None,
         name=None,
+        dtype="int32",
         **kwargs,
     ):
-        # Check dtype and provide a default.
-        if "dtype" not in kwargs or kwargs["dtype"] is None:
-            kwargs["dtype"] = "int32"
-        else:
-            dtype = tf.dtypes.as_dtype(kwargs["dtype"])
-            if not dtype.is_integer and dtype != tf.string:
-                raise ValueError(
-                    "Output dtype must be one of `'string'`, `'int32'`, and "
-                    f"`'int64'`. Received: dtype={dtype}"
-                )
+        if not is_integer_dtype(dtype) and not is_string_dtype(dtype):
+            raise ValueError(
+                "Output dtype must be an integer type or a string. "
+                f"Received: dtype={dtype}"
+            )
 
-        super().__init__(name=name, **kwargs)
+        super().__init__(dtype=dtype, name=name, **kwargs)
         self.rate = rate
         self.max_deletions = max_deletions
         self.seed = random.randint(1, 1e9) if seed is None else seed

--- a/keras_nlp/layers/random_swap.py
+++ b/keras_nlp/layers/random_swap.py
@@ -17,6 +17,8 @@ import tensorflow as tf
 from tensorflow import keras
 
 from keras_nlp.api_export import keras_nlp_export
+from keras_nlp.utils.tensor_utils import is_integer_dtype
+from keras_nlp.utils.tensor_utils import is_string_dtype
 
 
 @keras_nlp_export("keras_nlp.layers.RandomSwap")
@@ -117,20 +119,16 @@ class RandomSwap(keras.layers.Layer):
         skip_py_fn=None,
         seed=None,
         name=None,
+        dtype="int32",
         **kwargs,
     ):
-        # Check dtype and provide a default.
-        if "dtype" not in kwargs or kwargs["dtype"] is None:
-            kwargs["dtype"] = "int32"
-        else:
-            dtype = tf.dtypes.as_dtype(kwargs["dtype"])
-            if not dtype.is_integer and dtype != tf.string:
-                raise ValueError(
-                    "Output dtype must be one of `'string'`, `'int32'`, and "
-                    f"`'int64'`. Received: dtype={dtype}"
-                )
+        if not is_integer_dtype(dtype) and not is_string_dtype(dtype):
+            raise ValueError(
+                "Output dtype must be an integer type or a string. "
+                f"Received: dtype={dtype}"
+            )
 
-        super().__init__(name=name, **kwargs)
+        super().__init__(name=name, dtype=dtype, **kwargs)
         self.rate = rate
         self.max_swaps = max_swaps
         self.seed = random.randint(1, 1e9) if seed is None else seed

--- a/keras_nlp/metrics/bleu.py
+++ b/keras_nlp/metrics/bleu.py
@@ -21,7 +21,8 @@ import tensorflow as tf
 from tensorflow import keras
 
 from keras_nlp.api_export import keras_nlp_export
-from keras_nlp.utils.tf_utils import tensor_to_list
+from keras_nlp.utils.tensor_utils import is_floating_dtype
+from keras_nlp.utils.tensor_utils import tensor_to_list
 
 REPLACE_SUBSTRINGS = [
     ("<skipped>", ""),
@@ -106,13 +107,13 @@ class Bleu(keras.metrics.Metric):
         tokenizer=None,
         max_order=4,
         smooth=False,
-        dtype=None,
+        dtype="float32",
         name="bleu",
         **kwargs,
     ):
         super().__init__(name=name, dtype=dtype, **kwargs)
 
-        if not tf.as_dtype(self.dtype).is_floating:
+        if not is_floating_dtype(dtype):
             raise ValueError(
                 "`dtype` must be a floating point type. "
                 f"Received: dtype={dtype}"

--- a/keras_nlp/metrics/edit_distance.py
+++ b/keras_nlp/metrics/edit_distance.py
@@ -18,6 +18,7 @@ import tensorflow as tf
 from tensorflow import keras
 
 from keras_nlp.api_export import keras_nlp_export
+from keras_nlp.utils.tensor_utils import is_floating_dtype
 
 
 @keras_nlp_export("keras_nlp.metrics.EditDistance")
@@ -97,34 +98,18 @@ class EditDistance(keras.metrics.Metric):
     ... ])
     >>> edit_distance(y_true, y_pred)
     <tf.Tensor: shape=(), dtype=float32, numpy=0.73333335>
-
-    Pass the metric to `model.compile()`.
-    >>> inputs = keras.Input(shape=(None,), dtype="string")
-    >>> outputs = tf.strings.lower(inputs)
-    >>> model = keras.Model(inputs, outputs)
-    >>> model.compile(metrics=[keras_nlp.metrics.EditDistance()])
-    >>> x = tf.strings.split(
-    ...     tf.constant(
-    ...         ["the tiny little cat was found under the big funny bed"]
-    ...     )
-    ... )
-    >>> y = tf.strings.split(["the cat was found under the bed"])
-    >>> y = tf.strings.split(["the cat was found under the bed"])
-    >>> output = model.evaluate(y, x, return_dict=True)
-    >>> output["edit_distance"]
-    0.3636363744735718
     """
 
     def __init__(
         self,
         normalize=True,
-        dtype=None,
+        dtype="float32",
         name="edit_distance",
         **kwargs,
     ):
         super().__init__(name=name, dtype=dtype, **kwargs)
 
-        if not tf.as_dtype(self.dtype).is_floating:
+        if not is_floating_dtype(dtype):
             raise ValueError(
                 "`dtype` must be a floating point type. "
                 f"Received: dtype={dtype}"

--- a/keras_nlp/metrics/perplexity.py
+++ b/keras_nlp/metrics/perplexity.py
@@ -18,6 +18,7 @@ import tensorflow as tf
 from tensorflow import keras
 
 from keras_nlp.api_export import keras_nlp_export
+from keras_nlp.utils.tensor_utils import is_floating_dtype
 
 
 @keras_nlp_export("keras_nlp.metrics.Perplexity")
@@ -92,17 +93,17 @@ class Perplexity(keras.metrics.Metric):
         self,
         from_logits=False,
         mask_token_id=None,
-        dtype=None,
+        dtype="float32",
         name="perplexity",
         **kwargs,
     ):
-        super().__init__(name=name, dtype=dtype, **kwargs)
-
-        if not tf.as_dtype(self.dtype).is_floating:
+        if not is_floating_dtype(dtype):
             raise ValueError(
                 "`dtype` must be a floating point type. "
                 f"Received: dtype={dtype}"
             )
+
+        super().__init__(name=name, dtype=dtype, **kwargs)
 
         self._crossentropy = keras.losses.SparseCategoricalCrossentropy(
             from_logits=from_logits, reduction="sum"

--- a/keras_nlp/metrics/rouge_base.py
+++ b/keras_nlp/metrics/rouge_base.py
@@ -20,7 +20,8 @@ import types
 import tensorflow as tf
 from tensorflow import keras
 
-from keras_nlp.utils.tf_utils import tensor_to_string_list
+from keras_nlp.utils.tensor_utils import is_floating_dtype
+from keras_nlp.utils.tensor_utils import tensor_to_string_list
 
 try:
     from rouge_score import rouge_scorer
@@ -56,7 +57,7 @@ class RougeBase(keras.metrics.Metric):
         self,
         variant="rouge2",
         use_stemmer=False,
-        dtype=None,
+        dtype="float32",
         name="rouge",
         **kwargs,
     ):
@@ -68,7 +69,7 @@ class RougeBase(keras.metrics.Metric):
                 "package. Please install it with `pip install rouge-score`."
             )
 
-        if not tf.as_dtype(self.dtype).is_floating:
+        if not is_floating_dtype(dtype):
             raise ValueError(
                 "`dtype` must be a floating point type. "
                 f"Received: dtype={dtype}"

--- a/keras_nlp/metrics/rouge_l.py
+++ b/keras_nlp/metrics/rouge_l.py
@@ -115,14 +115,12 @@ class RougeL(RougeBase):
     def __init__(
         self,
         use_stemmer=False,
-        dtype=None,
         name="rouge-l",
         **kwargs,
     ):
         super().__init__(
             variant="rougeL",
             use_stemmer=use_stemmer,
-            dtype=dtype,
             name=name,
             **kwargs,
         )

--- a/keras_nlp/metrics/rouge_n.py
+++ b/keras_nlp/metrics/rouge_n.py
@@ -135,7 +135,6 @@ class RougeN(RougeBase):
         self,
         order=2,
         use_stemmer=False,
-        dtype=None,
         name="rouge-n",
         **kwargs,
     ):
@@ -148,7 +147,6 @@ class RougeN(RougeBase):
         super().__init__(
             variant=f"rouge{order}",
             use_stemmer=use_stemmer,
-            dtype=dtype,
             name=name,
             **kwargs,
         )

--- a/keras_nlp/models/bart/bart_seq_2_seq_lm.py
+++ b/keras_nlp/models/bart/bart_seq_2_seq_lm.py
@@ -28,7 +28,7 @@ from keras_nlp.models.task import Task
 from keras_nlp.samplers.serialization import get as get_sampler
 from keras_nlp.utils.keras_utils import is_xla_compatible
 from keras_nlp.utils.python_utils import classproperty
-from keras_nlp.utils.tf_utils import tensor_to_string_list
+from keras_nlp.utils.tensor_utils import tensor_to_string_list
 
 
 @keras_nlp_export("keras_nlp.models.BartSeq2SeqLM")

--- a/keras_nlp/models/gpt2/gpt2_causal_lm.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm.py
@@ -28,7 +28,7 @@ from keras_nlp.models.task import Task
 from keras_nlp.samplers.serialization import get as get_sampler
 from keras_nlp.utils.keras_utils import is_xla_compatible
 from keras_nlp.utils.python_utils import classproperty
-from keras_nlp.utils.tf_utils import tensor_to_string_list
+from keras_nlp.utils.tensor_utils import tensor_to_string_list
 
 
 @keras_nlp_export("keras_nlp.models.GPT2CausalLM")

--- a/keras_nlp/models/opt/opt_causal_lm.py
+++ b/keras_nlp/models/opt/opt_causal_lm.py
@@ -28,7 +28,7 @@ from keras_nlp.models.task import Task
 from keras_nlp.samplers.serialization import get as get_sampler
 from keras_nlp.utils.keras_utils import is_xla_compatible
 from keras_nlp.utils.python_utils import classproperty
-from keras_nlp.utils.tf_utils import tensor_to_string_list
+from keras_nlp.utils.tensor_utils import tensor_to_string_list
 
 
 @keras_nlp_export("keras_nlp.models.OPTCausalLM")

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_tokenizer.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_tokenizer.py
@@ -22,7 +22,7 @@ from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.models.xlm_roberta.xlm_roberta_presets import backbone_presets
 from keras_nlp.tokenizers.sentence_piece_tokenizer import SentencePieceTokenizer
 from keras_nlp.utils.python_utils import classproperty
-from keras_nlp.utils.tf_utils import tensor_to_string_list
+from keras_nlp.utils.tensor_utils import tensor_to_string_list
 
 
 @keras_nlp_export("keras_nlp.models.XLMRobertaTokenizer")

--- a/keras_nlp/tokenizers/byte_pair_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer.py
@@ -32,7 +32,9 @@ from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.tokenizers import tokenizer
 from keras_nlp.utils.python_utils import classproperty
 from keras_nlp.utils.python_utils import format_docstring
-from keras_nlp.utils.tf_utils import assert_tf_text_installed
+from keras_nlp.utils.tensor_utils import assert_tf_text_installed
+from keras_nlp.utils.tensor_utils import is_integer_dtype
+from keras_nlp.utils.tensor_utils import is_string_dtype
 
 try:
     import tensorflow_text as tf_text
@@ -272,22 +274,18 @@ class BytePairTokenizer(tokenizer.Tokenizer):
         sequence_length=None,
         add_prefix_space=False,
         unsplittable_tokens=None,
+        dtype="int32",
         **kwargs,
     ) -> None:
         assert_tf_text_installed(self.__class__.__name__)
 
-        # Check dtype and provide a default.
-        if "dtype" not in kwargs or kwargs["dtype"] is None:
-            kwargs["dtype"] = "int32"
-        else:
-            dtype = tf.dtypes.as_dtype(kwargs["dtype"])
-            if not dtype.is_integer and dtype != tf.string:
-                raise ValueError(
-                    "Output dtype must be an integer type or a string. "
-                    f"Received: `dtype={dtype}`"
-                )
+        if not is_integer_dtype(dtype) and not is_string_dtype(dtype):
+            raise ValueError(
+                "Output dtype must be an integer type or a string. "
+                f"Received: dtype={dtype}"
+            )
 
-        super().__init__(**kwargs)
+        super().__init__(dtype=dtype, **kwargs)
 
         if isinstance(vocabulary, str):
             with open(vocabulary, "r") as f:

--- a/keras_nlp/tokenizers/byte_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_tokenizer.py
@@ -19,7 +19,8 @@ import tensorflow as tf
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.tokenizers import tokenizer
-from keras_nlp.utils.tf_utils import assert_tf_text_installed
+from keras_nlp.utils.tensor_utils import assert_tf_text_installed
+from keras_nlp.utils.tensor_utils import is_integer_dtype
 
 try:
     import tensorflow_text as tf_text
@@ -161,20 +162,16 @@ class ByteTokenizer(tokenizer.Tokenizer):
         normalization_form: str = None,
         errors: str = "replace",
         replacement_char: int = 65533,
+        dtype="int32",
         **kwargs,
     ):
         assert_tf_text_installed(self.__class__.__name__)
 
-        # Check dtype and provide a default.
-        if "dtype" not in kwargs or kwargs["dtype"] is None:
-            kwargs["dtype"] = "int32"
-        else:
-            dtype = tf.dtypes.as_dtype(kwargs["dtype"])
-            if not dtype.is_integer:
-                raise ValueError(
-                    "Output dtype must be an integer type. "
-                    f"Received: dtype={dtype}"
-                )
+        if not is_integer_dtype(dtype):
+            raise ValueError(
+                "Output dtype must be an integer type. "
+                f"Received: dtype={dtype}"
+            )
 
         # Check normalization_form.
         if normalization_form not in (None, "NFC", "NFKC", "NFD", "NFKD"):
@@ -191,7 +188,7 @@ class ByteTokenizer(tokenizer.Tokenizer):
                 f"Received: errors={errors}"
             )
 
-        super().__init__(**kwargs)
+        super().__init__(dtype=dtype, **kwargs)
 
         self.lowercase = lowercase
         self.sequence_length = sequence_length

--- a/keras_nlp/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/sentence_piece_tokenizer.py
@@ -24,8 +24,10 @@ from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.tokenizers import tokenizer
 from keras_nlp.utils.python_utils import classproperty
 from keras_nlp.utils.python_utils import format_docstring
-from keras_nlp.utils.tf_utils import assert_tf_text_installed
-from keras_nlp.utils.tf_utils import tensor_to_string_list
+from keras_nlp.utils.tensor_utils import assert_tf_text_installed
+from keras_nlp.utils.tensor_utils import is_integer_dtype
+from keras_nlp.utils.tensor_utils import is_string_dtype
+from keras_nlp.utils.tensor_utils import tensor_to_string_list
 
 try:
     import tensorflow_text as tf_text
@@ -105,22 +107,18 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
         self,
         proto,
         sequence_length: int = None,
+        dtype="int32",
         **kwargs,
     ) -> None:
         assert_tf_text_installed(self.__class__.__name__)
 
-        # Check dtype and provide a default.
-        if "dtype" not in kwargs or kwargs["dtype"] is None:
-            kwargs["dtype"] = "int32"
-        else:
-            dtype = tf.dtypes.as_dtype(kwargs["dtype"])
-            if not dtype.is_integer and dtype != tf.string:
-                raise ValueError(
-                    "Output dtype must be one of `'string'`, `'int32'`, and "
-                    f"`'int64'`. Received: dtype={dtype}"
-                )
+        if not is_integer_dtype(dtype) and not is_string_dtype(dtype):
+            raise ValueError(
+                "Output dtype must be an integer type or a string. "
+                f"Received: dtype={dtype}"
+            )
 
-        super().__init__(**kwargs)
+        super().__init__(dtype=dtype, **kwargs)
 
         if isinstance(proto, str):
             # A string could be either a filepath, or a base64 encoded byte

--- a/keras_nlp/tokenizers/unicode_codepoint_tokenizer.py
+++ b/keras_nlp/tokenizers/unicode_codepoint_tokenizer.py
@@ -16,7 +16,8 @@ import tensorflow as tf
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.tokenizers import tokenizer
-from keras_nlp.utils.tf_utils import assert_tf_text_installed
+from keras_nlp.utils.tensor_utils import assert_tf_text_installed
+from keras_nlp.utils.tensor_utils import is_integer_dtype
 
 try:
     import tensorflow_text as tf_text
@@ -209,20 +210,16 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
         input_encoding: str = "UTF-8",
         output_encoding: str = "UTF-8",
         vocabulary_size: int = None,
+        dtype="int32",
         **kwargs,
     ) -> None:
         assert_tf_text_installed(self.__class__.__name__)
 
-        # Check dtype and provide a default.
-        if "dtype" not in kwargs or kwargs["dtype"] is None:
-            kwargs["dtype"] = "int32"
-        else:
-            dtype = tf.dtypes.as_dtype(kwargs["dtype"])
-            if not dtype.is_integer:
-                raise ValueError(
-                    "Output dtype must be an integer type. "
-                    f"Received: dtype={dtype}"
-                )
+        if not is_integer_dtype(dtype):
+            raise ValueError(
+                "Output dtype must be an integer type. "
+                f"Received: dtype={dtype}"
+            )
 
         # Check normalization_form.
         if normalization_form not in [None, "NFC", "NFKC", "NFD", "NFKD"]:
@@ -247,7 +244,7 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
                      UTF-8"""
                 )
 
-        super().__init__(**kwargs)
+        super().__init__(dtype=dtype, **kwargs)
 
         self.sequence_length = sequence_length
         self.lowercase = lowercase

--- a/keras_nlp/tokenizers/word_piece_tokenizer_trainer.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer_trainer.py
@@ -17,7 +17,7 @@ import tensorflow as tf
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.tokenizers.word_piece_tokenizer import pretokenize
-from keras_nlp.utils.tf_utils import assert_tf_text_installed
+from keras_nlp.utils.tensor_utils import assert_tf_text_installed
 
 try:
     from tensorflow_text.tools.wordpiece_vocab import (

--- a/keras_nlp/utils/keras_utils.py
+++ b/keras_nlp/utils/keras_utils.py
@@ -20,7 +20,7 @@ import tensorflow as tf
 from absl import logging
 from tensorflow import keras
 
-from keras_nlp.utils.tf_utils import is_tensor_type
+from keras_nlp.utils.tensor_utils import is_tensor_type
 
 
 def clone_initializer(initializer):

--- a/keras_nlp/utils/pipeline_model.py
+++ b/keras_nlp/utils/pipeline_model.py
@@ -21,7 +21,7 @@ import tensorflow as tf
 from tensorflow import keras
 
 from keras_nlp.utils.keras_utils import pack_x_y_sample_weight
-from keras_nlp.utils.tf_utils import is_tensor_type
+from keras_nlp.utils.tensor_utils import is_tensor_type
 
 
 def _convert_inputs_to_dataset(

--- a/keras_nlp/utils/tensor_utils.py
+++ b/keras_nlp/utils/tensor_utils.py
@@ -88,3 +88,21 @@ def is_tensor_type(x):
         return isinstance(x, (tf.Tensor, np.ndarray))
     else:
         return isinstance(x, (tf.Tensor, np.ndarray, pd.Series, pd.DataFrame))
+
+
+def is_floating_dtype(dtype):
+    if hasattr(dtype, "name"):
+        dtype = dtype.name
+    return "float" in dtype
+
+
+def is_integer_dtype(dtype):
+    if hasattr(dtype, "name"):
+        dtype = dtype.name
+    return "int" in dtype
+
+
+def is_string_dtype(dtype):
+    if hasattr(dtype, "name"):
+        dtype = dtype.name
+    return "string" in dtype

--- a/keras_nlp/utils/tensor_utils_test.py
+++ b/keras_nlp/utils/tensor_utils_test.py
@@ -14,8 +14,8 @@
 
 import tensorflow as tf
 
-from keras_nlp.utils.tf_utils import tensor_to_list
-from keras_nlp.utils.tf_utils import tensor_to_string_list
+from keras_nlp.utils.tensor_utils import tensor_to_list
+from keras_nlp.utils.tensor_utils import tensor_to_string_list
 
 
 class TensorToListTest(tf.test.TestCase):


### PR DESCRIPTION
We can show our dtype defaults in the actual init signature, which will be much more intuitive.