### PR TITLE
Update keras_nlp.metrics for core

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -102,7 +102,7 @@ jobs:
       env:
         KERAS_BACKEND: ${{ matrix.backend }}
       run: |
-        pytest --run_large keras_nlp/layers/modeling keras_nlp/samplers keras_nlp/tokenizers
+        pytest --run_large keras_nlp/layers/modeling keras_nlp/samplers keras_nlp/tokenizers keras_nlp/metrics
   format:
     name: Check the code format
     runs-on: ubuntu-latest

--- a/keras_nlp/metrics/bleu.py
+++ b/keras_nlp/metrics/bleu.py
@@ -21,6 +21,7 @@ import tensorflow as tf
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.backend import keras
+from keras_nlp.utils.tensor_utils import assert_tf_backend
 from keras_nlp.utils.tensor_utils import is_floating_dtype
 from keras_nlp.utils.tensor_utils import tensor_to_list
 
@@ -111,6 +112,8 @@ class Bleu(keras.metrics.Metric):
         name="bleu",
         **kwargs,
     ):
+        assert_tf_backend(self.__class__.__name__)
+
         super().__init__(name=name, dtype=dtype, **kwargs)
 
         if not is_floating_dtype(dtype):

--- a/keras_nlp/metrics/bleu_test.py
+++ b/keras_nlp/metrics/bleu_test.py
@@ -144,7 +144,8 @@ class BleuTest(TestCase):
 
     def test_model_compile(self):
         inputs = keras.Input(shape=(), dtype="string")
-        model = keras.Model(inputs, inputs)
+        outputs = keras.layers.Identity()(inputs)
+        model = keras.Model(inputs, outputs)
         model.compile(metrics=[Bleu()])
 
         y_pred = x = tf.constant(

--- a/keras_nlp/metrics/bleu_test.py
+++ b/keras_nlp/metrics/bleu_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Tests for Bleu."""
+import pytest
 import tensorflow as tf
 
 from keras_nlp.backend import keras
@@ -21,6 +22,7 @@ from keras_nlp.tests.test_case import TestCase
 from keras_nlp.tokenizers.byte_tokenizer import ByteTokenizer
 
 
+@pytest.mark.tf_only
 class BleuTest(TestCase):
     def test_initialization(self):
         bleu = Bleu()
@@ -142,12 +144,10 @@ class BleuTest(TestCase):
 
     def test_model_compile(self):
         inputs = keras.Input(shape=(), dtype="string")
-        outputs = tf.identity(inputs)
-        model = keras.Model(inputs, outputs)
-
+        model = keras.Model(inputs, inputs)
         model.compile(metrics=[Bleu()])
 
-        x = tf.constant(
+        y_pred = x = tf.constant(
             [
                 "He He He eats sweet apple which is a fruit.",
                 "I love Silicon Valley, it's one of my favourite shows.",
@@ -160,7 +160,7 @@ class BleuTest(TestCase):
             ]
         )
 
-        output = model.evaluate(x, y, return_dict=True)
+        output = model.compute_metrics(x, y, y_pred, sample_weight=None)
         self.assertAlmostEqual(output["bleu"], 0.243, delta=1e-3)
 
     def test_reset_state(self):

--- a/keras_nlp/metrics/edit_distance.py
+++ b/keras_nlp/metrics/edit_distance.py
@@ -18,6 +18,7 @@ import tensorflow as tf
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.backend import keras
+from keras_nlp.utils.tensor_utils import assert_tf_backend
 from keras_nlp.utils.tensor_utils import is_floating_dtype
 
 
@@ -107,6 +108,8 @@ class EditDistance(keras.metrics.Metric):
         name="edit_distance",
         **kwargs,
     ):
+        assert_tf_backend(self.__class__.__name__)
+
         super().__init__(name=name, dtype=dtype, **kwargs)
 
         if not is_floating_dtype(dtype):

--- a/keras_nlp/metrics/edit_distance_test.py
+++ b/keras_nlp/metrics/edit_distance_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Tests for EditDistance."""
+import pytest
 import tensorflow as tf
 
 from keras_nlp.backend import keras
@@ -20,6 +21,7 @@ from keras_nlp.metrics.edit_distance import EditDistance
 from keras_nlp.tests.test_case import TestCase
 
 
+@pytest.mark.tf_only
 class EditDistanceTest(TestCase):
     def test_initialization(self):
         edit_distance = EditDistance()
@@ -107,7 +109,8 @@ class EditDistanceTest(TestCase):
 
     def test_model_compile_normalize(self):
         inputs = keras.Input(shape=(None,), dtype="string")
-        model = keras.Model(inputs, inputs)
+        outputs = keras.layers.Identity()(inputs)
+        model = keras.Model(inputs, outputs)
 
         model.compile(metrics=[EditDistance()])
 
@@ -121,7 +124,8 @@ class EditDistanceTest(TestCase):
 
     def test_model_compile_normalize_false(self):
         inputs = keras.Input(shape=(None,), dtype="string")
-        model = keras.Model(inputs, inputs)
+        outputs = keras.layers.Identity()(inputs)
+        model = keras.Model(inputs, outputs)
 
         model.compile(metrics=[EditDistance(normalize=False)])
 

--- a/keras_nlp/metrics/edit_distance_test.py
+++ b/keras_nlp/metrics/edit_distance_test.py
@@ -107,34 +107,30 @@ class EditDistanceTest(TestCase):
 
     def test_model_compile_normalize(self):
         inputs = keras.Input(shape=(None,), dtype="string")
-        outputs = tf.strings.lower(inputs)
-        model = keras.Model(inputs, outputs)
+        model = keras.Model(inputs, inputs)
 
         model.compile(metrics=[EditDistance()])
 
-        x = tf.strings.split(
+        y_pred = x = tf.strings.split(["the cat was found under the bed"])
+        y = tf.strings.split(
             ["the tiny little cat was found under the big funny bed"]
         )
-        y = tf.strings.split(["the cat was found under the bed"])
 
-        output = model.evaluate(y, x, return_dict=True)
-
+        output = model.compute_metrics(x, y, y_pred, sample_weight=None)
         self.assertAlmostEqual(output["edit_distance"], 0.364, delta=1e-3)
 
     def test_model_compile_normalize_false(self):
         inputs = keras.Input(shape=(None,), dtype="string")
-        outputs = tf.strings.lower(inputs)
-        model = keras.Model(inputs, outputs)
+        model = keras.Model(inputs, inputs)
 
         model.compile(metrics=[EditDistance(normalize=False)])
 
-        x = tf.strings.split(
+        y_pred = x = tf.strings.split(["the cat was found under the bed"])
+        y = tf.strings.split(
             ["the tiny little cat was found under the big funny bed"]
         )
-        y = tf.strings.split(["the cat was found under the bed"])
 
-        output = model.evaluate(y, x, return_dict=True)
-
+        output = model.compute_metrics(x, y, y_pred, sample_weight=None)
         self.assertAlmostEqual(output["edit_distance"], 4.0, delta=1e-3)
 
     def test_reset_state_normalize(self):

--- a/keras_nlp/metrics/perplexity.py
+++ b/keras_nlp/metrics/perplexity.py
@@ -18,6 +18,7 @@ import tensorflow as tf
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.backend import keras
+from keras_nlp.utils.tensor_utils import assert_tf_backend
 from keras_nlp.utils.tensor_utils import is_floating_dtype
 
 
@@ -97,6 +98,8 @@ class Perplexity(keras.metrics.Metric):
         name="perplexity",
         **kwargs,
     ):
+        assert_tf_backend(self.__class__.__name__)
+
         if not is_floating_dtype(dtype):
             raise ValueError(
                 "`dtype` must be a floating point type. "

--- a/keras_nlp/metrics/perplexity_test.py
+++ b/keras_nlp/metrics/perplexity_test.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 """Tests for Perplexity."""
+import pytest
 import tensorflow as tf
 
 from keras_nlp.metrics.perplexity import Perplexity
 from keras_nlp.tests.test_case import TestCase
 
 
+@pytest.mark.tf_only
 class PerplexityTest(TestCase):
     def test_vars_after_initializing_class(self):
         perplexity = Perplexity()

--- a/keras_nlp/metrics/rouge_base.py
+++ b/keras_nlp/metrics/rouge_base.py
@@ -20,6 +20,7 @@ import types
 import tensorflow as tf
 
 from keras_nlp.backend import keras
+from keras_nlp.utils.tensor_utils import assert_tf_backend
 from keras_nlp.utils.tensor_utils import is_floating_dtype
 from keras_nlp.utils.tensor_utils import tensor_to_list
 
@@ -61,6 +62,8 @@ class RougeBase(keras.metrics.Metric):
         name="rouge",
         **kwargs,
     ):
+        assert_tf_backend(self.__class__.__name__)
+
         super().__init__(name=name, dtype=dtype, **kwargs)
 
         if rouge_scorer is None:

--- a/keras_nlp/metrics/rouge_l_test.py
+++ b/keras_nlp/metrics/rouge_l_test.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 """Tests for RougeL."""
+import pytest
 import tensorflow as tf
 
 from keras_nlp.metrics.rouge_l import RougeL
 from keras_nlp.tests.test_case import TestCase
 
 
+@pytest.mark.tf_only
 class RougeLTest(TestCase):
     def test_initialization(self):
         rouge = RougeL()

--- a/keras_nlp/metrics/rouge_n_test.py
+++ b/keras_nlp/metrics/rouge_n_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Tests for RougeN."""
+import pytest
 import tensorflow as tf
 
 from keras_nlp.backend import keras
@@ -20,6 +21,7 @@ from keras_nlp.metrics.rouge_n import RougeN
 from keras_nlp.tests.test_case import TestCase
 
 
+@pytest.mark.tf_only
 class RougeNTest(TestCase):
     def test_initialization(self):
         rouge = RougeN()
@@ -96,16 +98,14 @@ class RougeNTest(TestCase):
 
     def test_model_compile(self):
         inputs = keras.Input(shape=(), dtype="string")
-        outputs = tf.strings.lower(inputs)
-        model = keras.Model(inputs, outputs)
+        model = keras.Model(inputs, inputs)
 
-        model.compile(metrics=[RougeN()])
+        model.compile(loss="mse", metrics=[RougeN()])
 
-        x = tf.constant(["HELLO THIS IS FUN"])
+        y_pred = x = tf.constant(["hello this is fun"])
         y = tf.constant(["hello this is awesome"])
 
-        output = model.evaluate(x, y, return_dict=True)
-        del output["loss"]
+        output = model.compute_metrics(x, y, y_pred, sample_weight=None)
         self.assertAllClose(
             output,
             {"precision": 0.666666, "recall": 0.666666, "f1_score": 0.666666},

--- a/keras_nlp/metrics/rouge_n_test.py
+++ b/keras_nlp/metrics/rouge_n_test.py
@@ -97,19 +97,19 @@ class RougeNTest(TestCase):
         )
 
     def test_model_compile(self):
-        inputs = keras.Input(shape=(), dtype="string")
-        model = keras.Model(inputs, inputs)
+        inputs = keras.Input(shape=(None,), dtype="string")
+        outputs = keras.layers.Identity()(inputs)
+        model = keras.Model(inputs, outputs)
 
-        model.compile(loss="mse", metrics=[RougeN()])
+        model.compile(metrics=[RougeN()])
 
         y_pred = x = tf.constant(["hello this is fun"])
         y = tf.constant(["hello this is awesome"])
 
         output = model.compute_metrics(x, y, y_pred, sample_weight=None)
-        self.assertAllClose(
-            output,
-            {"precision": 0.666666, "recall": 0.666666, "f1_score": 0.666666},
-        )
+        self.assertAllClose(output["precision"], 0.666666)
+        self.assertAllClose(output["recall"], 0.666666)
+        self.assertAllClose(output["f1_score"], 0.666666)
 
     def test_incorrect_order(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
This PR isn't really a port for jax/torch. It is unclear how/if these should work without string dyptes, so just punting for now. But it does two things

- Disables these metrics symbols outside the tf runtime.
- Updates testing so test pass in keras-core tf (keras-core does not allow a evaluate call without a loss, so we switch to compute_metrics)