### PR TITLE
Fix mixed precision for BART

### DIFF
--- a/keras_nlp/models/bart/bart_seq_2_seq_lm.py
+++ b/keras_nlp/models/bart/bart_seq_2_seq_lm.py
@@ -193,8 +193,8 @@ class BartSeq2SeqLM(GenerativeTask):
         # Use token embedding weights to project from the token representation
         # to vocabulary logits.
         outputs = tf.matmul(
-            x,
-            tf.cast(backbone.token_embedding.embeddings, x.dtype),
+            tf.cast(x, backbone.token_embedding.embeddings.dtype),
+            backbone.token_embedding.embeddings,
             transpose_b=True,
         )
 

--- a/keras_nlp/models/bart/bart_seq_2_seq_lm.py
+++ b/keras_nlp/models/bart/bart_seq_2_seq_lm.py
@@ -194,7 +194,7 @@ class BartSeq2SeqLM(GenerativeTask):
         # to vocabulary logits.
         outputs = tf.matmul(
             x,
-            backbone.token_embedding.embeddings,
+            tf.cast(backbone.token_embedding.embeddings, x.dtype),
             transpose_b=True,
         )
 

--- a/keras_nlp/models/bart/bart_seq_2_seq_lm.py
+++ b/keras_nlp/models/bart/bart_seq_2_seq_lm.py
@@ -338,7 +338,10 @@ class BartSeq2SeqLM(GenerativeTask):
         hidden_states = x
 
         logits = tf.matmul(
-            hidden_states,
+            tf.cast(
+                hidden_states,
+                self.backbone.get_layer("token_embedding").embeddings.dtype,
+            ),
             self.backbone.get_layer("token_embedding").embeddings,
             transpose_b=True,
         )


### PR DESCRIPTION
With 

```
policy = keras.mixed_precision.Policy("mixed_float16")
keras.mixed_precision.set_global_policy(policy)
```
,

this error shows up:
```
TypeError: Exception encountered when calling layer "tf.linalg.matmul" (type TFOpLambda).

Input 'y' of 'BatchMatMulV2' Op has type float32 that does not match type float16 of argument 'x'.

Call arguments received by layer "tf.linalg.matmul" (type TFOpLambda):
  • a=tf.Tensor(shape=(None, None, 768), dtype=float16)
  • b=<tf.Variable 'token_embedding/embeddings:0' shape=(50265, 768) dtype=float32>
  • transpose_a=False
  • transpose_b=True
  • adjoint_a=False
  • adjoint_b=False
  • a_is_sparse=False
  • b_is_sparse=False
  • output_type=None
  • name=None
```