### PR TITLE
Remove tests for preprocessing inside a functional model

### DIFF
--- a/keras_nlp/models/albert/albert_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/albert/albert_masked_lm_preprocessor_test.py
@@ -14,9 +14,7 @@
 """Tests for ALBERT masked language model preprocessor layer."""
 
 import io
-import os
 
-import pytest
 import sentencepiece
 import tensorflow as tf
 
@@ -150,20 +148,3 @@ class AlbertMaskedLMPreprocessorTest(TestCase):
             new_preprocessor.get_config(),
             self.preprocessor.get_config(),
         )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["the quick brown fox"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs, y, sw = self.preprocessor(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        outputs = model(input_data)["token_ids"]
-        restored_outputs = restored_model(input_data)["token_ids"]
-        self.assertAllEqual(outputs, restored_outputs)

--- a/keras_nlp/models/albert/albert_preprocessor_test.py
+++ b/keras_nlp/models/albert/albert_preprocessor_test.py
@@ -14,9 +14,7 @@
 
 """Tests for ALBERT preprocessor layer."""
 import io
-import os
 
-import pytest
 import sentencepiece
 import tensorflow as tf
 
@@ -163,19 +161,4 @@ class AlbertPreprocessorTest(TestCase):
         self.assertEqual(
             new_preprocessor.get_config(),
             self.preprocessor.get_config(),
-        )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["the quick brown fox"])
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = self.preprocessor(inputs)
-        model = keras.Model(inputs, outputs)
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data)["token_ids"],
-            restored_model(input_data)["token_ids"],
         )

--- a/keras_nlp/models/albert/albert_tokenizer_test.py
+++ b/keras_nlp/models/albert/albert_tokenizer_test.py
@@ -14,9 +14,7 @@
 
 """Tests for ALBERT tokenizer."""
 import io
-import os
 
-import pytest
 import sentencepiece
 import tensorflow as tf
 
@@ -88,22 +86,4 @@ class AlbertTokenizerTest(TestCase):
         self.assertEqual(
             new_tokenizer.get_config(),
             self.tokenizer.get_config(),
-        )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["the quick brown fox"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = self.tokenizer(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data),
-            restored_model(input_data),
         )

--- a/keras_nlp/models/bart/bart_preprocessor_test.py
+++ b/keras_nlp/models/bart/bart_preprocessor_test.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 """Tests for BART preprocessor layer."""
-import os
 
-import pytest
 import tensorflow as tf
 
 from keras_nlp.backend import keras
@@ -165,36 +163,4 @@ class BartPreprocessorTest(TestCase):
         )
         self.assertEqual(
             new_preprocessor.get_config(), self.preprocessor.get_config()
-        )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = {
-            "encoder_text": tf.constant([" airplane at airport"]),
-            "decoder_text": tf.constant([" kohli is the best"]),
-        }
-
-        inputs = {
-            "encoder_text": keras.Input(
-                dtype="string", name="encoder_text", shape=()
-            ),
-            "decoder_text": keras.Input(
-                dtype="string", name="decoder_text", shape=()
-            ),
-        }
-        outputs = self.preprocessor(inputs)
-        model = keras.Model(inputs=inputs, outputs=outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-
-        model_output = model(input_data)
-        restored_model_output = restored_model(input_data)
-
-        self.assertAllClose(
-            model_output,
-            restored_model_output,
         )

--- a/keras_nlp/models/bart/bart_seq_2_seq_lm_preprocessor_test.py
+++ b/keras_nlp/models/bart/bart_seq_2_seq_lm_preprocessor_test.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 """Tests for BART preprocessor layer."""
-import os
 
-import pytest
 import tensorflow as tf
 
 from keras_nlp.backend import keras
@@ -153,36 +151,4 @@ class BartSeq2SeqLMPreprocessorTest(TestCase):
         )
         self.assertEqual(
             new_preprocessor.get_config(), self.preprocessor.get_config()
-        )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = {
-            "encoder_text": tf.constant([" airplane at airport"]),
-            "decoder_text": tf.constant([" kohli is the best"]),
-        }
-
-        inputs = {
-            "encoder_text": keras.Input(
-                dtype="string", name="encoder_text", shape=()
-            ),
-            "decoder_text": keras.Input(
-                dtype="string", name="decoder_text", shape=()
-            ),
-        }
-        outputs, y, sw = self.preprocessor(inputs)
-        model = keras.Model(inputs=inputs, outputs=outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-
-        model_output = model(input_data)
-        restored_model_output = restored_model(input_data)
-
-        self.assertAllClose(
-            model_output,
-            restored_model_output,
         )

--- a/keras_nlp/models/bart/bart_tokenizer_test.py
+++ b/keras_nlp/models/bart/bart_tokenizer_test.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 """Tests for BART tokenizer."""
-import os
 
-import pytest
-import tensorflow as tf
 
 from keras_nlp.backend import keras
 from keras_nlp.models.bart.bart_tokenizer import BartTokenizer
@@ -80,22 +77,4 @@ class BartTokenizerTest(TestCase):
         self.assertEqual(
             new_tokenizer.get_config(),
             self.tokenizer.get_config(),
-        )
-
-    @pytest.mark.large  # Saving is slow, so mark these large.
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant([" airplane at airport"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = self.tokenizer(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data),
-            restored_model(input_data),
         )

--- a/keras_nlp/models/bert/bert_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/bert/bert_masked_lm_preprocessor_test.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 """Tests for BERT masked language model preprocessor layer."""
 
-import os
 
-import pytest
 import tensorflow as tf
 
 from keras_nlp.backend import keras
@@ -134,20 +132,3 @@ class BertMaskedLMPreprocessorTest(TestCase):
             new_preprocessor.get_config(),
             self.preprocessor.get_config(),
         )
-
-    @pytest.mark.large  # Saving is slow, so mark these large.
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["the quick brown fox"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs, y, sw = self.preprocessor(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        outputs = model(input_data)["token_ids"]
-        restored_outputs = restored_model(input_data)["token_ids"]
-        self.assertAllEqual(outputs, restored_outputs)

--- a/keras_nlp/models/bert/bert_preprocessor_test.py
+++ b/keras_nlp/models/bert/bert_preprocessor_test.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 """Tests for BERT preprocessor layer."""
 
-import os
 
-import pytest
 import tensorflow as tf
 
 from keras_nlp.backend import keras
@@ -118,19 +116,4 @@ class BertPreprocessorTest(TestCase):
         self.assertEqual(
             new_preprocessor.get_config(),
             self.preprocessor.get_config(),
-        )
-
-    @pytest.mark.large  # Saving is slow, so mark these large.
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["THE QUICK BROWN FOX."])
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = self.preprocessor(inputs)
-        model = keras.Model(inputs, outputs)
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data)["token_ids"],
-            restored_model(input_data)["token_ids"],
         )

--- a/keras_nlp/models/bert/bert_tokenizer_test.py
+++ b/keras_nlp/models/bert/bert_tokenizer_test.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 """Tests for BERT tokenizer."""
 
-import os
-
-import pytest
-import tensorflow as tf
 
 from keras_nlp.backend import keras
 from keras_nlp.models.bert.bert_tokenizer import BertTokenizer
@@ -64,20 +60,4 @@ class BertTokenizerTest(TestCase):
         self.assertEqual(
             new_tokenizer.get_config(),
             self.tokenizer.get_config(),
-        )
-
-    @pytest.mark.large  # Saving is slow, so mark these large.
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["THE QUICK BROWN FOX."])
-        tokenizer = BertTokenizer(vocabulary=self.vocab)
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = tokenizer(inputs)
-        model = keras.Model(inputs, outputs)
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data),
-            restored_model(input_data),
         )

--- a/keras_nlp/models/deberta_v3/deberta_v3_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_masked_lm_preprocessor_test.py
@@ -14,9 +14,7 @@
 
 """Tests for DeBERTa preprocessor layer."""
 import io
-import os
 
-import pytest
 import sentencepiece
 import tensorflow as tf
 
@@ -146,20 +144,3 @@ class DebertaV3PreprocessorTest(TestCase):
             new_preprocessor.get_config(),
             self.preprocessor.get_config(),
         )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["the quick brown fox"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs, y, sw = self.preprocessor(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        outputs = model(input_data)["token_ids"]
-        restored_outputs = restored_model(input_data)["token_ids"]
-        self.assertAllEqual(outputs, restored_outputs)

--- a/keras_nlp/models/deberta_v3/deberta_v3_preprocessor_test.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_preprocessor_test.py
@@ -14,9 +14,7 @@
 
 """Tests for DeBERTa preprocessor layer."""
 import io
-import os
 
-import pytest
 import sentencepiece
 import tensorflow as tf
 
@@ -142,19 +140,4 @@ class DebertaV3PreprocessorTest(TestCase):
         self.assertEqual(
             new_preprocessor.get_config(),
             self.preprocessor.get_config(),
-        )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["the quick brown fox"])
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = self.preprocessor(inputs)
-        model = keras.Model(inputs, outputs)
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data)["token_ids"],
-            restored_model(input_data)["token_ids"],
         )

--- a/keras_nlp/models/deberta_v3/deberta_v3_tokenizer_test.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_tokenizer_test.py
@@ -14,9 +14,7 @@
 
 """Tests for DeBERTa tokenizer."""
 import io
-import os
 
-import pytest
 import sentencepiece
 import tensorflow as tf
 
@@ -100,22 +98,4 @@ class DebertaV3TokenizerTest(TestCase):
         self.assertEqual(
             new_tokenizer.get_config(),
             self.tokenizer.get_config(),
-        )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["the quick brown fox"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = self.tokenizer(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data),
-            restored_model(input_data),
         )

--- a/keras_nlp/models/distil_bert/distil_bert_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/distil_bert/distil_bert_masked_lm_preprocessor_test.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 """Tests for DistilBERT masked language model preprocessor layer."""
-import os
 
-import pytest
 import tensorflow as tf
 
 from keras_nlp.backend import keras
@@ -111,20 +109,3 @@ class DistilBertMaskedLMPreprocessorTest(TestCase):
             new_preprocessor.get_config(),
             self.preprocessor.get_config(),
         )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant([" THE QUICK BROWN FOX."])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs, y, sw = self.preprocessor(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        outputs = model(input_data)["token_ids"]
-        restored_outputs = restored_model(input_data)["token_ids"]
-        self.assertAllEqual(outputs, restored_outputs)

--- a/keras_nlp/models/distil_bert/distil_bert_preprocessor_test.py
+++ b/keras_nlp/models/distil_bert/distil_bert_preprocessor_test.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 """Tests for DistilBERT preprocessor layer."""
 
-import os
 
-import pytest
 import tensorflow as tf
 
 from keras_nlp.backend import keras
@@ -108,19 +106,4 @@ class DistilBertPreprocessorTest(TestCase):
         self.assertEqual(
             new_preprocessor.get_config(),
             self.preprocessor.get_config(),
-        )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["THE QUICK BROWN FOX."])
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = self.preprocessor(inputs)
-        model = keras.Model(inputs, outputs)
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data)["token_ids"],
-            restored_model(input_data)["token_ids"],
         )

--- a/keras_nlp/models/distil_bert/distil_bert_tokenizer_test.py
+++ b/keras_nlp/models/distil_bert/distil_bert_tokenizer_test.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 """Tests for DistilBERT tokenizer."""
 
-import os
-
-import pytest
-import tensorflow as tf
 
 from keras_nlp.backend import keras
 from keras_nlp.models.distil_bert.distil_bert_tokenizer import (
@@ -66,20 +62,4 @@ class DistilBertTokenizerTest(TestCase):
         self.assertEqual(
             new_tokenizer.get_config(),
             self.tokenizer.get_config(),
-        )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["THE QUICK BROWN FOX."])
-        tokenizer = DistilBertTokenizer(vocabulary=self.vocab)
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = tokenizer(inputs)
-        model = keras.Model(inputs, outputs)
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data),
-            restored_model(input_data),
         )

--- a/keras_nlp/models/f_net/f_net_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/f_net/f_net_masked_lm_preprocessor_test.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import io
-import os
 
-import pytest
 import sentencepiece
 import tensorflow as tf
 
@@ -128,20 +126,3 @@ class FNetMaskedLMPreprocessorTest(TestCase):
             new_preprocessor.get_config(),
             self.preprocessor.get_config(),
         )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["the quick brown fox"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs, y, sw = self.preprocessor(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        outputs = model(input_data)["token_ids"]
-        restored_outputs = restored_model(input_data)["token_ids"]
-        self.assertAllEqual(outputs, restored_outputs)

--- a/keras_nlp/models/f_net/f_net_preprocessor_test.py
+++ b/keras_nlp/models/f_net/f_net_preprocessor_test.py
@@ -14,9 +14,7 @@
 
 """Tests for FNet preprocessor layer."""
 import io
-import os
 
-import pytest
 import sentencepiece
 import tensorflow as tf
 
@@ -145,19 +143,4 @@ class FNetPreprocessorTest(TestCase):
         self.assertEqual(
             new_preprocessor.get_config(),
             self.preprocessor.get_config(),
-        )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["the quick brown fox"])
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = self.preprocessor(inputs)
-        model = keras.Model(inputs, outputs)
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data)["token_ids"],
-            restored_model(input_data)["token_ids"],
         )

--- a/keras_nlp/models/f_net/f_net_tokenizer_test.py
+++ b/keras_nlp/models/f_net/f_net_tokenizer_test.py
@@ -14,7 +14,6 @@
 
 """Tests for FNet tokenizer."""
 import io
-import os
 
 import pytest
 import sentencepiece
@@ -89,22 +88,4 @@ class FNetTokenizerTest(TestCase):
         self.assertEqual(
             new_tokenizer.get_config(),
             self.tokenizer.get_config(),
-        )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["the quick brown fox"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = self.tokenizer(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data),
-            restored_model(input_data),
         )

--- a/keras_nlp/models/gpt2/gpt2_causal_lm_preprocessor_test.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm_preprocessor_test.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 """Tests for GPT2 causal LM preprocessor layer."""
-import os
 
-import pytest
 import tensorflow as tf
 
 from keras_nlp.backend import keras
@@ -126,22 +124,4 @@ class GPT2CausalLMPreprocessorTest(TestCase):
         self.assertEqual(
             new_preprocessor.get_config(),
             self.preprocessor.get_config(),
-        )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["airplane at airport"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs, y, sw = self.preprocessor(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data)["token_ids"],
-            restored_model(input_data)["token_ids"],
         )

--- a/keras_nlp/models/gpt2/gpt2_preprocessor_test.py
+++ b/keras_nlp/models/gpt2/gpt2_preprocessor_test.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 """Tests for GPT2 preprocessor layer."""
-import os
 
-import pytest
 import tensorflow as tf
 
 from keras_nlp.backend import keras
@@ -107,22 +105,4 @@ class GPT2PreprocessorTest(TestCase):
         self.assertEqual(
             new_preprocessor.get_config(),
             self.preprocessor.get_config(),
-        )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["airplane at airport"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = self.preprocessor(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data)["token_ids"],
-            restored_model(input_data)["token_ids"],
         )

--- a/keras_nlp/models/gpt2/gpt2_tokenizer_test.py
+++ b/keras_nlp/models/gpt2/gpt2_tokenizer_test.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 """Tests for GPT-2 preprocessing layers."""
-import os
 
-import pytest
-import tensorflow as tf
 
 from keras_nlp.backend import keras
 from keras_nlp.models.gpt2.gpt2_tokenizer import GPT2Tokenizer
@@ -96,22 +93,4 @@ class GPT2TokenizerTest(TestCase):
         self.assertEqual(
             new_tokenizer.get_config(),
             self.tokenizer.get_config(),
-        )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant([" airplane at airport"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = self.tokenizer(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data),
-            restored_model(input_data),
         )

--- a/keras_nlp/models/gpt_neo_x/gpt_neo_x_causal_lm_preprocessor_test.py
+++ b/keras_nlp/models/gpt_neo_x/gpt_neo_x_causal_lm_preprocessor_test.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 """Tests for GPTNeoX causal LM preprocessor layer."""
-import os
 
-import pytest
 import tensorflow as tf
 
 from keras_nlp.backend import keras
@@ -126,22 +124,4 @@ class GPTNeoXCausalLMPreprocessorTest(TestCase):
         self.assertEqual(
             new_preprocessor.get_config(),
             self.preprocessor.get_config(),
-        )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["airplane at airport"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs, y, sw = self.preprocessor(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data)["token_ids"],
-            restored_model(input_data)["token_ids"],
         )

--- a/keras_nlp/models/gpt_neo_x/gpt_neo_x_preprocessor_test.py
+++ b/keras_nlp/models/gpt_neo_x/gpt_neo_x_preprocessor_test.py
@@ -14,9 +14,7 @@
 
 """Tests for GPTNeoX preprocessor layer."""
 
-import os
 
-import pytest
 import tensorflow as tf
 
 from keras_nlp.backend import keras
@@ -110,22 +108,4 @@ class GPTNeoXPreprocessorTest(TestCase):
         self.assertEqual(
             new_preprocessor.get_config(),
             self.preprocessor.get_config(),
-        )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["airplane at airport"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = self.preprocessor(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data)["token_ids"],
-            restored_model(input_data)["token_ids"],
         )

--- a/keras_nlp/models/gpt_neo_x/gpt_neo_x_tokenizer_test.py
+++ b/keras_nlp/models/gpt_neo_x/gpt_neo_x_tokenizer_test.py
@@ -14,10 +14,6 @@
 
 """Tests for GPT-NeoX preprocessing layers."""
 
-import os
-
-import pytest
-import tensorflow as tf
 
 from keras_nlp.backend import keras
 from keras_nlp.models.gpt_neo_x.gpt_neo_x_tokenizer import GPTNeoXTokenizer
@@ -97,22 +93,4 @@ class GPTNeoXTokenizerTest(TestCase):
         self.assertEqual(
             new_tokenizer.get_config(),
             self.tokenizer.get_config(),
-        )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant([" airplane at airport"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = self.tokenizer(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data),
-            restored_model(input_data),
         )

--- a/keras_nlp/models/opt/opt_causal_lm_preprocessor_test.py
+++ b/keras_nlp/models/opt/opt_causal_lm_preprocessor_test.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 """Tests for OPT causal LM preprocessor layer."""
-import os
 
-import pytest
 import tensorflow as tf
 
 from keras_nlp.backend import keras
@@ -128,22 +126,4 @@ class OPTCausalLMPreprocessorTest(TestCase):
         self.assertEqual(
             new_preprocessor.get_config(),
             self.preprocessor.get_config(),
-        )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant([" airplane at airport"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs, y, sw = self.preprocessor(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data)["token_ids"],
-            restored_model(input_data)["token_ids"],
         )

--- a/keras_nlp/models/opt/opt_preprocessor_test.py
+++ b/keras_nlp/models/opt/opt_preprocessor_test.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 """Tests for OPT preprocessor layer."""
-import os
 
-import pytest
 import tensorflow as tf
 
 from keras_nlp.backend import keras
@@ -109,22 +107,4 @@ class OPTPreprocessorTest(TestCase):
         self.assertEqual(
             new_preprocessor.get_config(),
             self.preprocessor.get_config(),
-        )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant([" airplane at airport"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = self.preprocessor(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data)["token_ids"],
-            restored_model(input_data)["token_ids"],
         )

--- a/keras_nlp/models/opt/opt_tokenizer_test.py
+++ b/keras_nlp/models/opt/opt_tokenizer_test.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 """Tests for OPT tokenizer layer."""
-import os
 
-import pytest
-import tensorflow as tf
 
 from keras_nlp.backend import keras
 from keras_nlp.models.opt.opt_tokenizer import OPTTokenizer
@@ -80,22 +77,4 @@ class OPTTokenizerTest(TestCase):
         self.assertEqual(
             new_tokenizer.get_config(),
             self.tokenizer.get_config(),
-        )
-
-    @pytest.mark.large  # Saving is slow, so mark these large.
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant([" airplane at airport"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = self.tokenizer(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data),
-            restored_model(input_data),
         )

--- a/keras_nlp/models/roberta/roberta_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/roberta/roberta_masked_lm_preprocessor_test.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 """Tests for RoBERTa masked language model preprocessor layer."""
-import os
 
-import pytest
 import tensorflow as tf
 
 from keras_nlp.backend import keras
@@ -147,20 +145,3 @@ class RobertaMaskedLMPreprocessorTest(TestCase):
             new_preprocessor.get_config(),
             self.preprocessor.get_config(),
         )
-
-    @pytest.mark.large  # Saving is slow, so mark these large.
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant([" airplane at airport"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs, y, sw = self.preprocessor(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        outputs = model(input_data)["token_ids"]
-        restored_outputs = restored_model(input_data)["token_ids"]
-        self.assertAllEqual(outputs, restored_outputs)

--- a/keras_nlp/models/roberta/roberta_preprocessor_test.py
+++ b/keras_nlp/models/roberta/roberta_preprocessor_test.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 """Tests for RoBERTa preprocessor layer."""
-import os
 
-import pytest
 import tensorflow as tf
 
 from keras_nlp.backend import keras
@@ -145,22 +143,4 @@ class RobertaPreprocessorTest(TestCase):
         self.assertEqual(
             new_preprocessor.get_config(),
             self.preprocessor.get_config(),
-        )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant([" airplane at airport"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = self.preprocessor(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data)["token_ids"],
-            restored_model(input_data)["token_ids"],
         )

--- a/keras_nlp/models/roberta/roberta_tokenizer_test.py
+++ b/keras_nlp/models/roberta/roberta_tokenizer_test.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 """Tests for RoBERTa tokenizer."""
-import os
 
-import pytest
-import tensorflow as tf
 
 from keras_nlp.backend import keras
 from keras_nlp.models.roberta.roberta_tokenizer import RobertaTokenizer
@@ -81,22 +78,4 @@ class RobertaTokenizerTest(TestCase):
         self.assertEqual(
             new_tokenizer.get_config(),
             self.tokenizer.get_config(),
-        )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant([" airplane at airport"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = self.tokenizer(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data),
-            restored_model(input_data),
         )

--- a/keras_nlp/models/t5/t5_tokenizer_test.py
+++ b/keras_nlp/models/t5/t5_tokenizer_test.py
@@ -14,9 +14,7 @@
 
 """Tests for T5 tokenizer."""
 import io
-import os
 
-import pytest
 import sentencepiece
 import tensorflow as tf
 
@@ -87,22 +85,4 @@ class T5TokenizerTest(TestCase):
         self.assertEqual(
             new_tokenizer.get_config(),
             self.tokenizer.get_config(),
-        )
-
-    @pytest.mark.large  # Saving is slow, so mark these large.
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["the quick brown fox"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = self.tokenizer(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data),
-            restored_model(input_data),
         )

--- a/keras_nlp/models/whisper/whisper_audio_feature_extractor_test.py
+++ b/keras_nlp/models/whisper/whisper_audio_feature_extractor_test.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 """Tests for Whisper audio feature extractor."""
 
-import os
 
-import pytest
 import tensorflow as tf
 
 from keras_nlp.backend import keras
@@ -76,22 +74,4 @@ class WhisperAudioFeatureExtractorTest(TestCase):
         self.assertEqual(
             new_audio_feature_extractor.get_config(),
             self.audio_feature_extractor.get_config(),
-        )
-
-    @pytest.mark.large  # Saving is slow, so mark these large.
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        audio_tensor = tf.ones((2, 200), dtype="float32")
-
-        inputs = keras.Input(dtype="float32", shape=(None,))
-        outputs = self.audio_feature_extractor(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(audio_tensor),
-            restored_model(audio_tensor),
         )

--- a/keras_nlp/models/whisper/whisper_preprocessor_test.py
+++ b/keras_nlp/models/whisper/whisper_preprocessor_test.py
@@ -14,9 +14,7 @@
 
 """Tests for Whisper preprocessor layer."""
 
-import os
 
-import pytest
 import tensorflow as tf
 
 from keras_nlp.backend import keras
@@ -184,40 +182,4 @@ class WhisperPreprocessorTest(TestCase):
         self.assertEqual(
             new_preprocessor.get_config(),
             self.preprocessor.get_config(),
-        )
-
-    @pytest.mark.tf_only
-    @pytest.mark.large
-    def test_saved_model(self):
-        input_data = {
-            "encoder_audio": tf.ones((1, 200)),
-            "decoder_text": tf.constant([" airplane at airport"]),
-        }
-
-        inputs = {
-            "encoder_audio": keras.Input(
-                dtype="float32", shape=(None,), name="encoder_audio"
-            ),
-            "decoder_text": keras.Input(
-                dtype="string", shape=(), name="decoder_text"
-            ),
-        }
-        outputs = self.preprocessor(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-
-        model_output = model(input_data)
-        restored_model_output = restored_model(input_data)
-
-        self.assertAllEqual(
-            model_output["encoder_features"],
-            restored_model_output["encoder_features"],
-        )
-        self.assertAllEqual(
-            model_output["decoder_token_ids"],
-            restored_model_output["decoder_token_ids"],
         )

--- a/keras_nlp/models/whisper/whisper_tokenizer_test.py
+++ b/keras_nlp/models/whisper/whisper_tokenizer_test.py
@@ -13,12 +13,9 @@
 # limitations under the License.
 
 """Tests for Whisper preprocessing layers."""
-import os
 
 import pytest
-import tensorflow as tf
 
-from keras_nlp.backend import keras
 from keras_nlp.models.whisper.whisper_tokenizer import WhisperTokenizer
 from keras_nlp.tests.test_case import TestCase
 
@@ -104,21 +101,3 @@ class WhisperTokenizerTest(TestCase):
             WhisperTokenizer(
                 vocabulary=["a", "b", "c"], merges=[], special_tokens={}
             )
-
-    @pytest.mark.large  # Saving is slow, so mark these large.
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant([" airplane at airport"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = self.tokenizer(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data),
-            restored_model(input_data),
-        )

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_masked_lm_preprocessor_test.py
@@ -14,9 +14,7 @@
 
 """Tests for XLM-RoBERTa masked language model preprocessor layer."""
 import io
-import os
 
-import pytest
 import sentencepiece
 import tensorflow as tf
 
@@ -149,20 +147,3 @@ class XLMRobertaMaskedLMPreprocessorTest(TestCase):
             new_preprocessor.get_config(),
             self.preprocessor.get_config(),
         )
-
-    @pytest.mark.large
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant([" quick brown fox"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs, y, sw = self.preprocessor(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        outputs = model(input_data)["token_ids"]
-        restored_outputs = restored_model(input_data)["token_ids"]
-        self.assertAllEqual(outputs, restored_outputs)

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_preprocessor_test.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_preprocessor_test.py
@@ -14,9 +14,7 @@
 
 """Tests for XLM-RoBERTa preprocessor layer."""
 import io
-import os
 
-import pytest
 import sentencepiece
 import tensorflow as tf
 
@@ -138,19 +136,4 @@ class XLMRobertaPreprocessorTest(TestCase):
         self.assertEqual(
             new_preprocessor.get_config(),
             self.preprocessor.get_config(),
-        )
-
-    @pytest.mark.large  # Saving is slow, so mark these large.
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["the quick brown fox"])
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = self.preprocessor(inputs)
-        model = keras.Model(inputs, outputs)
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data)["token_ids"],
-            restored_model(input_data)["token_ids"],
         )

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_tokenizer_test.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_tokenizer_test.py
@@ -14,9 +14,7 @@
 
 """Tests for XLM-RoBERTa tokenizer."""
 import io
-import os
 
-import pytest
 import sentencepiece
 import tensorflow as tf
 
@@ -113,22 +111,4 @@ class XLMRobertaTokenizerTest(TestCase):
         self.assertEqual(
             new_tokenizer.get_config(),
             self.tokenizer.get_config(),
-        )
-
-    @pytest.mark.large  # Saving is slow, so mark these large.
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["the quick brown fox"])
-
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = self.tokenizer(inputs)
-        model = keras.Model(inputs, outputs)
-
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data),
-            restored_model(input_data),
         )

--- a/keras_nlp/tokenizers/byte_pair_tokenizer_test.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 
 import pytest
 import tensorflow as tf
@@ -169,19 +168,4 @@ class BytePairTokenizerTest(TestCase):
         self.assertAllEqual(
             self.tokenizer(input_data),
             cloned_tokenizer(input_data),
-        )
-
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["the quick brown whale."])
-        tokenizer = self.tokenizer
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = tokenizer(inputs)
-        model = keras.Model(inputs, outputs)
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data),
-            restored_model(input_data),
         )

--- a/keras_nlp/tokenizers/byte_tokenizer_test.py
+++ b/keras_nlp/tokenizers/byte_tokenizer_test.py
@@ -12,12 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 
-import pytest
 import tensorflow as tf
 
-from keras_nlp.backend import keras
 from keras_nlp.tests.test_case import TestCase
 from keras_nlp.tokenizers.byte_tokenizer import ByteTokenizer
 
@@ -182,16 +179,6 @@ class ByteTokenizerTest(TestCase):
         ]
         self.assertAllEqual(output, exp_output)
 
-    @pytest.mark.tf_only
-    def test_functional_model(self):
-        input_data = tf.constant(["hello", "fun", "▀▁▂▃"])
-        tokenizer = ByteTokenizer()
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = tokenizer.detokenize(tokenizer.tokenize(inputs))
-        model = keras.Model(inputs, outputs)
-        model_output = model(input_data)
-        self.assertAllEqual(model_output, ["hello", "fun", "▀▁▂▃"])
-
     def test_load_model_with_config(self):
         input_data = ["hello"]
 
@@ -235,25 +222,3 @@ class ByteTokenizerTest(TestCase):
             "trainable": True,
         }
         self.assertEqual(tokenizer.get_config(), exp_config)
-
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["this is fun"])
-
-        tokenizer = ByteTokenizer(
-            name="byte_tokenizer_config_test",
-            lowercase=False,
-            sequence_length=20,
-            normalization_form="NFKC",
-            errors="replace",
-        )
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = tokenizer(inputs)
-        model = keras.Model(inputs, outputs)
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data),
-            restored_model(input_data),
-        )

--- a/keras_nlp/tokenizers/sentence_piece_tokenizer_test.py
+++ b/keras_nlp/tokenizers/sentence_piece_tokenizer_test.py
@@ -15,11 +15,9 @@
 import io
 import os
 
-import pytest
 import sentencepiece
 import tensorflow as tf
 
-from keras_nlp.backend import keras
 from keras_nlp.tests.test_case import TestCase
 from keras_nlp.tokenizers.sentence_piece_tokenizer import SentencePieceTokenizer
 
@@ -114,18 +112,6 @@ class SentencePieceTokenizerTest(TestCase):
         with self.assertRaises(ValueError):
             tokenizer.id_to_token(-1)
 
-    @pytest.mark.tf_only
-    def test_functional_model(self):
-        input_data = tf.constant(["the quick brown fox."])
-        tokenizer = SentencePieceTokenizer(
-            proto=self.proto,
-        )
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = tokenizer.detokenize(tokenizer.tokenize(inputs))
-        model = keras.Model(inputs, outputs)
-        model_output = model(input_data)
-        self.assertAllEqual(model_output, ["the quick brown fox."])
-
     def test_from_file(self):
         filepath = os.path.join(self.get_temp_dir(), "model.txt")
         input_data = ["the quick brown fox."]
@@ -190,24 +176,4 @@ class SentencePieceTokenizerTest(TestCase):
         self.assertAllEqual(
             original_tokenizer(input_data),
             cloned_tokenizer(input_data),
-        )
-
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        filepath = os.path.join(self.get_temp_dir(), "model.txt")
-        input_data = tf.constant(["the quick brown whale."])
-        with tf.io.gfile.GFile(filepath, "wb") as file:
-            file.write(self.proto)
-        tokenizer = SentencePieceTokenizer(
-            proto=filepath,
-        )
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = tokenizer(inputs)
-        model = keras.Model(inputs, outputs)
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data),
-            restored_model(input_data),
         )

--- a/keras_nlp/tokenizers/tokenizer.py
+++ b/keras_nlp/tokenizers/tokenizer.py
@@ -66,16 +66,6 @@ class Tokenizer(PreprocessingLayer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def __new__(cls, *args, **kwargs):
-        # Wrap the `tokenize` and `detokenize` methods so they route through
-        # __call__. This is needed for functional model support.
-        obj = super().__new__(cls, *args, **kwargs)
-        obj._tokenize_without_call = obj.tokenize
-        obj._detokenize_without_call = obj.detokenize
-        obj.tokenize = obj._tokenize_with_call
-        obj.detokenize = obj._detokenize_with_call
-        return obj
-
     def tokenize(self, inputs, *args, **kwargs):
         """Transform input tensors of strings into output tokens.
 
@@ -131,18 +121,5 @@ class Tokenizer(PreprocessingLayer):
             f"{self.__class__.__name__}."
         )
 
-    def _tokenize_with_call(self, *args, **kwargs):
-        return self(*args, mode="tokenize", **kwargs)
-
-    def _detokenize_with_call(self, *args, **kwargs):
-        return self(*args, mode="detokenize", **kwargs)
-
-    def call(self, *args, mode="tokenize", training=None, **kwargs):
-        if mode == "tokenize":
-            return self._tokenize_without_call(*args, **kwargs)
-        elif mode == "detokenize":
-            return self._detokenize_without_call(*args, **kwargs)
-        else:
-            raise ValueError(
-                f"Unsupported tokenizer mode. Received: mode={mode}"
-            )
+    def call(self, inputs, *args, training=None, **kwargs):
+        return self.tokenize(inputs, *args, **kwargs)

--- a/keras_nlp/tokenizers/tokenizer_test.py
+++ b/keras_nlp/tokenizers/tokenizer_test.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import tensorflow as tf
 
-from keras_nlp.backend import keras
 from keras_nlp.tests.test_case import TestCase
 from keras_nlp.tokenizers.tokenizer import Tokenizer
 
@@ -44,18 +42,6 @@ class TokenizerTest(TestCase):
         tokenizer = SimpleTokenizer()
         detokenize_output = tokenizer.detokenize(input_data)
         self.assertAllEqual(detokenize_output, ["the quick brown fox"])
-
-    @pytest.mark.tf_only
-    def test_functional_model(self):
-        input_data = tf.constant(["the   quick   brown   fox"])
-        tokenizer = SimpleTokenizer()
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = tokenizer.detokenize(tokenizer.tokenize(inputs))
-        model = keras.Model(inputs, outputs)
-        model_output = model(input_data)
-        # There appears to be a bug with shape inference for ragged reduce_join.
-        # The second dimension should be removed.
-        self.assertAllEqual(model_output, [["the quick brown fox"]])
 
     def test_missing_tokenize_raises(self):
         with self.assertRaises(NotImplementedError):

--- a/keras_nlp/tokenizers/unicode_codepoint_tokenizer_test.py
+++ b/keras_nlp/tokenizers/unicode_codepoint_tokenizer_test.py
@@ -12,12 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 
-import pytest
 import tensorflow as tf
 
-from keras_nlp.backend import keras
 from keras_nlp.tests.test_case import TestCase
 from keras_nlp.tokenizers.unicode_codepoint_tokenizer import (
     UnicodeCodepointTokenizer,
@@ -236,27 +233,6 @@ class UnicodeCodepointTokenizerTest(TestCase):
         ]
         self.assertAllEqual(output, exp_output)
 
-    @pytest.mark.tf_only
-    def test_functional_model(self):
-        input_data = tf.constant(
-            ["ninja", "samurai", "▀▁▂▃", "keras", "tensorflow"]
-        )
-        tokenizer = UnicodeCodepointTokenizer()
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = tokenizer.detokenize(tokenizer.tokenize(inputs))
-        model = keras.Model(inputs, outputs)
-        model_output = model(input_data)
-        self.assertAllEqual(
-            model_output,
-            [
-                b"ninja",
-                b"samurai",
-                b"\xe2\x96\x80\xe2\x96\x81\xe2\x96\x82\xe2\x96\x83",
-                b"keras",
-                b"tensorflow",
-            ],
-        )
-
     def test_load_model_with_config(self):
         input_data = tf.constant(["hello"])
 
@@ -332,27 +308,4 @@ class UnicodeCodepointTokenizerTest(TestCase):
         self.assertEqual(
             tokenize_different_encoding.get_config(),
             exp_config_different_encoding,
-        )
-
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["ninjas and samurais", "time travel"])
-
-        tokenizer = UnicodeCodepointTokenizer(
-            name="unicode_character_tokenizer_config_gen",
-            lowercase=False,
-            sequence_length=20,
-            normalization_form="NFKC",
-            errors="replace",
-            vocabulary_size=None,
-        )
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = tokenizer(inputs)
-        model = keras.Model(inputs, outputs)
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data),
-            restored_model(input_data),
         )

--- a/keras_nlp/tokenizers/word_piece_tokenizer_test.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer_test.py
@@ -14,10 +14,8 @@
 
 import os
 
-import pytest
 import tensorflow as tf
 
-from keras_nlp.backend import keras
 from keras_nlp.tests.test_case import TestCase
 from keras_nlp.tokenizers.word_piece_tokenizer import WordPieceTokenizer
 
@@ -156,17 +154,6 @@ class WordPieceTokenizerTest(TestCase):
         call_output = tokenizer(input_data)
         self.assertAllEqual(call_output, [1, 2, 3, 4, 5, 6])
 
-    @pytest.mark.tf_only
-    def test_functional_model(self):
-        input_data = tf.constant(["the quick brown fox"])
-        vocab_data = ["[UNK]", "the", "qu", "##ick", "br", "##own", "fox"]
-        tokenizer = WordPieceTokenizer(vocabulary=vocab_data)
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = tokenizer.detokenize(tokenizer.tokenize(inputs))
-        model = keras.Model(inputs, outputs)
-        model_output = model(input_data)
-        self.assertAllEqual(model_output, ["the quick brown fox"])
-
     def test_batching_ragged_tensors(self):
         tokenizer = WordPieceTokenizer(
             vocabulary=["[UNK]", "a", "b", "c", "d", "e", "f"]
@@ -206,28 +193,6 @@ class WordPieceTokenizerTest(TestCase):
         self.assertAllEqual(
             original_tokenizer(input_data),
             cloned_tokenizer(input_data),
-        )
-
-    @pytest.mark.tf_only
-    def test_saved_model(self):
-        input_data = tf.constant(["quick brOWN whale"])
-        vocab_data = ["@UNK@", "qu", "@@ick", "br", "@@OWN", "fox"]
-        tokenizer = WordPieceTokenizer(
-            vocabulary=vocab_data,
-            lowercase=False,
-            oov_token="@UNK@",
-            suffix_indicator="@@",
-            dtype="string",
-        )
-        inputs = keras.Input(dtype="string", shape=())
-        outputs = tokenizer(inputs)
-        model = keras.Model(inputs, outputs)
-        path = os.path.join(self.get_temp_dir(), "model.keras")
-        model.save(path, save_format="keras_v3")
-        restored_model = keras.models.load_model(path)
-        self.assertAllEqual(
-            model(input_data),
-            restored_model(input_data),
         )
 
     def test_no_oov_token_in_vocabulary(self):


### PR DESCRIPTION
This removes all testing for using string dtypes inside the `call` graph of a functional model. This will **never** work in a multi-backend fashion because `torch` and `jax` deliberately lack `string` dtypes.

There is really only one case where adding tokenization into the **call graph** of a model makes sense--inference in tensorflow. And for that use case, we should switch to recommending an export flow (like `tf.keras.export.ExportArchive()`). Ditching these tests will simplify the code base, speed up testing, and allow us to focus on workflows that apply to all backends.

Instead we, can focus on the follow options for applying tokenization:

1. Automatically, via a `Task` and `tf.data`.
2. Manually, with `tf.data`.
3. Manually, in eager mode outside of a model.
4. Inside an exported `tf.function`.

For the export flow, it would look something like:
```python
export_archive = keras.export.ExportArchive()
export_archive.track(classifier)
export_archive.add_endpoint(
    name="serve",
    fn=lambda x: classifier(classifier.preprocessor(x)),
    input_signature=[tf.TensorSpec(shape=(None), dtype=tf.string)],
)
export_archive.write_out("serving_model")
```

Plenty of planning will still need to be done on `export()` flows for `keras_core`, but that's probably out of scope for this PR.
