### PR TITLE
Fix publish to pypi action

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,7 +10,6 @@ jobs:
     - name: Install dependencies
       run: |
           pip install -r requirements.txt --progress-bar off
-          pip install --no-deps -e "." --progress-bar off
     - name: Build a binary wheel and a source tarball
       run: >-
         python pip_build.py


### PR DESCRIPTION
In #1124, I accidentally added a line doing a `pip install .` package install to the publish flow.

This is silly, we shouldn't need to be installing the package before building the package for pypi, and it appears to be causing failures on the action:
https://github.com/keras-team/keras-nlp/actions/runs/5513665846/jobs/10052068366

These were not caught because we don't run the pypi action on each PR.