### PR TITLE
Stop pinning keras-core

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,4 +1,4 @@
-keras-core==0.1.0
+keras-core
 # Tooling.
 astor
 numpy~=1.23.2  # Numpy 1.24 breaks tests on ragged tensors


### PR DESCRIPTION
All fixes should now be handled in keras-nlp or keras-core.