### PR TITLE
Fix saving bug

### DIFF
--- a/keras_nlp/models/albert/albert_classifier.py
+++ b/keras_nlp/models/albert/albert_classifier.py
@@ -186,9 +186,10 @@ class AlbertClassifier(Task):
         self.dropout = dropout
 
         # Default compilation
+        logit_output = self.activation == keras.activations.linear
         self.compile(
             loss=keras.losses.SparseCategoricalCrossentropy(
-                from_logits=activation is None
+                from_logits=logit_output
             ),
             optimizer=keras.optimizers.Adam(5e-5),
             metrics=[keras.metrics.SparseCategoricalAccuracy()],

--- a/keras_nlp/models/albert/albert_classifier_test.py
+++ b/keras_nlp/models/albert/albert_classifier_test.py
@@ -115,12 +115,26 @@ class AlbertClassifierTest(tf.test.TestCase, parameterized.TestCase):
         self.classifier.fit(self.preprocessed_dataset)
 
     def test_serialization(self):
-        config = keras.utils.serialize_keras_object(self.classifier)
-        new_classifier = keras.utils.deserialize_keras_object(config)
-        self.assertEqual(
-            new_classifier.get_config(),
-            self.classifier.get_config(),
+        # Defaults.
+        original = AlbertClassifier(
+            self.backbone,
+            num_classes=2,
         )
+        config = keras.utils.serialize_keras_object(original)
+        restored = keras.utils.deserialize_keras_object(config)
+        self.assertEqual(restored.get_config(), original.get_config())
+        # With options.
+        original = AlbertClassifier(
+            self.backbone,
+            num_classes=4,
+            preprocessor=self.preprocessor,
+            activation=keras.activations.softmax,
+            name="test",
+            trainable=False,
+        )
+        config = keras.utils.serialize_keras_object(original)
+        restored = keras.utils.deserialize_keras_object(config)
+        self.assertEqual(restored.get_config(), original.get_config())
 
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),

--- a/keras_nlp/models/bert/bert_classifier.py
+++ b/keras_nlp/models/bert/bert_classifier.py
@@ -171,9 +171,10 @@ class BertClassifier(Task):
         self.dropout = dropout
 
         # Default compilation
+        logit_output = self.activation == keras.activations.linear
         self.compile(
             loss=keras.losses.SparseCategoricalCrossentropy(
-                from_logits=activation is None
+                from_logits=logit_output
             ),
             optimizer=keras.optimizers.Adam(5e-5),
             metrics=[keras.metrics.SparseCategoricalAccuracy()],

--- a/keras_nlp/models/bert/bert_classifier_test.py
+++ b/keras_nlp/models/bert/bert_classifier_test.py
@@ -90,12 +90,26 @@ class BertClassifierTest(tf.test.TestCase, parameterized.TestCase):
         self.classifier.fit(self.preprocessed_dataset)
 
     def test_serialization(self):
-        config = keras.utils.serialize_keras_object(self.classifier)
-        new_classifier = keras.utils.deserialize_keras_object(config)
-        self.assertEqual(
-            new_classifier.get_config(),
-            self.classifier.get_config(),
+        # Defaults.
+        original = BertClassifier(
+            self.backbone,
+            num_classes=2,
         )
+        config = keras.utils.serialize_keras_object(original)
+        restored = keras.utils.deserialize_keras_object(config)
+        self.assertEqual(restored.get_config(), original.get_config())
+        # With options.
+        original = BertClassifier(
+            self.backbone,
+            num_classes=4,
+            preprocessor=self.preprocessor,
+            activation=keras.activations.softmax,
+            name="test",
+            trainable=False,
+        )
+        config = keras.utils.serialize_keras_object(original)
+        restored = keras.utils.deserialize_keras_object(config)
+        self.assertEqual(restored.get_config(), original.get_config())
 
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),

--- a/keras_nlp/models/deberta_v3/deberta_v3_classifier.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_classifier.py
@@ -202,9 +202,10 @@ class DebertaV3Classifier(Task):
         self.dropout = dropout
 
         # Default compilation
+        logit_output = self.activation == keras.activations.linear
         self.compile(
             loss=keras.losses.SparseCategoricalCrossentropy(
-                from_logits=activation is None
+                from_logits=logit_output
             ),
             optimizer=keras.optimizers.Adam(5e-5),
             metrics=[keras.metrics.SparseCategoricalAccuracy()],

--- a/keras_nlp/models/deberta_v3/deberta_v3_classifier_test.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_classifier_test.py
@@ -113,12 +113,27 @@ class DebertaV3ClassifierTest(tf.test.TestCase, parameterized.TestCase):
         self.classifier.fit(self.preprocessed_dataset)
 
     def test_serialization(self):
-        config = keras.utils.serialize_keras_object(self.classifier)
-        new_classifier = keras.utils.deserialize_keras_object(config)
-        self.assertEqual(
-            new_classifier.get_config(),
-            self.classifier.get_config(),
+        # Defaults.
+        original = DebertaV3Classifier(
+            self.backbone,
+            num_classes=2,
         )
+        config = keras.utils.serialize_keras_object(original)
+        restored = keras.utils.deserialize_keras_object(config)
+        self.assertEqual(restored.get_config(), original.get_config())
+        # With options.
+        original = DebertaV3Classifier(
+            self.backbone,
+            num_classes=4,
+            preprocessor=self.preprocessor,
+            activation=keras.activations.softmax,
+            hidden_dim=4,
+            name="test",
+            trainable=False,
+        )
+        config = keras.utils.serialize_keras_object(original)
+        restored = keras.utils.deserialize_keras_object(config)
+        self.assertEqual(restored.get_config(), original.get_config())
 
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),

--- a/keras_nlp/models/distil_bert/distil_bert_classifier.py
+++ b/keras_nlp/models/distil_bert/distil_bert_classifier.py
@@ -187,9 +187,10 @@ class DistilBertClassifier(Task):
         self.hidden_dim = hidden_dim
         self.dropout = dropout
 
+        logit_output = self.activation == keras.activations.linear
         self.compile(
             loss=keras.losses.SparseCategoricalCrossentropy(
-                from_logits=activation is None
+                from_logits=logit_output
             ),
             optimizer=keras.optimizers.Adam(5e-5),
             metrics=[keras.metrics.SparseCategoricalAccuracy()],

--- a/keras_nlp/models/distil_bert/distil_bert_classifier_test.py
+++ b/keras_nlp/models/distil_bert/distil_bert_classifier_test.py
@@ -97,12 +97,27 @@ class DistilBertClassifierTest(tf.test.TestCase, parameterized.TestCase):
         self.classifier.fit(self.preprocessed_dataset)
 
     def test_serialization(self):
-        config = keras.utils.serialize_keras_object(self.classifier)
-        new_classifier = keras.utils.deserialize_keras_object(config)
-        self.assertEqual(
-            new_classifier.get_config(),
-            self.classifier.get_config(),
+        # Defaults.
+        original = DistilBertClassifier(
+            self.backbone,
+            num_classes=2,
         )
+        config = keras.utils.serialize_keras_object(original)
+        restored = keras.utils.deserialize_keras_object(config)
+        self.assertEqual(restored.get_config(), original.get_config())
+        # With options.
+        original = DistilBertClassifier(
+            self.backbone,
+            num_classes=4,
+            preprocessor=self.preprocessor,
+            activation=keras.activations.softmax,
+            hidden_dim=4,
+            name="test",
+            trainable=False,
+        )
+        config = keras.utils.serialize_keras_object(original)
+        restored = keras.utils.deserialize_keras_object(config)
+        self.assertEqual(restored.get_config(), original.get_config())
 
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),

--- a/keras_nlp/models/f_net/f_net_classifier.py
+++ b/keras_nlp/models/f_net/f_net_classifier.py
@@ -138,9 +138,10 @@ class FNetClassifier(Task):
         self.activation = keras.activations.get(activation)
         self.dropout = dropout
 
+        logit_output = self.activation == keras.activations.linear
         self.compile(
             loss=keras.losses.SparseCategoricalCrossentropy(
-                from_logits=activation is None
+                from_logits=logit_output
             ),
             optimizer=keras.optimizers.Adam(5e-5),
             metrics=[keras.metrics.SparseCategoricalAccuracy()],

--- a/keras_nlp/models/f_net/f_net_classifier_test.py
+++ b/keras_nlp/models/f_net/f_net_classifier_test.py
@@ -112,12 +112,26 @@ class FNetClassifierTest(tf.test.TestCase, parameterized.TestCase):
         self.classifier.fit(self.preprocessed_dataset)
 
     def test_serialization(self):
-        config = keras.utils.serialize_keras_object(self.classifier)
-        new_classifier = keras.utils.deserialize_keras_object(config)
-        self.assertEqual(
-            new_classifier.get_config(),
-            self.classifier.get_config(),
+        # Defaults.
+        original = FNetClassifier(
+            self.backbone,
+            num_classes=2,
         )
+        config = keras.utils.serialize_keras_object(original)
+        restored = keras.utils.deserialize_keras_object(config)
+        self.assertEqual(restored.get_config(), original.get_config())
+        # With options.
+        original = FNetClassifier(
+            self.backbone,
+            num_classes=4,
+            preprocessor=self.preprocessor,
+            activation=keras.activations.softmax,
+            name="test",
+            trainable=False,
+        )
+        config = keras.utils.serialize_keras_object(original)
+        restored = keras.utils.deserialize_keras_object(config)
+        self.assertEqual(restored.get_config(), original.get_config())
 
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),

--- a/keras_nlp/models/roberta/roberta_classifier.py
+++ b/keras_nlp/models/roberta/roberta_classifier.py
@@ -181,9 +181,10 @@ class RobertaClassifier(Task):
         self.dropout = dropout
 
         # Default compilation
+        logit_output = self.activation == keras.activations.linear
         self.compile(
             loss=keras.losses.SparseCategoricalCrossentropy(
-                from_logits=activation is None
+                from_logits=logit_output
             ),
             optimizer=keras.optimizers.Adam(2e-5),
             metrics=[keras.metrics.SparseCategoricalAccuracy()],

--- a/keras_nlp/models/roberta/roberta_classifier_test.py
+++ b/keras_nlp/models/roberta/roberta_classifier_test.py
@@ -109,12 +109,27 @@ class RobertaClassifierTest(tf.test.TestCase, parameterized.TestCase):
         self.classifier.fit(self.preprocessed_dataset)
 
     def test_serialization(self):
-        config = keras.utils.serialize_keras_object(self.classifier)
-        new_classifier = keras.utils.deserialize_keras_object(config)
-        self.assertEqual(
-            new_classifier.get_config(),
-            self.classifier.get_config(),
+        # Defaults.
+        original = RobertaClassifier(
+            self.backbone,
+            num_classes=2,
         )
+        config = keras.utils.serialize_keras_object(original)
+        restored = keras.utils.deserialize_keras_object(config)
+        self.assertEqual(restored.get_config(), original.get_config())
+        # With options.
+        original = RobertaClassifier(
+            self.backbone,
+            num_classes=4,
+            preprocessor=self.preprocessor,
+            activation=keras.activations.softmax,
+            hidden_dim=4,
+            name="test",
+            trainable=False,
+        )
+        config = keras.utils.serialize_keras_object(original)
+        restored = keras.utils.deserialize_keras_object(config)
+        self.assertEqual(restored.get_config(), original.get_config())
 
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -58,9 +58,9 @@ class Task(PipelineModel):
             # Only handle sparse categorical crossentropy.
             return
 
-        is_softmax = activation == keras.activations.softmax
-        is_linear = activation == keras.activations.linear
-        if is_softmax and from_logits:
+        softmax_output = activation == keras.activations.softmax
+        logit_output = activation == keras.activations.linear
+        if softmax_output and from_logits:
             raise ValueError(
                 "The `loss` passed to `compile()` expects logit output, but "
                 "the model is configured to output softmax probabilities "
@@ -68,7 +68,7 @@ class Task(PipelineModel):
                 "`from_logits=False` to your loss, e.g. "
                 "`loss=keras.losses.SparseCategoricalCrossentropy(from_logits=False)`. "
             )
-        if is_linear and not from_logits:
+        if logit_output and not from_logits:
             raise ValueError(
                 "The `loss` passed to `compile()` expects softmax probability "
                 "output, but the model is configured to output logits "

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_classifier.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_classifier.py
@@ -193,9 +193,10 @@ class XLMRobertaClassifier(Task):
         self.hidden_dim = hidden_dim
         self.dropout = dropout
 
+        logit_output = self.activation == keras.activations.linear
         self.compile(
             loss=keras.losses.SparseCategoricalCrossentropy(
-                from_logits=activation is None
+                from_logits=logit_output
             ),
             optimizer=keras.optimizers.Adam(5e-5),
             metrics=[keras.metrics.SparseCategoricalAccuracy()],

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_classifier_test.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_classifier_test.py
@@ -108,12 +108,27 @@ class XLMRobertaClassifierTest(tf.test.TestCase, parameterized.TestCase):
         self.classifier.fit(self.preprocessed_dataset)
 
     def test_serialization(self):
-        config = keras.utils.serialize_keras_object(self.classifier)
-        new_classifier = keras.utils.deserialize_keras_object(config)
-        self.assertEqual(
-            new_classifier.get_config(),
-            self.classifier.get_config(),
+        # Defaults.
+        original = XLMRobertaClassifier(
+            self.backbone,
+            num_classes=2,
         )
+        config = keras.utils.serialize_keras_object(original)
+        restored = keras.utils.deserialize_keras_object(config)
+        self.assertEqual(restored.get_config(), original.get_config())
+        # With options.
+        original = XLMRobertaClassifier(
+            self.backbone,
+            num_classes=4,
+            preprocessor=self.preprocessor,
+            activation=keras.activations.softmax,
+            hidden_dim=4,
+            name="test",
+            trainable=False,
+        )
+        config = keras.utils.serialize_keras_object(original)
+        restored = keras.utils.deserialize_keras_object(config)
+        self.assertEqual(restored.get_config(), original.get_config())
 
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),


### PR DESCRIPTION
See https://github.com/keras-team/keras-nlp/issues/1042 for repro.

This was actually introduced when we added output activations to our classifiers and a faulty assumption we made a serializing activations.

`keras.activations.get(None) == keras.activations.linear`

Which means that when you round trip through saving/serializing, `activation=None` becomes `activation=keras.activations.linear`. This was causing us to choose an incorrect loss, which was correctly tripping an error we added to the base `Task` object to detect an incorrect loss, which was causing some odd serialization errors to get printed with normal saving.

Probably more to do here... both with improving our compilation experience overall, and surfacing better errors for saving. Also, someday soon I hope I need to consolidate some of our model testing code.