### PR TITLE
Extend the timeout for large tests

### DIFF
--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -65,12 +65,12 @@ steps:
     gcloud container clusters get-credentials $_CLUSTER_NAME --zone $_CLUSTER_ZONE --project keras-team-test
     job_name=$(kubectl create -f output.yaml -o name)
     sleep 5
-    pod_name=$(kubectl wait --for condition=ready --timeout=30m pod -l job-name=${job_name#job.batch/} -o name)
+    pod_name=$(kubectl wait --for condition=ready --timeout=60m pod -l job-name=${job_name#job.batch/} -o name)
     kubectl logs -f $pod_name --container=train
     sleep 5
     gcloud artifacts docker images delete $_IMAGE_NAME:$BUILD_ID
     exit $(kubectl get $pod_name -o jsonpath={.status.containerStatuses[0].state.terminated.exitCode})
-timeout: 3600s  # 60 minutes
+timeout: 5400s  # 90 minutes
 options:
   volumes:
   - name: go-modules

--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -65,12 +65,12 @@ steps:
     gcloud container clusters get-credentials $_CLUSTER_NAME --zone $_CLUSTER_ZONE --project keras-team-test
     job_name=$(kubectl create -f output.yaml -o name)
     sleep 5
-    pod_name=$(kubectl wait --for condition=ready --timeout=60m pod -l job-name=${job_name#job.batch/} -o name)
+    pod_name=$(kubectl wait --for condition=ready --timeout=120m pod -l job-name=${job_name#job.batch/} -o name)
     kubectl logs -f $pod_name --container=train
     sleep 5
     gcloud artifacts docker images delete $_IMAGE_NAME:$BUILD_ID
     exit $(kubectl get $pod_name -o jsonpath={.status.containerStatuses[0].state.terminated.exitCode})
-timeout: 5400s  # 90 minutes
+timeout: 120m
 options:
   volumes:
   - name: go-modules

--- a/.cloudbuild/cloudbuild_tpu.yaml
+++ b/.cloudbuild/cloudbuild_tpu.yaml
@@ -67,12 +67,12 @@ steps:
     gcloud container clusters get-credentials $_CLUSTER_NAME --zone $_CLUSTER_ZONE --project keras-team-test
     job_name=$(kubectl create -f output.yaml -o name)
     sleep 5
-    pod_name=$(kubectl wait --for condition=ready --timeout=30m pod -l job-name=${job_name#job.batch/} -o name)
+    pod_name=$(kubectl wait --for condition=ready --timeout=120m pod -l job-name=${job_name#job.batch/} -o name)
     kubectl logs -f $pod_name --container=train
     sleep 5
     # gcloud artifacts docker images delete $_IMAGE_NAME:$BUILD_ID
     exit $(kubectl get $pod_name -o jsonpath={.status.containerStatuses[0].state.terminated.exitCode})
-timeout: 3600s  # 60 minutes
+timeout: 120m
 options:
   volumes:
   - name: go-modules

--- a/.cloudbuild/cloudbuild_tpu.yaml
+++ b/.cloudbuild/cloudbuild_tpu.yaml
@@ -67,12 +67,12 @@ steps:
     gcloud container clusters get-credentials $_CLUSTER_NAME --zone $_CLUSTER_ZONE --project keras-team-test
     job_name=$(kubectl create -f output.yaml -o name)
     sleep 5
-    pod_name=$(kubectl wait --for condition=ready --timeout=10m pod -l job-name=${job_name#job.batch/} -o name)
+    pod_name=$(kubectl wait --for condition=ready --timeout=30m pod -l job-name=${job_name#job.batch/} -o name)
     kubectl logs -f $pod_name --container=train
     sleep 5
     # gcloud artifacts docker images delete $_IMAGE_NAME:$BUILD_ID
     exit $(kubectl get $pod_name -o jsonpath={.status.containerStatuses[0].state.terminated.exitCode})
-timeout: 1800s  # 30 minutes
+timeout: 3600s  # 60 minutes
 options:
   volumes:
   - name: go-modules

--- a/.cloudbuild/unit_test_jobs.jsonnet
+++ b/.cloudbuild/unit_test_jobs.jsonnet
@@ -11,7 +11,7 @@ local unittest = base.BaseTest {
   frameworkPrefix: backend,
   modelName: "keras-nlp",
   mode: "unit-tests",
-  timeout: 3600, # 1 hour, in seconds
+  timeout: 7200, # 2 hours, in seconds
 
   // Set up runtime environment.
   image: image,

--- a/.cloudbuild/unit_test_jobs_tpu.jsonnet
+++ b/.cloudbuild/unit_test_jobs_tpu.jsonnet
@@ -10,7 +10,7 @@ local unittest = base.BaseTest {
   frameworkPrefix: "tf",
   modelName: "keras-nlp",
   mode: "unit-tests",
-  timeout: 5400, # 90 minutes, in seconds
+  timeout: 7200, # 2 hours, in seconds
 
   // Set up runtime environment.
   image: image,

--- a/.cloudbuild/unit_test_jobs_tpu.jsonnet
+++ b/.cloudbuild/unit_test_jobs_tpu.jsonnet
@@ -10,7 +10,7 @@ local unittest = base.BaseTest {
   frameworkPrefix: "tf",
   modelName: "keras-nlp",
   mode: "unit-tests",
-  timeout: 3600, # 1 hour, in seconds
+  timeout: 5400, # 90 minutes, in seconds
 
   // Set up runtime environment.
   image: image,


### PR DESCRIPTION
We are getting more models and with tensorflow 2.12 also check the new saved model format.

We should think of where to save time on tests, but for now can do the easy fix.