### PR TITLE
Fix broken tests

### DIFF
--- a/keras_nlp/models/deberta_v3/deberta_v3_backbone_test.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_backbone_test.py
@@ -20,6 +20,7 @@ import pytest
 import tensorflow as tf
 
 from keras_nlp.backend import keras
+from keras_nlp.backend import ops
 from keras_nlp.models.deberta_v3.deberta_v3_backbone import DebertaV3Backbone
 from keras_nlp.tests.test_case import TestCase
 


### PR DESCRIPTION
Silly error due to a merge conflict.

Looks like github didn't pick it up because the diffs applied cleanly and the tests were not rerun.