### PR TITLE
Port tokenizers and preprocessing to core

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -102,7 +102,7 @@ jobs:
       env:
         KERAS_BACKEND: ${{ matrix.backend }}
       run: |
-        pytest --run_large keras_nlp/layers/modeling keras_nlp/samplers
+        pytest --run_large keras_nlp/layers/modeling keras_nlp/samplers keras_nlp/tokenizers
   format:
     name: Check the code format
     runs-on: ubuntu-latest

--- a/keras_nlp/layers/preprocessing/masked_lm_mask_generator.py
+++ b/keras_nlp/layers/preprocessing/masked_lm_mask_generator.py
@@ -32,15 +32,18 @@ class MaskedLMMaskGenerator(PreprocessingLayer):
     """Layer that applies language model masking.
 
     This layer is useful for preparing inputs for masked language modeling
-    (MaskedLM) tasks. It follows the masking strategy described in the [original BERT
-    paper](https://arxiv.org/abs/1810.04805). Given tokenized text,
-    it randomly selects certain number of tokens for masking. Then for each
-    selected token, it has a chance (configurable) to be replaced by
+    (MaskedLM) tasks. It follows the masking strategy described in the
+    [original BERT paper](https://arxiv.org/abs/1810.04805). Given tokenized
+    text, it randomly selects certain number of tokens for masking. Then for
+    each selected token, it has a chance (configurable) to be replaced by
     "mask token" or random token, or stay unchanged.
 
     Input data should be passed as tensors, `tf.RaggedTensor`s, or lists. For
     batched input, inputs should be a list of lists or a rank two tensor. For
     unbatched inputs, each element should be a list or a rank one tensor.
+
+    This layer can be used with `tf.data` to generate dynamic masks on the fly
+    during training.
 
     Args:
         vocabulary_size: int, the size of the vocabulary.

--- a/keras_nlp/layers/preprocessing/masked_lm_mask_generator.py
+++ b/keras_nlp/layers/preprocessing/masked_lm_mask_generator.py
@@ -15,8 +15,11 @@
 import tensorflow as tf
 
 from keras_nlp.api_export import keras_nlp_export
-from keras_nlp.backend import keras
+from keras_nlp.layers.preprocessing.preprocessing_layer import (
+    PreprocessingLayer,
+)
 from keras_nlp.utils.tensor_utils import assert_tf_text_installed
+from keras_nlp.utils.tensor_utils import convert_to_ragged_batch
 
 try:
     import tensorflow_text as tf_text
@@ -25,7 +28,7 @@ except ImportError:
 
 
 @keras_nlp_export("keras_nlp.layers.MaskedLMMaskGenerator")
-class MaskedLMMaskGenerator(keras.layers.Layer):
+class MaskedLMMaskGenerator(PreprocessingLayer):
     """Layer that applies language model masking.
 
     This layer is useful for preparing inputs for masked language modeling
@@ -35,7 +38,9 @@ class MaskedLMMaskGenerator(keras.layers.Layer):
     selected token, it has a chance (configurable) to be replaced by
     "mask token" or random token, or stay unchanged.
 
-    Users should use this layer with `tf.data` to generate masks.
+    Input data should be passed as tensors, `tf.RaggedTensor`s, or lists. For
+    batched input, inputs should be a list of lists or a rank two tensor. For
+    unbatched inputs, each element should be a list or a rank one tensor.
 
     Args:
         vocabulary_size: int, the size of the vocabulary.
@@ -59,11 +64,6 @@ class MaskedLMMaskGenerator(keras.layers.Layer):
             Note: mask_token_rate + random_token_rate <= 1,  and for
             (1 - mask_token_rate - random_token_rate), the token will not be
             changed. Defaults to `0.1`.
-
-    Input:
-        A 1D integer tensor of shape [sequence_length] or a 2D integer tensor
-        of shape [batch_size, sequence_length], or a 2D integer RaggedTensor.
-        Represents the sequence to mask.
 
     Returns:
         A Dict with 4 keys:
@@ -90,19 +90,19 @@ class MaskedLMMaskGenerator(keras.layers.Layer):
         mask_selection_length=5
     )
     # Dense input.
-    masker(tf.constant([1, 2, 3, 4, 5]))
+    masker([1, 2, 3, 4, 5])
 
     # Ragged input.
-    masker(tf.ragged.constant([[1, 2], [1, 2, 3, 4]]))
+    masker([[1, 2], [1, 2, 3, 4]])
     ```
 
     Masking a batch that contains special tokens.
     ```python
     pad_id, cls_id, sep_id, mask_id = 0, 1, 2, 3
-    batch = tf.constant([
+    batch = [
         [cls_id,   4,    5,      6, sep_id,    7,    8, sep_id, pad_id, pad_id],
         [cls_id,   4,    5, sep_id,      6,    7,    8,      9, sep_id, pad_id],
-    ])
+    ]
 
     masker = keras_nlp.layers.MaskedLMMaskGenerator(
         vocabulary_size = 10,
@@ -115,7 +115,6 @@ class MaskedLMMaskGenerator(keras.layers.Layer):
             pad_id,
         ]
     )
-
     masker(batch)
     ```
     """
@@ -134,6 +133,7 @@ class MaskedLMMaskGenerator(keras.layers.Layer):
         assert_tf_text_installed(self.__class__.__name__)
 
         super().__init__(**kwargs)
+
         self.vocabulary_size = vocabulary_size
         self.unselectable_token_ids = unselectable_token_ids
         self.mask_selection_rate = mask_selection_rate
@@ -165,15 +165,7 @@ class MaskedLMMaskGenerator(keras.layers.Layer):
         )
 
     def call(self, inputs):
-        input_is_ragged = isinstance(inputs, tf.RaggedTensor)
-        input_is_1d = inputs.shape.rank == 1
-        if input_is_1d:
-            # If inputs is of rank 1, we manually add the batch axis.
-            inputs = inputs[tf.newaxis, :]
-        if not input_is_ragged:
-            # `tf_text.mask_language_model` requires a ragged tensor, so
-            # convert dense to ragged.
-            inputs = tf.RaggedTensor.from_tensor(inputs)
+        inputs, unbatched, rectangular = convert_to_ragged_batch(inputs)
 
         (
             token_ids,
@@ -185,7 +177,7 @@ class MaskedLMMaskGenerator(keras.layers.Layer):
             mask_values_chooser=self._mask_values_chooser,
         )
 
-        if not input_is_ragged:
+        if rectangular:
             # If we converted the input from dense to ragged, convert back.
             token_ids = token_ids.to_tensor()
 
@@ -197,7 +189,7 @@ class MaskedLMMaskGenerator(keras.layers.Layer):
             mask_ids = mask_ids.to_tensor(shape=target_shape)
             mask_weights = mask_weights.to_tensor(shape=target_shape)
 
-        if input_is_1d:
+        if unbatched:
             # If inputs is 1D, we format the output to be 1D as well.
             token_ids = tf.squeeze(token_ids, axis=0)
             mask_positions = tf.squeeze(mask_positions, axis=0)

--- a/keras_nlp/layers/preprocessing/masked_lm_mask_generator_test.py
+++ b/keras_nlp/layers/preprocessing/masked_lm_mask_generator_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import tensorflow as tf
 
 from keras_nlp.layers.preprocessing.masked_lm_mask_generator import (
@@ -41,104 +42,70 @@ class MaskedLMMaskGeneratorTest(TestCase):
         self.mask_token_id = self.VOCAB.index("[MASK]")
         self.vocabulary_size = len(self.VOCAB)
 
-    def test_mask_ragged_tensor(self):
+    def test_mask_ragged(self):
         masked_lm_masker = MaskedLMMaskGenerator(
             vocabulary_size=self.vocabulary_size,
-            mask_selection_rate=0.5,
-            mask_selection_length=5,
+            mask_selection_rate=1,
+            mask_selection_length=4,
             mask_token_id=self.mask_token_id,
             mask_token_rate=1,
             random_token_rate=0,
         )
-        inputs = tf.ragged.constant([[5, 3, 2], [1, 2, 3, 4, 5]])
-        outputs = masked_lm_masker(inputs)
-        token_ids, mask_positions, mask_ids = (
-            outputs["token_ids"],
-            outputs["mask_positions"],
-            outputs["mask_ids"],
-        )
-        self.assertEqual(type(token_ids), type(inputs))
-        self.assertAllEqual(token_ids.shape, inputs.shape)
-        self.assertAllEqual(mask_positions.shape, mask_ids.shape)
+        inputs = [[5, 3, 2], [1, 2, 3, 4]]
+        x = masked_lm_masker(inputs)
+        self.assertAllEqual(x["token_ids"], [[1, 1, 1], [1, 1, 1, 1]])
+        self.assertAllEqual(x["mask_positions"], [[0, 1, 2, 0], [0, 1, 2, 3]])
+        self.assertAllEqual(x["mask_ids"], [[5, 3, 2, 0], [1, 2, 3, 4]])
 
-        # Test all selected token_ids are correctly masked.
-        masked_values = tf.gather(
-            token_ids,
-            mask_positions,
-            batch_dims=1,
-        )
-        self.assertEqual(tf.reduce_mean(masked_values), self.mask_token_id)
-
-    def test_mask_tensor(self):
+    def test_mask_dense(self):
         masked_lm_masker = MaskedLMMaskGenerator(
             vocabulary_size=self.vocabulary_size,
-            mask_selection_rate=0.5,
-            mask_selection_length=5,
+            mask_selection_rate=1,
+            mask_selection_length=4,
             mask_token_id=self.mask_token_id,
             mask_token_rate=1,
             random_token_rate=0,
         )
-        inputs = tf.random.uniform(
-            shape=[5, 10],
-            maxval=len(self.VOCAB),
-            dtype="int32",
-        )
-        outputs = masked_lm_masker(inputs)
-        token_ids, mask_positions, mask_ids = (
-            outputs["token_ids"],
-            outputs["mask_positions"],
-            outputs["mask_ids"],
-        )
-        self.assertEqual(type(token_ids), type(inputs))
-        self.assertAllEqual(token_ids.shape, inputs.shape)
-        self.assertAllEqual(mask_positions.shape, mask_ids.shape)
-        # Test all selected token_ids are correctly masked.
-        masked_values = tf.gather(
-            token_ids,
-            mask_positions,
-            batch_dims=1,
-        )
-        self.assertEqual(tf.reduce_mean(masked_values), self.mask_token_id)
+        inputs = [[5, 3, 2, 4], [1, 2, 3, 4]]
+        x = masked_lm_masker(inputs)
+        self.assertAllEqual(x["token_ids"], [[1, 1, 1, 1], [1, 1, 1, 1]])
+        self.assertAllEqual(x["mask_positions"], [[0, 1, 2, 3], [0, 1, 2, 3]])
+        self.assertAllEqual(x["mask_ids"], [[5, 3, 2, 4], [1, 2, 3, 4]])
 
-    def test_mask_1d_input(self):
+    def test_unbatched(self):
         masked_lm_masker = MaskedLMMaskGenerator(
             vocabulary_size=self.vocabulary_size,
-            mask_selection_rate=0.5,
-            mask_selection_length=5,
+            mask_selection_rate=1,
+            mask_selection_length=4,
             mask_token_id=self.mask_token_id,
             mask_token_rate=1,
             random_token_rate=0,
         )
-        inputs = tf.constant([1, 2, 3, 4, 5])
-        outputs = masked_lm_masker(inputs)
-        self.assertAllEqual(outputs["token_ids"].shape, inputs.shape)
+        inputs = [5, 3, 2, 4]
+        x = masked_lm_masker(inputs)
+        self.assertAllEqual(x["token_ids"], [1, 1, 1, 1])
+        self.assertAllEqual(x["mask_positions"], [0, 1, 2, 3])
+        self.assertAllEqual(x["mask_ids"], [5, 3, 2, 4])
+
+    def test_random_replacement(self):
+        masked_lm_masker = MaskedLMMaskGenerator(
+            vocabulary_size=10_000,
+            mask_selection_rate=1,
+            mask_selection_length=4,
+            mask_token_id=self.mask_token_id,
+            mask_token_rate=0,
+            random_token_rate=1,
+        )
+        inputs = [5, 3, 2, 4]
+        x = masked_lm_masker(inputs)
+        self.assertNotAllEqual(x["token_ids"], [1, 1, 1, 1])
+        self.assertAllEqual(x["mask_positions"], [0, 1, 2, 3])
+        self.assertAllEqual(x["mask_ids"], [5, 3, 2, 4])
 
     def test_number_of_masked_position_as_expected(self):
         mask_selection_rate = 0.5
         mask_selection_length = 5
-        masked_lm_masker = MaskedLMMaskGenerator(
-            vocabulary_size=self.vocabulary_size,
-            mask_selection_rate=mask_selection_rate,
-            mask_token_id=self.mask_token_id,
-            unselectable_token_ids=None,
-        )
-        inputs = tf.ragged.constant(
-            [[0, 1, 2], [0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4]]
-        )
-        outputs = masked_lm_masker(inputs)
-        expected_number_of_masked_tokens = tf.cast(
-            tf.math.ceil(
-                tf.cast(inputs.row_lengths(), dtype="float32")
-                * mask_selection_rate,
-            ),
-            dtype="int64",
-        )
-
-        self.assertAllEqual(
-            outputs["mask_positions"].row_lengths(),
-            expected_number_of_masked_tokens,
-        )
-
+        inputs = [[0, 1, 2], [0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4]]
         # Cap the number of masked tokens at 0, so we can test if
         # mask_selection_length takes effect.
         mask_selection_length = 0
@@ -150,37 +117,6 @@ class MaskedLMMaskGeneratorTest(TestCase):
         )
         outputs = masked_lm_masker(inputs)
         self.assertEqual(tf.reduce_sum(outputs["mask_positions"]), 0)
-
-    def test_apply_random_token_not_mask(self):
-        masked_lm_masker = MaskedLMMaskGenerator(
-            vocabulary_size=self.vocabulary_size,
-            mask_selection_rate=0.5,
-            mask_token_id=self.mask_token_id,
-            mask_token_rate=0,
-            random_token_rate=1,
-        )
-        inputs = tf.random.uniform(
-            shape=[5, 10],
-            maxval=len(self.VOCAB),
-            dtype="int32",
-        )
-        outputs = masked_lm_masker(inputs)
-        tokens_ids, mask_positions, mask_ids = (
-            outputs["token_ids"],
-            outputs["mask_positions"],
-            outputs["mask_ids"],
-        )
-        self.assertAllEqual(tokens_ids.shape, inputs.shape)
-        self.assertAllEqual(
-            mask_positions.row_lengths(), mask_ids.row_lengths()
-        )
-        masked_values = tf.gather(
-            tokens_ids,
-            mask_positions,
-            batch_dims=1,
-        )
-        # Verify that selected tokens_ids are replaced by random tokens_ids.
-        self.assertNotEqual(tf.reduce_mean(masked_values), self.mask_token_id)
 
     def test_invalid_mask_token(self):
         with self.assertRaisesRegex(ValueError, "Mask token id should be*"):
@@ -205,10 +141,9 @@ class MaskedLMMaskGeneratorTest(TestCase):
             mask_token_rate=1,
             random_token_rate=0,
         )
-        inputs = tf.convert_to_tensor([unselectable_token_ids])
-        outputs = masked_lm_masker(inputs)
+        outputs = masked_lm_masker([unselectable_token_ids])
         # Verify that no token is masked out.
-        self.assertEqual(tf.reduce_sum(outputs["mask_positions"]), 0)
+        self.assertEqual(np.sum(np.array(outputs["mask_weights"])), 0)
 
     def test_config(self):
         unselectable_token_ids = [
@@ -231,26 +166,8 @@ class MaskedLMMaskGeneratorTest(TestCase):
 
         # Test cloned masked_lm_masker can be run.
         cloned_masked_lm_masker = MaskedLMMaskGenerator.from_config(config)
-        inputs = tf.ragged.constant(
-            [[0, 1, 2], [0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4]]
-        )
+        inputs = [[5, 3, 2], [1, 2, 3, 4]]
         cloned_masked_lm_masker(inputs)
-
-    def test_graph_mode_execution(self):
-        masked_lm_masker = MaskedLMMaskGenerator(
-            vocabulary_size=self.vocabulary_size,
-            mask_selection_rate=0.5,
-            mask_token_id=self.mask_token_id,
-            mask_selection_length=5,
-        )
-
-        @tf.function
-        def masker(inputs):
-            return masked_lm_masker(inputs)
-
-        masker(tf.constant([1, 2, 3]))
-        masker(tf.constant([[1, 2, 3], [1, 2, 3]]))
-        masker(tf.ragged.constant([[3, 5, 7, 7], [4, 6, 7, 5]]))
 
     def test_with_tf_data(self):
         ds = tf.data.Dataset.from_tensor_slices(

--- a/keras_nlp/layers/preprocessing/preprocessing_layer.py
+++ b/keras_nlp/layers/preprocessing/preprocessing_layer.py
@@ -1,0 +1,50 @@
+# Copyright 2023 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+from keras_nlp.backend import config
+from keras_nlp.backend import keras
+from keras_nlp.utils.tensor_utils import (
+    convert_to_backend_tensor_or_python_list,
+)
+
+
+class PreprocessingLayer(keras.layers.Layer):
+    """Preprocessing layer base class."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._convert_input_args = False
+        self._allow_non_tensor_positional_args = True
+        self.built = True
+
+    def __call__(self, *args, **kwargs):
+        # Always place on CPU for preprocessing, to avoid expensive back and
+        # forth copies to GPU before the trainable model.
+        with tf.device("cpu"):
+            outputs = super().__call__(*args, **kwargs)
+
+            # Jax and Torch lack native string and ragged types.
+            # If we are running on those backends and not running with tf.data
+            # (we are outside a tf.function), we covert all ragged and string
+            # tensor to pythonic types.
+            is_tf_backend = config.backend() == "tensorflow"
+            is_in_tf_graph = not tf.executing_eagerly()
+            if not is_tf_backend and not is_in_tf_graph:
+                outputs = tf.nest.map_structure(
+                    convert_to_backend_tensor_or_python_list, outputs
+                )
+
+        return outputs

--- a/keras_nlp/layers/preprocessing/random_swap.py
+++ b/keras_nlp/layers/preprocessing/random_swap.py
@@ -16,13 +16,16 @@ import random
 import tensorflow as tf
 
 from keras_nlp.api_export import keras_nlp_export
-from keras_nlp.backend import keras
+from keras_nlp.layers.preprocessing.preprocessing_layer import (
+    PreprocessingLayer,
+)
+from keras_nlp.utils.tensor_utils import convert_to_ragged_batch
 from keras_nlp.utils.tensor_utils import is_integer_dtype
 from keras_nlp.utils.tensor_utils import is_string_dtype
 
 
 @keras_nlp_export("keras_nlp.layers.RandomSwap")
-class RandomSwap(keras.layers.Layer):
+class RandomSwap(PreprocessingLayer):
     """Augments input by randomly swapping words.
 
     This layer comes in handy when you need to generate new data using swap
@@ -33,8 +36,9 @@ class RandomSwap(keras.layers.Layer):
     augmentation, you can split by character for character level swaps, or by
     word for word level swaps.
 
-    Input should be either a `tf.RaggedTensor` or a dense `tf.Tensor`, and
-    either rank-1 or rank-2.
+    Input data should be passed as tensors, `tf.RaggedTensor`s, or lists. For
+    batched input, inputs should be a list of lists or a rank two tensor. For
+    unbatched inputs, each element should be a list or a rank one tensor.
 
     Args:
         rate: The probability of a given token being chosen to be swapped
@@ -129,6 +133,7 @@ class RandomSwap(keras.layers.Layer):
             )
 
         super().__init__(name=name, dtype=dtype, **kwargs)
+
         self.rate = rate
         self.max_swaps = max_swaps
         self.seed = random.randint(1, 1e9) if seed is None else seed
@@ -158,22 +163,7 @@ class RandomSwap(keras.layers.Layer):
             )
 
     def call(self, inputs):
-        if not isinstance(inputs, (tf.Tensor, tf.RaggedTensor)):
-            inputs = tf.convert_to_tensor(inputs)
-
-        input_is_1d = False
-        if inputs.shape.rank < 1 or inputs.shape.rank > 2:
-            raise ValueError(
-                "Input must either be rank 1 or rank 2. Received input with "
-                f"rank={inputs.shape.rank}"
-            )
-        elif inputs.shape.rank == 1:
-            input_is_1d = True
-            # Add a new axis at the beginning.
-            inputs = tf.expand_dims(inputs, axis=0)
-        if isinstance(inputs, tf.Tensor):
-            # Convert to ragged tensor.
-            inputs = tf.RaggedTensor.from_tensor(inputs)
+        inputs, unbatched, _ = convert_to_ragged_batch(inputs)
 
         skip_masks = None
         if self.skip_list:
@@ -249,7 +239,7 @@ class RandomSwap(keras.layers.Layer):
         )
         swapped.flat_values.set_shape([None])
 
-        if input_is_1d:
+        if unbatched:
             swapped = tf.squeeze(swapped, axis=0)
         return swapped
 
@@ -266,3 +256,8 @@ class RandomSwap(keras.layers.Layer):
             }
         )
         return config
+
+    def compute_output_shape(self, inputs_shape):
+        inputs_shape = list(inputs_shape)
+        inputs_shape[-1] = None
+        return tuple(inputs_shape)

--- a/keras_nlp/layers/preprocessing/random_swap_test.py
+++ b/keras_nlp/layers/preprocessing/random_swap_test.py
@@ -27,9 +27,10 @@ class RandomSwapTest(TestCase):
         split = tf.strings.split(inputs)
         augmenter = RandomSwap(rate=0.7, max_swaps=3, seed=42)
         augmented = augmenter(split)
-        output = tf.strings.reduce_join(augmented, separator=" ", axis=-1)
-        self.assertAllEqual(output.shape, tf.convert_to_tensor(inputs).shape)
-        exp_output = [b"like I Hey", b"Tensorflow Keras and"]
+        output = [
+            tf.strings.reduce_join(x, separator=" ", axis=-1) for x in augmented
+        ]
+        exp_output = ["like I Hey", "Tensorflow Keras and"]
         self.assertAllEqual(output, exp_output)
 
     def test_shape_and_output_from_character_swap(self):
@@ -38,9 +39,8 @@ class RandomSwapTest(TestCase):
         split = tf.strings.unicode_split(inputs, "UTF-8")
         augmenter = RandomSwap(rate=0.7, max_swaps=6, seed=42)
         augmented = augmenter(split)
-        output = tf.strings.reduce_join(augmented, axis=-1)
-        self.assertAllEqual(output.shape, tf.convert_to_tensor(inputs).shape)
-        exp_output = [b"yli I eHke", b"seaad rnK Tensolrfow"]
+        output = [tf.strings.reduce_join(x, axis=-1) for x in augmented]
+        exp_output = ["yli I eHke", "seaad rnK Tensolrfow"]
         self.assertAllEqual(output, exp_output)
 
     def test_with_integer_tokens(self):
@@ -48,9 +48,6 @@ class RandomSwapTest(TestCase):
         inputs = tf.constant([[1, 2, 3], [4, 5, 6]])
         augmenter = RandomSwap(rate=0.7, max_swaps=6, seed=42)
         output = augmenter(inputs)
-        self.assertAllEqual(
-            output.to_tensor().shape, tf.convert_to_tensor(inputs).shape
-        )
         exp_output = [[3, 2, 1], [6, 4, 5]]
         self.assertAllEqual(output, exp_output)
 
@@ -63,8 +60,7 @@ class RandomSwapTest(TestCase):
         split = tf.strings.split(inputs)
         augmented = augmenter(split)
         output = tf.strings.reduce_join(augmented, separator=" ", axis=-1)
-        self.assertAllEqual(output.shape, tf.convert_to_tensor(inputs).shape)
-        exp_output = [b"I Hey like", b"Keras and Tensorflow"]
+        exp_output = ["I Hey like", "Keras and Tensorflow"]
         self.assertAllEqual(output, exp_output)
 
         def skip_fn(word):
@@ -75,8 +71,7 @@ class RandomSwapTest(TestCase):
         augmenter = RandomSwap(rate=0.9, max_swaps=3, seed=11, skip_fn=skip_fn)
         augmented = augmenter(split)
         output = tf.strings.reduce_join(augmented, separator=" ", axis=-1)
-        self.assertAllEqual(output.shape, tf.convert_to_tensor(inputs).shape)
-        exp_output = [b"I Hey like", b"Keras and Tensorflow"]
+        exp_output = ["I Hey like", "Keras and Tensorflow"]
         self.assertAllEqual(output, exp_output)
 
         def skip_py_fn(word):
@@ -89,8 +84,7 @@ class RandomSwapTest(TestCase):
         )
         augmented = augmenter(split)
         output = tf.strings.reduce_join(augmented, separator=" ", axis=-1)
-        self.assertAllEqual(output.shape, tf.convert_to_tensor(inputs).shape)
-        exp_output = [b"I Hey like", b"Keras and Tensorflow"]
+        exp_output = ["I Hey like", "Keras and Tensorflow"]
         self.assertAllEqual(output, exp_output)
 
     def test_get_config_and_from_config(self):
@@ -121,8 +115,8 @@ class RandomSwapTest(TestCase):
         ds = ds.apply(tf.data.experimental.dense_to_ragged_batch(2))
         output = ds.take(1).get_single_element()
         exp_output = [
-            [b"like", b"I", b"Hey"],
-            [b"and", b"Tensorflow", b"Keras"],
+            ["like", "I", "Hey"],
+            ["and", "Tensorflow", "Keras"],
         ]
         self.assertAllEqual(output, exp_output)
 
@@ -139,8 +133,8 @@ class RandomSwapTest(TestCase):
         ds = ds.apply(tf.data.experimental.dense_to_ragged_batch(2))
         output = ds.take(1).get_single_element()
         exp_output = [
-            [b"like", b"I", b"Hey"],
-            [b"Keras", b"and", b"Tensorflow"],
+            ["like", "I", "Hey"],
+            ["Keras", "and", "Tensorflow"],
         ]
         self.assertAllEqual(output, exp_output)
 
@@ -152,8 +146,8 @@ class RandomSwapTest(TestCase):
         ds = ds.apply(tf.data.experimental.dense_to_ragged_batch(2))
         output = ds.take(1).get_single_element()
         exp_output = [
-            [b"Hey", b"I", b"like"],
-            [b"Tensorflow", b"Keras", b"and"],
+            ["Hey", "I", "like"],
+            ["Tensorflow", "Keras", "and"],
         ]
         self.assertAllEqual(output, exp_output)
 
@@ -166,8 +160,8 @@ class RandomSwapTest(TestCase):
         ds = ds.batch(2).map(augmenter)
         output = ds.take(1).get_single_element()
         exp_output = [
-            [b"like", b"I", b"Hey"],
-            [b"Tensorflow", b"Keras", b"and"],
+            ["like", "I", "Hey"],
+            ["Tensorflow", "Keras", "and"],
         ]
         self.assertAllEqual(output, exp_output)
 
@@ -183,8 +177,8 @@ class RandomSwapTest(TestCase):
         ds = ds.batch(2).map(augmenter)
         output = ds.take(1).get_single_element()
         exp_output = [
-            [b"Hey", b"I", b"like"],
-            [b"and", b"Keras", b"Tensorflow"],
+            ["Hey", "I", "like"],
+            ["and", "Keras", "Tensorflow"],
         ]
         self.assertAllEqual(output, exp_output)
 
@@ -195,21 +189,7 @@ class RandomSwapTest(TestCase):
         ds = ds.batch(2).map(augmenter)
         output = ds.take(1).get_single_element()
         exp_output = [
-            [b"Hey", b"I", b"like"],
-            [b"and", b"Keras", b"Tensorflow"],
+            ["Hey", "I", "like"],
+            ["and", "Keras", "Tensorflow"],
         ]
         self.assertAllEqual(output, exp_output)
-
-    def test_functional_model(self):
-        keras.utils.set_random_seed(1337)
-        input_data = tf.constant(["Hey I like", "Keras and Tensorflow"])
-        augmenter = RandomSwap(rate=0.7, max_swaps=2, seed=42)
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = augmenter(tf.strings.split(inputs))
-        model = keras.Model(inputs, outputs)
-        model_output = model(input_data)
-        exp_output = [
-            [b"like", b"I", b"Hey"],
-            [b"Tensorflow", b"Keras", b"and"],
-        ]
-        self.assertAllEqual(model_output, exp_output)

--- a/keras_nlp/layers/preprocessing/start_end_packer.py
+++ b/keras_nlp/layers/preprocessing/start_end_packer.py
@@ -12,16 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Start End Packer implementation based on `keras.layers.Layer`."""
-
 import tensorflow as tf
 
 from keras_nlp.api_export import keras_nlp_export
-from keras_nlp.backend import keras
+from keras_nlp.layers.preprocessing.preprocessing_layer import (
+    PreprocessingLayer,
+)
+from keras_nlp.utils.tensor_utils import convert_to_ragged_batch
 
 
 @keras_nlp_export("keras_nlp.layers.StartEndPacker")
-class StartEndPacker(keras.layers.Layer):
+class StartEndPacker(PreprocessingLayer):
     """Adds start and end tokens to a sequence and pads to a fixed length.
 
     This layer is useful when tokenizing inputs for tasks like translation,
@@ -29,8 +30,10 @@ class StartEndPacker(keras.layers.Layer):
     be called after tokenization. The layer will first trim inputs to fit, then
     add start/end tokens, and finally pad, if necessary, to `sequence_length`.
 
-    Input should be either a `tf.RaggedTensor` or a dense `tf.Tensor`, and
-    either rank-1 or rank-2.
+    Input data should be passed as tensors or `tf.RaggedTensor` or lists. For
+    batched input, inputs should be a list of lists or a rank two tensor. For
+    unbatched inputs, each element should be a list or a rank one tensor.
+
 
     Args:
         sequence_length: int. The desired output length.
@@ -60,57 +63,55 @@ class StartEndPacker(keras.layers.Layer):
     Examples:
 
     Unbatched input (int).
-    >>> input_data = tf.constant([5, 6, 7])
+    >>> inputs = [5, 6, 7]
     >>> start_end_packer = keras_nlp.layers.StartEndPacker(
     ...     sequence_length=7, start_value=1, end_value=2,
     ... )
-    >>> start_end_packer(input_data)
-    <tf.Tensor: shape=(7,), dtype=int32, numpy=
-    array([1, 5, 6, 7, 2, 0, 0], dtype=int32)>
+    >>> outputs = start_end_packer(inputs)
+    >>> np.array(outputs)
+    array([1, 5, 6, 7, 2, 0, 0], dtype=int32)
 
     Batched input (int).
-    >>> input_data = tf.ragged.constant([[5, 6, 7], [8, 9, 10, 11, 12, 13, 14]])
+    >>> inputs = [[5, 6, 7], [8, 9, 10, 11, 12, 13, 14]]
     >>> start_end_packer = keras_nlp.layers.StartEndPacker(
     ...     sequence_length=6, start_value=1, end_value=2,
     ... )
-    >>> start_end_packer(input_data)
-    <tf.Tensor: shape=(2, 6), dtype=int32, numpy=
+    >>> outputs = start_end_packer(inputs)
+    >>> np.array(outputs)
     array([[ 1,  5,  6,  7,  2,  0],
-           [ 1,  8,  9, 10, 11,  2]], dtype=int32)>
+           [ 1,  8,  9, 10, 11,  2]], dtype=int32)
 
     Unbatched input (str).
-    >>> input_data = tf.constant(["this", "is", "fun"])
+    >>> inputs = tf.constant(["this", "is", "fun"])
     >>> start_end_packer = keras_nlp.layers.StartEndPacker(
     ...     sequence_length=6, start_value="<s>", end_value="</s>",
     ...     pad_value="<pad>"
     ... )
-    >>> start_end_packer(input_data)
-    <tf.Tensor: shape=(6,), dtype=string, numpy=
-    array([b'<s>', b'this', b'is', b'fun', b'</s>', b'<pad>'], dtype=object)>
+    >>> outputs = start_end_packer(inputs)
+    >>> np.array(outputs).astype("U")
+    array(['<s>', 'this', 'is', 'fun', '</s>', '<pad>'], dtype='<U5')
 
     Batched input (str).
-    >>> input_data = tf.ragged.constant([["this", "is", "fun"], ["awesome"]])
+    >>> inputs = tf.ragged.constant([["this", "is", "fun"], ["awesome"]])
     >>> start_end_packer = keras_nlp.layers.StartEndPacker(
     ...     sequence_length=6, start_value="<s>", end_value="</s>",
     ...     pad_value="<pad>"
     ... )
-    >>> start_end_packer(input_data)
-    <tf.Tensor: shape=(2, 6), dtype=string, numpy=
-    array([[b'<s>', b'this', b'is', b'fun', b'</s>', b'<pad>'],
-           [b'<s>', b'awesome', b'</s>', b'<pad>', b'<pad>', b'<pad>']],
-          dtype=object)>
+    >>> outputs = start_end_packer(inputs)
+    >>> np.array(outputs).astype("U")
+    array([['<s>', 'this', 'is', 'fun', '</s>', '<pad>'],
+           ['<s>', 'awesome', '</s>', '<pad>', '<pad>', '<pad>']], dtype='<U7')
 
     Multiple start tokens.
-    >>> input_data = tf.ragged.constant([["this", "is", "fun"], ["awesome"]])
+    >>> inputs = tf.ragged.constant([["this", "is", "fun"], ["awesome"]])
     >>> start_end_packer = keras_nlp.layers.StartEndPacker(
     ...     sequence_length=6, start_value=["</s>", "<s>"], end_value="</s>",
     ...     pad_value="<pad>"
     ... )
-    >>> start_end_packer(input_data)
-    <tf.Tensor: shape=(2, 6), dtype=string, numpy=
-    array([[b'</s>', b'<s>', b'this', b'is', b'fun', b'</s>'],
-        [b'</s>', b'<s>', b'awesome', b'</s>', b'<pad>', b'<pad>']],
-        dtype=object)>
+    >>> outputs = start_end_packer(inputs)
+    >>> np.array(outputs).astype("U")
+    array([['</s>', '<s>', 'this', 'is', 'fun', '</s>'],
+           ['</s>', '<s>', 'awesome', '</s>', '<pad>', '<pad>']], dtype='<U7')
     """
 
     def __init__(
@@ -157,28 +158,13 @@ class StartEndPacker(keras.layers.Layer):
         add_start_value=True,
         add_end_value=True,
     ):
+        inputs, unbatched, _ = convert_to_ragged_batch(inputs)
+
         x = inputs  # Intermediate result.
-
-        if not isinstance(x, (tf.Tensor, tf.RaggedTensor)):
-            x = tf.convert_to_tensor(x)
-
-        dtype = x.dtype
-
-        input_is_1d = x.shape.rank == 1
-        if x.shape.rank < 1 or x.shape.rank > 2:
-            raise ValueError(
-                "Input must either be rank 1 or rank 2. Received input with "
-                f"rank={x.shape.rank}"
-            )
-        if input_is_1d:
-            # Add a new axis at the beginning.
-            x = tf.expand_dims(x, axis=0)
-        if isinstance(x, tf.Tensor):
-            # Convert to ragged tensor.
-            x = tf.RaggedTensor.from_tensor(x)
 
         batch_size = tf.shape(x)[0]
         sequence_length = sequence_length or self.sequence_length
+        dtype = inputs.dtype
 
         # Concatenate start and end tokens.
         if add_start_value and self.start_value is not None:
@@ -201,12 +187,12 @@ class StartEndPacker(keras.layers.Layer):
             default_value=self.pad_value,
             shape=(batch_size, sequence_length),
         )
-        outputs = tf.squeeze(outputs, axis=0) if input_is_1d else outputs
+        outputs = tf.squeeze(outputs, axis=0) if unbatched else outputs
 
         if self.return_padding_mask:
             mask = tf.ones_like(x, dtype="bool")
             mask = mask.to_tensor(shape=(batch_size, sequence_length))
-            mask = tf.squeeze(mask, axis=0) if input_is_1d else mask
+            mask = tf.squeeze(mask, axis=0) if unbatched else mask
             return outputs, mask
 
         return outputs
@@ -223,3 +209,8 @@ class StartEndPacker(keras.layers.Layer):
             }
         )
         return config
+
+    def compute_output_shape(self, inputs_shape):
+        inputs_shape = list(inputs_shape)
+        inputs_shape[-1] = self.sequence_length
+        return tuple(inputs_shape)

--- a/keras_nlp/layers/preprocessing/start_end_packer.py
+++ b/keras_nlp/layers/preprocessing/start_end_packer.py
@@ -30,10 +30,9 @@ class StartEndPacker(PreprocessingLayer):
     be called after tokenization. The layer will first trim inputs to fit, then
     add start/end tokens, and finally pad, if necessary, to `sequence_length`.
 
-    Input data should be passed as tensors or `tf.RaggedTensor` or lists. For
+    Input data should be passed as tensors, `tf.RaggedTensor`s, or lists. For
     batched input, inputs should be a list of lists or a rank two tensor. For
     unbatched inputs, each element should be a list or a rank one tensor.
-
 
     Args:
         sequence_length: int. The desired output length.

--- a/keras_nlp/layers/preprocessing/start_end_packer_test.py
+++ b/keras_nlp/layers/preprocessing/start_end_packer_test.py
@@ -13,47 +13,38 @@
 # limitations under the License.
 
 """Tests for Start End Packer layer."""
+
+
 import tensorflow as tf
 
-from keras_nlp.backend import keras
 from keras_nlp.layers.preprocessing.start_end_packer import StartEndPacker
 from keras_nlp.tests.test_case import TestCase
 
 
 class StartEndPackerTest(TestCase):
     def test_dense_input(self):
-        input_data = tf.constant([5, 6, 7])
+        input_data = [5, 6, 7]
         start_end_packer = StartEndPacker(sequence_length=5)
         output = start_end_packer(input_data)
         expected_output = [5, 6, 7, 0, 0]
         self.assertAllEqual(output, expected_output)
 
     def test_dense_2D_input(self):
-        input_data = tf.constant([[5, 6, 7]])
+        input_data = [[5, 6, 7]]
         start_end_packer = StartEndPacker(sequence_length=5)
         output = start_end_packer(input_data)
         expected_output = [[5, 6, 7, 0, 0]]
         self.assertAllEqual(output, expected_output)
 
     def test_ragged_input(self):
-        input_data = tf.ragged.constant([[5, 6, 7], [8, 9, 10, 11]])
+        input_data = [[5, 6, 7], [8, 9, 10, 11]]
         start_end_packer = StartEndPacker(sequence_length=5)
         output = start_end_packer(input_data)
         expected_output = [[5, 6, 7, 0, 0], [8, 9, 10, 11, 0]]
         self.assertAllEqual(output, expected_output)
 
-    def test_ragged_input_error(self):
-        input_data = tf.ragged.constant([[[5, 6, 7], [8, 9, 10, 11]]])
-        start_end_packer = StartEndPacker(sequence_length=5)
-        with self.assertRaisesRegex(
-            ValueError,
-            "Input must either be rank 1 or rank 2. Received input with "
-            "rank=3",
-        ):
-            start_end_packer(input_data)
-
     def test_start_end_token(self):
-        input_data = tf.ragged.constant([[5, 6, 7], [8, 9, 10, 11]])
+        input_data = [[5, 6, 7], [8, 9, 10, 11]]
         start_end_packer = StartEndPacker(
             sequence_length=6, start_value=1, end_value=2
         )
@@ -62,7 +53,7 @@ class StartEndPackerTest(TestCase):
         self.assertAllEqual(output, expected_output)
 
     def test_multiple_start_end_tokens(self):
-        input_data = tf.ragged.constant([[5, 6, 7], [8, 9, 10, 11, 12, 13]])
+        input_data = [[5, 6, 7], [8, 9, 10, 11, 12, 13]]
         start_end_packer = StartEndPacker(
             sequence_length=8,
             start_value=[1, 2],
@@ -74,7 +65,7 @@ class StartEndPackerTest(TestCase):
         self.assertAllEqual(output, expected_output)
 
     def test_start_end_padding_value(self):
-        input_data = tf.ragged.constant([[5, 6, 7], [8, 9, 10, 11]])
+        input_data = [[5, 6, 7], [8, 9, 10, 11]]
         start_end_packer = StartEndPacker(
             sequence_length=7, start_value=1, end_value=2, pad_value=3
         )
@@ -83,7 +74,7 @@ class StartEndPackerTest(TestCase):
         self.assertAllEqual(output, expected_output)
 
     def test_end_token_value_during_truncation(self):
-        input_data = tf.ragged.constant([[5, 6], [8, 9, 10, 11, 12, 13]])
+        input_data = [[5, 6], [8, 9, 10, 11, 12, 13]]
         start_end_packer = StartEndPacker(
             sequence_length=5, start_value=1, end_value=2, pad_value=0
         )
@@ -92,9 +83,7 @@ class StartEndPackerTest(TestCase):
         self.assertAllEqual(output, expected_output)
 
     def test_string_input(self):
-        input_data = tf.ragged.constant(
-            [["KerasNLP", "is", "awesome"], ["amazing"]]
-        )
+        input_data = [["KerasNLP", "is", "awesome"], ["amazing"]]
         start_end_packer = StartEndPacker(
             sequence_length=5,
             start_value="[START]",
@@ -109,9 +98,7 @@ class StartEndPackerTest(TestCase):
         self.assertAllEqual(output, expected_output)
 
     def test_string_input_with_multiple_special_values(self):
-        input_data = tf.ragged.constant(
-            [["KerasNLP", "is", "awesome"], ["amazing"]]
-        )
+        input_data = [["KerasNLP", "is", "awesome"], ["amazing"]]
         start_end_packer = StartEndPacker(
             sequence_length=6,
             start_value=["[END]", "[START]"],
@@ -129,20 +116,6 @@ class StartEndPackerTest(TestCase):
         with self.assertRaises(ValueError):
             StartEndPacker(sequence_length=5, start_value=1.0)
 
-    def test_functional_model(self):
-        input_data = tf.ragged.constant([[5, 6, 7], [8, 9, 10, 11]])
-        start_end_packer = StartEndPacker(
-            sequence_length=7, start_value=1, end_value=2, pad_value=3
-        )
-
-        inputs = keras.Input(dtype="int32", shape=())
-        outputs = start_end_packer(inputs)
-        model = keras.Model(inputs, outputs)
-        model_output = model(input_data)
-
-        expected_output = [[1, 5, 6, 7, 2, 3, 3], [1, 8, 9, 10, 11, 2, 3]]
-        self.assertAllEqual(model_output, expected_output)
-
     def test_batch(self):
         start_end_packer = StartEndPacker(
             sequence_length=7, start_value=1, end_value=2, pad_value=3
@@ -155,12 +128,10 @@ class StartEndPackerTest(TestCase):
         output = ds.take(1).get_single_element()
 
         exp_output = [[1, 5, 6, 7, 2, 3, 3], [1, 8, 9, 10, 11, 2, 3]]
-
-        for i in range(output.shape[0]):
-            self.assertAllEqual(output[i], exp_output[i])
+        self.assertAllEqual(output, exp_output)
 
     def test_call_overrides(self):
-        x = tf.constant([5, 6, 7])
+        x = [5, 6, 7]
         packer = StartEndPacker(start_value=1, end_value=2, sequence_length=4)
         self.assertAllEqual(packer(x), [1, 5, 6, 2])
         self.assertAllEqual(packer(x, add_start_value=False), [5, 6, 7, 2])

--- a/keras_nlp/metrics/rouge_base.py
+++ b/keras_nlp/metrics/rouge_base.py
@@ -21,7 +21,7 @@ import tensorflow as tf
 
 from keras_nlp.backend import keras
 from keras_nlp.utils.tensor_utils import is_floating_dtype
-from keras_nlp.utils.tensor_utils import tensor_to_string_list
+from keras_nlp.utils.tensor_utils import tensor_to_list
 
 try:
     from rouge_score import rouge_scorer
@@ -174,8 +174,8 @@ class RougeBase(keras.metrics.Metric):
         batch_size = tf.shape(y_true)[0]
 
         def calculate_rouge_score(reference, hypothesis):
-            reference = tensor_to_string_list(reference)
-            hypothesis = tensor_to_string_list(hypothesis)
+            reference = tensor_to_list(reference)
+            hypothesis = tensor_to_list(hypothesis)
             score = self._rouge_scorer.score(reference, hypothesis)[
                 self.variant
             ]

--- a/keras_nlp/models/generative_task.py
+++ b/keras_nlp/models/generative_task.py
@@ -18,7 +18,7 @@ import tensorflow as tf
 from keras_nlp.backend import keras
 from keras_nlp.models.task import Task
 from keras_nlp.samplers.serialization import get as get_sampler
-from keras_nlp.utils.tensor_utils import tensor_to_string_list
+from keras_nlp.utils.tensor_utils import tensor_to_list
 
 
 @keras.saving.register_keras_serializable(package="keras_nlp")
@@ -120,7 +120,7 @@ class GenerativeTask(Task):
             is_string = x.dtype == tf.string
             # Convert outputs to a friendly pythonic type. For numerical outputs
             # that is numpy, for string outputs that is `list` and `str`.
-            return tensor_to_string_list(x) if is_string else x.numpy()
+            return tensor_to_list(x) if is_string else x.numpy()
 
         if isinstance(outputs[0], dict):
             normalized = {}

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_tokenizer.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_tokenizer.py
@@ -22,7 +22,7 @@ from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.models.xlm_roberta.xlm_roberta_presets import backbone_presets
 from keras_nlp.tokenizers.sentence_piece_tokenizer import SentencePieceTokenizer
 from keras_nlp.utils.python_utils import classproperty
-from keras_nlp.utils.tensor_utils import tensor_to_string_list
+from keras_nlp.utils.tensor_utils import tensor_to_list
 
 
 @keras_nlp_export("keras_nlp.models.XLMRobertaTokenizer")
@@ -108,7 +108,7 @@ class XLMRobertaTokenizer(SentencePieceTokenizer):
 
     def get_vocabulary(self):
         """Get the size of the tokenizer vocabulary."""
-        vocabulary = tensor_to_string_list(
+        vocabulary = tensor_to_list(
             self._sentence_piece.id_to_string(
                 tf.range(super().vocabulary_size())
             )
@@ -130,7 +130,7 @@ class XLMRobertaTokenizer(SentencePieceTokenizer):
                 f"Received: {id}"
             )
 
-        return tensor_to_string_list(self._sentence_piece.id_to_string(id - 1))
+        return tensor_to_list(self._sentence_piece.id_to_string(id - 1))
 
     def token_to_id(self, token):
         """Convert a string token to an integer id."""

--- a/keras_nlp/tests/test_case.py
+++ b/keras_nlp/tests/test_case.py
@@ -32,3 +32,22 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         x1 = tf.nest.map_structure(convert_to_numpy, x1)
         x2 = tf.nest.map_structure(convert_to_numpy, x2)
         super().assertAllClose(x1, x2, atol=atol, rtol=rtol, msg=msg)
+
+    def assertAllEqual(self, x1, x2, msg=None):
+        def convert_strings(x):
+            """Convert any string tensors to simple python types.
+
+            This allows for simple output comparisons across backend without
+            needing to worry about tensorflow's bytes representation.
+            """
+            if hasattr(x, "dtype") and x.dtype == tf.string:
+                if isinstance(x, tf.RaggedTensor):
+                    x = x.to_list()
+                if isinstance(x, tf.Tensor):
+                    x = x.numpy() if x.shape.rank == 0 else x.numpy().tolist()
+                return tf.nest.map_structure(lambda x: x.decode("utf-8"), x)
+            return x
+
+        x1 = tf.nest.map_structure(convert_strings, x1)
+        x2 = tf.nest.map_structure(convert_strings, x2)
+        super().assertAllEqual(x1, x2, msg=msg)

--- a/keras_nlp/tests/test_case.py
+++ b/keras_nlp/tests/test_case.py
@@ -37,10 +37,10 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         def convert_strings(x):
             """Convert any string tensors to simple python types.
 
-            This allows for simple output comparisons across backend without
+            This allows for simple output comparisons across backends without
             needing to worry about tensorflow's bytes representation.
             """
-            if hasattr(x, "dtype") and x.dtype == tf.string:
+            if getattr(x, "dtype", None) == tf.string:
                 if isinstance(x, tf.RaggedTensor):
                     x = x.to_list()
                 if isinstance(x, tf.Tensor):

--- a/keras_nlp/tokenizers/byte_pair_tokenizer_test.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer_test.py
@@ -16,7 +16,6 @@ import os
 
 import pytest
 import tensorflow as tf
-from absl.testing import parameterized
 
 from keras_nlp.backend import keras
 from keras_nlp.tests.test_case import TestCase
@@ -44,7 +43,7 @@ class BytePairTokenizerTest(TestCase):
         input_data = ["brown.", "black."]
         call_output = self.tokenizer(input_data)
         tokenize_output = self.tokenizer.tokenize(input_data)
-        expected = tf.ragged.constant([[31876, 4], [14178, 4]])
+        expected = [[31876, 4], [14178, 4]]
         self.assertAllEqual(call_output, expected)
         self.assertAllEqual(tokenize_output, expected)
 
@@ -55,15 +54,13 @@ class BytePairTokenizerTest(TestCase):
     def test_tokenize_string_output(self):
         input_data = ["quick brown fox.", "slow black bear."]
         tokenizer = BytePairTokenizer(
-            vocabulary=VOCAB_PATH, merges=MERGE_PATH, dtype=tf.string
+            vocabulary=VOCAB_PATH, merges=MERGE_PATH, dtype="string"
         )
         call_output = tokenizer(input_data)
-        expected = tf.ragged.constant(
-            [
-                ["quick", "Ġbrown", "Ġfox", "."],
-                ["slow", "Ġblack", "Ġbear", "."],
-            ]
-        )
+        expected = [
+            ["quick", "Ġbrown", "Ġfox", "."],
+            ["slow", "Ġblack", "Ġbear", "."],
+        ]
         self.assertAllEqual(call_output, expected)
 
     def test_tokenize_with_special_tokens(self):
@@ -83,24 +80,19 @@ class BytePairTokenizerTest(TestCase):
             merges=merges,
         )
         output = tokenizer("sp")
-        self.assertEqual(output, [0])
+        self.assertAllEqual(output, [0])
 
     def test_tokenize_prefix_space(self):
         input_data = ["brown.", "black."]
         tokenizer = BytePairTokenizer(
             vocabulary=VOCAB_PATH,
             merges=MERGE_PATH,
-            dtype=tf.string,
+            dtype="string",
             add_prefix_space=True,
         )
         call_output = tokenizer(input_data)
 
-        expected = tf.ragged.constant(
-            [
-                ["Ġbrown", "."],
-                ["Ġblack", "."],
-            ]
-        )
+        expected = [["Ġbrown", "."], ["Ġblack", "."]]
         self.assertAllEqual(call_output, expected)
 
     def test_tokenize_scalar_input(self):
@@ -115,7 +107,7 @@ class BytePairTokenizerTest(TestCase):
         self.assertAllEqual(input_data, decoded)
 
     def test_detokenize_list_input(self):
-        input_data = ["quick brown fox.", "slow black bear."]
+        input_data = ["quick brown fox.", "slow bear"]
         encoded = self.tokenizer.tokenize(input_data)
         decoded = self.tokenizer.detokenize(encoded)
         self.assertAllEqual(input_data, decoded)
@@ -163,9 +155,10 @@ class BytePairTokenizerTest(TestCase):
         ds = tf.data.Dataset.from_tensor_slices(data)
         ds = ds.batch(2).map(self.tokenizer)
         encoded = next(iter(ds))
-        expected = tf.ragged.constant(
-            [[100, 524, 95, 10, 1296, 6755], [100, 524, 67, 10, 1296, 6755]]
-        )
+        expected = [
+            [100, 524, 95, 10, 1296, 6755],
+            [100, 524, 67, 10, 1296, 6755],
+        ]
         self.assertAllEqual(encoded, expected)
 
     def test_config(self):
@@ -178,20 +171,15 @@ class BytePairTokenizerTest(TestCase):
             cloned_tokenizer(input_data),
         )
 
-    @parameterized.named_parameters(
-        ("tf_format", "tf", "model"),
-        ("keras_format", "keras_v3", "model.keras"),
-    )
-    def test_saved_model(self, save_format, filename):
+    @pytest.mark.tf_only
+    def test_saved_model(self):
         input_data = tf.constant(["the quick brown whale."])
         tokenizer = self.tokenizer
         inputs = keras.Input(dtype="string", shape=())
         outputs = tokenizer(inputs)
         model = keras.Model(inputs, outputs)
-        path = os.path.join(self.get_temp_dir(), filename)
-        # Don't save traces in the tf format, we check compilation elsewhere.
-        kwargs = {"save_traces": False} if save_format == "tf" else {}
-        model.save(path, save_format=save_format, **kwargs)
+        path = os.path.join(self.get_temp_dir(), "model.keras")
+        model.save(path, save_format="keras_v3")
         restored_model = keras.models.load_model(path)
         self.assertAllEqual(
             model(input_data),

--- a/keras_nlp/tokenizers/tokenizer.py
+++ b/keras_nlp/tokenizers/tokenizer.py
@@ -15,11 +15,13 @@
 from typing import List
 
 from keras_nlp.api_export import keras_nlp_export
-from keras_nlp.backend import keras
+from keras_nlp.layers.preprocessing.preprocessing_layer import (
+    PreprocessingLayer,
+)
 
 
 @keras_nlp_export("keras_nlp.tokenizers.Tokenizer")
-class Tokenizer(keras.layers.Layer):
+class Tokenizer(PreprocessingLayer):
     """A base class for tokenizer layers.
 
     Tokenizers in the KerasNLP library should all subclass this layer.
@@ -60,6 +62,9 @@ class Tokenizer(keras.layers.Layer):
     tokenizer.detokenize(["This", "is", "a", "test"])
     ```
     """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def __new__(cls, *args, **kwargs):
         # Wrap the `tokenize` and `detokenize` methods so they route through

--- a/keras_nlp/tokenizers/tokenizer_test.py
+++ b/keras_nlp/tokenizers/tokenizer_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import tensorflow as tf
 
 from keras_nlp.backend import keras
@@ -44,6 +45,7 @@ class TokenizerTest(TestCase):
         detokenize_output = tokenizer.detokenize(input_data)
         self.assertAllEqual(detokenize_output, ["the quick brown fox"])
 
+    @pytest.mark.tf_only
     def test_functional_model(self):
         input_data = tf.constant(["the   quick   brown   fox"])
         tokenizer = SimpleTokenizer()

--- a/keras_nlp/tokenizers/unicode_codepoint_tokenizer_test.py
+++ b/keras_nlp/tokenizers/unicode_codepoint_tokenizer_test.py
@@ -14,8 +14,8 @@
 
 import os
 
+import pytest
 import tensorflow as tf
-from absl.testing import parameterized
 
 from keras_nlp.backend import keras
 from keras_nlp.tests.test_case import TestCase
@@ -26,19 +26,17 @@ from keras_nlp.tokenizers.unicode_codepoint_tokenizer import (
 
 class UnicodeCodepointTokenizerTest(TestCase):
     def test_tokenize(self):
-        input_data = tf.constant(["ninja", "samurai", "▀▁▂▃"])
+        input_data = ["ninja", "samurai", "▀▁▂▃"]
         tokenizer = UnicodeCodepointTokenizer()
         call_output = tokenizer(input_data)
         tokenize_output = tokenizer.tokenize(input_data)
-        self.assertIsInstance(call_output, tf.RaggedTensor)
         exp_outputs = [
             [110, 105, 110, 106, 97],
             [115, 97, 109, 117, 114, 97, 105],
             [9600, 9601, 9602, 9603],
         ]
-        for i in range(call_output.shape[0]):
-            self.assertAllEqual(call_output[i], exp_outputs[i])
-            self.assertAllEqual(tokenize_output[i], exp_outputs[i])
+        self.assertAllEqual(call_output, exp_outputs)
+        self.assertAllEqual(tokenize_output, exp_outputs)
 
     def test_tokenize_scalar(self):
         input_data = "ninja"
@@ -50,10 +48,9 @@ class UnicodeCodepointTokenizerTest(TestCase):
         self.assertAllEqual(tokenize_output, [110, 105, 110, 106, 97])
 
     def test_dense_output(self):
-        input_data = tf.constant(["ninja", "samurai", "▀▁▂▃"])
+        input_data = ["ninja", "samurai", "▀▁▂▃"]
         tokenizer = UnicodeCodepointTokenizer(sequence_length=10)
         call_output = tokenizer(input_data)
-        self.assertIsInstance(call_output, tf.Tensor)
         self.assertAllEqual(
             call_output,
             [
@@ -73,12 +70,11 @@ class UnicodeCodepointTokenizerTest(TestCase):
         self.assertAllEqual(tokenize_output, [104, 104, 104, 104, 97])
 
     def test_tokenize_dense_with_vocabulary_size(self):
-        input_data = tf.constant(["ninja", "samurai", "▀▁▂▃"])
+        input_data = ["ninja", "samurai", "▀▁▂▃"]
         tokenizer = UnicodeCodepointTokenizer(
             sequence_length=10, vocabulary_size=105
         )
         call_output = tokenizer(input_data)
-        self.assertIsInstance(call_output, tf.Tensor)
         self.assertAllEqual(
             call_output,
             [
@@ -89,28 +85,24 @@ class UnicodeCodepointTokenizerTest(TestCase):
         )
 
     def test_tokenize_ragged_with_vocabulary_size(self):
-        input_data = tf.constant(["ninja", "samurai", "▀▁▂▃"])
+        input_data = ["ninja", "samurai", "▀▁▂▃"]
         tokenizer = UnicodeCodepointTokenizer(vocabulary_size=105)
         call_output = tokenizer(input_data)
         tokenize_output = tokenizer.tokenize(input_data)
-        self.assertIsInstance(call_output, tf.RaggedTensor)
         exp_outputs = [
             [104, 104, 104, 104, 97],
             [104, 97, 104, 104, 104, 97, 104],
             [104, 104, 104, 104],
         ]
-        for i in range(call_output.shape[0]):
-            self.assertAllEqual(call_output[i], exp_outputs[i])
-            self.assertAllEqual(tokenize_output[i], exp_outputs[i])
+        self.assertAllEqual(call_output, exp_outputs)
+        self.assertAllEqual(tokenize_output, exp_outputs)
 
     def test_detokenize(self):
-        input_data = tf.ragged.constant(
-            [
-                [110, 105, 110, 106, 97],
-                [115, 97, 109, 117, 114, 97, 105],
-                [9600, 9601, 9602, 9603],
-            ]
-        )
+        input_data = [
+            [110, 105, 110, 106, 97],
+            [115, 97, 109, 117, 114, 97, 105],
+            [9600, 9601, 9602, 9603],
+        ]
 
         tokenizer = UnicodeCodepointTokenizer()
         detokenize_output = tokenizer.detokenize(input_data)
@@ -187,8 +179,7 @@ class UnicodeCodepointTokenizerTest(TestCase):
             [107, 101, 114, 97, 115],
             [116, 101, 110, 115, 111, 114, 102, 108, 111, 119],
         ]
-        for i in range(output.shape[0]):
-            self.assertAllEqual(output[i], exp_output[i])
+        self.assertAllEqual(output, exp_output)
 
     def test_tokenize_first_batch_second_with_sequence_length(self):
         tokenizer = UnicodeCodepointTokenizer(sequence_length=10)
@@ -207,8 +198,7 @@ class UnicodeCodepointTokenizerTest(TestCase):
             [107, 101, 114, 97, 115, 0, 0, 0, 0, 0],
             [116, 101, 110, 115, 111, 114, 102, 108, 111, 119],
         ]
-        for i in range(output.shape[0]):
-            self.assertAllEqual(output[i], exp_output[i])
+        self.assertAllEqual(output, exp_output)
 
     def test_batch_first_tokenize_second(self):
         tokenizer = UnicodeCodepointTokenizer()
@@ -226,8 +216,7 @@ class UnicodeCodepointTokenizerTest(TestCase):
             [107, 101, 114, 97, 115],
             [116, 101, 110, 115, 111, 114, 102, 108, 111, 119],
         ]
-        for i in range(output.shape[0]):
-            self.assertAllEqual(output[i], exp_output[i])
+        self.assertAllEqual(output, exp_output)
 
     def test_batch_first_tokenize_second_with_sequence_length(self):
         tokenizer = UnicodeCodepointTokenizer(sequence_length=10)
@@ -245,9 +234,9 @@ class UnicodeCodepointTokenizerTest(TestCase):
             [107, 101, 114, 97, 115, 0, 0, 0, 0, 0],
             [116, 101, 110, 115, 111, 114, 102, 108, 111, 119],
         ]
-        for i in range(output.shape[0]):
-            self.assertAllEqual(output[i], exp_output[i])
+        self.assertAllEqual(output, exp_output)
 
+    @pytest.mark.tf_only
     def test_functional_model(self):
         input_data = tf.constant(
             ["ninja", "samurai", "▀▁▂▃", "keras", "tensorflow"]
@@ -345,11 +334,8 @@ class UnicodeCodepointTokenizerTest(TestCase):
             exp_config_different_encoding,
         )
 
-    @parameterized.named_parameters(
-        ("tf_format", "tf", "model"),
-        ("keras_format", "keras_v3", "model.keras"),
-    )
-    def test_saved_model(self, save_format, filename):
+    @pytest.mark.tf_only
+    def test_saved_model(self):
         input_data = tf.constant(["ninjas and samurais", "time travel"])
 
         tokenizer = UnicodeCodepointTokenizer(
@@ -363,10 +349,8 @@ class UnicodeCodepointTokenizerTest(TestCase):
         inputs = keras.Input(dtype="string", shape=())
         outputs = tokenizer(inputs)
         model = keras.Model(inputs, outputs)
-        path = os.path.join(self.get_temp_dir(), filename)
-        # Don't save traces in the tf format, we check compilation elsewhere.
-        kwargs = {"save_traces": False} if save_format == "tf" else {}
-        model.save(path, save_format=save_format, **kwargs)
+        path = os.path.join(self.get_temp_dir(), "model.keras")
+        model.save(path, save_format="keras_v3")
         restored_model = keras.models.load_model(path)
         self.assertAllEqual(
             model(input_data),

--- a/keras_nlp/tokenizers/word_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer.py
@@ -24,6 +24,7 @@ from keras_nlp.tokenizers import tokenizer
 from keras_nlp.utils.python_utils import classproperty
 from keras_nlp.utils.python_utils import format_docstring
 from keras_nlp.utils.tensor_utils import assert_tf_text_installed
+from keras_nlp.utils.tensor_utils import convert_to_ragged_batch
 from keras_nlp.utils.tensor_utils import is_integer_dtype
 from keras_nlp.utils.tensor_utils import is_string_dtype
 
@@ -230,13 +231,14 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
 
     Ragged outputs.
     >>> vocab = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox", "."]
-    >>> inputs = ["The quick brown fox."]
+    >>> inputs = "The quick brown fox."
     >>> tokenizer = keras_nlp.tokenizers.WordPieceTokenizer(
     ...     vocabulary=vocab,
     ...     lowercase=True,
     ... )
-    >>> tokenizer(inputs)
-    <tf.RaggedTensor [[1, 2, 3, 4, 5, 6, 7]]>
+    >>> outputs = tokenizer(inputs)
+    >>> np.array(outputs)
+    array([1, 2, 3, 4, 5, 6, 7], dtype=int32)
 
     Dense outputs.
     >>> vocab = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox", "."]
@@ -246,20 +248,21 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
     ...     sequence_length=10,
     ...     lowercase=True,
     ... )
-    >>> tokenizer(inputs)
-    <tf.Tensor: shape=(1, 10), dtype=int32, numpy=
-    array([[1, 2, 3, 4, 5, 6, 7, 0, 0, 0]], dtype=int32)>
+    >>> outputs = tokenizer(inputs)
+    >>> np.array(outputs)
+    array([[1, 2, 3, 4, 5, 6, 7, 0, 0, 0]], dtype=int32)
 
     String output.
     >>> vocab = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox", "."]
-    >>> inputs = ["The quick brown fox."]
+    >>> inputs = "The quick brown fox."
     >>> tokenizer = keras_nlp.tokenizers.WordPieceTokenizer(
     ...     vocabulary=vocab,
     ...     lowercase=True,
     ...     dtype="string",
     ... )
-    >>> tokenizer(inputs)
-    <tf.RaggedTensor [[b'the', b'qu', b'##ick', b'br', b'##own', b'fox', b'.']]>
+    >>> outputs = tokenizer(inputs)
+    >>> np.array(outputs).astype("U")
+    array(['the', 'qu', '##ick', 'br', '##own', 'fox', '.'], dtype='<U5')
 
     Detokenization.
     >>> vocab = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox", "."]
@@ -268,8 +271,9 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
     ...     vocabulary=vocab,
     ...     lowercase=True,
     ... )
-    >>> tokenizer.detokenize(tokenizer.tokenize(inputs)).numpy().decode('utf-8')
-    'the quick brown fox .'
+    >>> outputs = tokenizer.detokenize(tokenizer.tokenize(inputs))
+    >>> np.array(outputs).astype("U")
+    array('the quick brown fox .', dtype='<U21')
 
     Custom splitting.
     >>> vocab = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox", "."]
@@ -424,7 +428,11 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
         return tokens
 
     def detokenize(self, inputs):
-        return self._fast_word_piece.detokenize(inputs)
+        inputs, unbatched, _ = convert_to_ragged_batch(inputs)
+        outputs = self._fast_word_piece.detokenize(inputs)
+        if unbatched:
+            outputs = tf.squeeze(outputs, 0)
+        return outputs
 
     @classproperty
     def presets(cls):

--- a/keras_nlp/utils/tensor_utils.py
+++ b/keras_nlp/utils/tensor_utils.py
@@ -15,6 +15,7 @@
 import tensorflow as tf
 
 from keras_nlp.backend import config
+from keras_nlp.backend import ops
 
 try:
     import tensorflow_text as tf_text
@@ -46,20 +47,75 @@ def tensor_to_list(inputs):
         list_outputs = inputs.numpy()
         if inputs.shape.rank != 0:
             list_outputs = list_outputs.tolist()
+    if inputs.dtype == tf.string:
+        list_outputs = _decode_strings_to_utf8(list_outputs)
     return list_outputs
 
 
-def tensor_to_string_list(inputs):
-    """Detokenize and convert tensor to nested lists of python strings.
+def convert_to_backend_tensor_or_python_list(x):
+    """
+    Convert a tensor to the backend friendly representation of the data.
 
-    This is a convenience method which converts each byte string to a python
-    string.
+    This wraps `ops.convert_to_tensor` to account for the fact that torch and
+    jax both lack native types for ragged and string data.
+
+    If we encounter one of these types in torch or jax, we will instead covert
+    the tensor to simple pythonic types (lists of strings).
+    """
+    if isinstance(x, tf.RaggedTensor) or x.dtype == tf.string:
+        return tensor_to_list(x)
+    return ops.convert_to_tensor(x)
+
+
+def convert_to_ragged_batch(inputs):
+    """Convert pythonic or numpy-like input to a 2-D tf.RaggedTensor.
+
+    This is useful for text preprocessing layers which deal with already
+    tokenized or split text.
 
     Args:
-        inputs: Input tensor, or dict/list/tuple of input tensors.
+        inputs: A numpy-like input passed to a layer's call method. This input
+            should represent a possibly batched list of token sequences.
+
+    Returns:
+        An `(inputs, unbatched, rectangular)` tuple, where `inputs` is a
+        2-D `tf.RaggedTensor`, `unbatched` is `True` if the inputs were
+        origianlly rank 1, and `rectangular` is `True` if the inputs rows are
+        all of equal lengths.
     """
-    list_outputs = tensor_to_list(inputs)
-    return _decode_strings_to_utf8(list_outputs)
+    rectangular = True
+    # `tf.keras.layers.Layer` does a weird conversion in __call__, where a list
+    # of lists of ints will become a list of list of scalar tensors. We could
+    # clean this up if we no longer need to care about that case.
+    if isinstance(inputs, (list, tuple)):
+        if isinstance(inputs[0], (list, tuple)):
+            rectangular = len(set([len(row) for row in inputs])) == 1
+            rows = [tf.convert_to_tensor(row) for row in inputs]
+            inputs = tf.ragged.stack(rows).with_row_splits_dtype("int64")
+        else:
+            inputs = tf.convert_to_tensor(inputs)
+    elif isinstance(inputs, tf.RaggedTensor):
+        rectangular = False
+    elif hasattr(inputs, "__array__"):
+        inputs = tf.convert_to_tensor(inputs)
+    elif not isinstance(inputs, tf.RaggedTensor):
+        raise ValueError(
+            f"Unknown tensor type. Tensor input can be passed as "
+            "tensors, numpy arrays, or python lists. Received: "
+            f"`type(inputs)={type(inputs)}`"
+        )
+    if inputs.shape.rank < 1 or inputs.shape.rank > 2:
+        raise ValueError(
+            f"Tokenized tensor input should be rank 1 (unbatched) or "
+            f"rank 2 (batched). Received: `inputs.shape={input.shape}`"
+        )
+    unbatched = inputs.shape.rank == 1
+    rectangular = rectangular or unbatched
+    if unbatched:
+        inputs = tf.expand_dims(inputs, 0)
+    if isinstance(inputs, tf.Tensor):
+        inputs = tf.RaggedTensor.from_tensor(inputs)
+    return inputs, unbatched, rectangular
 
 
 def truncate_at_token(inputs, token, mask):

--- a/keras_nlp/utils/tensor_utils.py
+++ b/keras_nlp/utils/tensor_utils.py
@@ -68,14 +68,14 @@ def convert_to_backend_tensor_or_python_list(x):
 
 
 def convert_to_ragged_batch(inputs):
-    """Convert pythonic or numpy-like input to a 2-D tf.RaggedTensor.
+    """Convert pythonic or numpy-like input to a 2-D `tf.RaggedTensor`.
 
     This is useful for text preprocessing layers which deal with already
     tokenized or split text.
 
     Args:
-        inputs: A numpy-like input passed to a layer's call method. This input
-            should represent a possibly batched list of token sequences.
+        inputs: A pythonic or numpy-like input to covert. This input should
+            represent a possibly batched list of token sequences.
 
     Returns:
         An `(inputs, unbatched, rectangular)` tuple, where `inputs` is a


### PR DESCRIPTION
🚧 This is an experimental feature branch, more details soon. 🚧

This is one of the trickier parts of the port, given that jax and torch lack ragged or strings type. To account for this, we will convert the output of all preprocessing layers to simple pythonic types in those backends, unless we are running with `tf.data`, in which case `tf.ragged` should still be used.

This means we need to improve our input conversion on preprocessing and tokenizer layers to account that inputs could be passed as "ragged-like" python lists. I factored out a utility `convert_to_ragged_batch` to do so.

I suspect this is not the end of discussions around preprocessing UX, but will at least give us something workable in the multi-backend case for now.