### PR TITLE
Rename mask_positions to masked_positions

### DIFF
--- a/keras_nlp/layers/modeling/masked_lm_head.py
+++ b/keras_nlp/layers/modeling/masked_lm_head.py
@@ -27,7 +27,7 @@ class MaskedLMHead(keras.layers.Layer):
 
      - `inputs`: which should be a tensor of encoded tokens with shape
        `(batch_size, sequence_length, encoding_dim)`.
-     - `mask_positions`: which should be a tensor of integer positions to
+     - `masked_positions`: which should be a tensor of integer positions to
        predict with shape `(batch_size, masks_per_sequence)`.
 
     The token encodings should usually be the last output of an encoder model,
@@ -80,7 +80,7 @@ class MaskedLMHead(keras.layers.Layer):
         size=(batch_size, seq_length, encoding_size),
     )
     # Generate random positions and labels
-    mask_positions = np.random.randint(
+    masked_positions = np.random.randint(
         seq_length, size=(batch_size, mask_length),
     )
     mask_ids = np.random.randint(
@@ -91,7 +91,7 @@ class MaskedLMHead(keras.layers.Layer):
     mask_preds = keras_nlp.layers.MaskedLMHead(
         vocabulary_size=vocab_size,
         activation="softmax",
-    )(encoded_tokens, mask_positions=mask_positions)
+    )(encoded_tokens, masked_positions=masked_positions)
     # Calculate a loss.
     keras.losses.sparse_categorical_crossentropy(mask_ids, mask_preds)
     ```

--- a/keras_nlp/layers/preprocessing/masked_lm_mask_generator_test.py
+++ b/keras_nlp/layers/preprocessing/masked_lm_mask_generator_test.py
@@ -54,7 +54,7 @@ class MaskedLMMaskGeneratorTest(TestCase):
         inputs = [[5, 3, 2], [1, 2, 3, 4]]
         x = masked_lm_masker(inputs)
         self.assertAllEqual(x["token_ids"], [[1, 1, 1], [1, 1, 1, 1]])
-        self.assertAllEqual(x["mask_positions"], [[0, 1, 2, 0], [0, 1, 2, 3]])
+        self.assertAllEqual(x["masked_positions"], [[0, 1, 2, 0], [0, 1, 2, 3]])
         self.assertAllEqual(x["mask_ids"], [[5, 3, 2, 0], [1, 2, 3, 4]])
 
     def test_mask_dense(self):
@@ -69,7 +69,7 @@ class MaskedLMMaskGeneratorTest(TestCase):
         inputs = [[5, 3, 2, 4], [1, 2, 3, 4]]
         x = masked_lm_masker(inputs)
         self.assertAllEqual(x["token_ids"], [[1, 1, 1, 1], [1, 1, 1, 1]])
-        self.assertAllEqual(x["mask_positions"], [[0, 1, 2, 3], [0, 1, 2, 3]])
+        self.assertAllEqual(x["masked_positions"], [[0, 1, 2, 3], [0, 1, 2, 3]])
         self.assertAllEqual(x["mask_ids"], [[5, 3, 2, 4], [1, 2, 3, 4]])
 
     def test_unbatched(self):
@@ -84,7 +84,7 @@ class MaskedLMMaskGeneratorTest(TestCase):
         inputs = [5, 3, 2, 4]
         x = masked_lm_masker(inputs)
         self.assertAllEqual(x["token_ids"], [1, 1, 1, 1])
-        self.assertAllEqual(x["mask_positions"], [0, 1, 2, 3])
+        self.assertAllEqual(x["masked_positions"], [0, 1, 2, 3])
         self.assertAllEqual(x["mask_ids"], [5, 3, 2, 4])
 
     def test_random_replacement(self):
@@ -99,7 +99,7 @@ class MaskedLMMaskGeneratorTest(TestCase):
         inputs = [5, 3, 2, 4]
         x = masked_lm_masker(inputs)
         self.assertNotAllEqual(x["token_ids"], [1, 1, 1, 1])
-        self.assertAllEqual(x["mask_positions"], [0, 1, 2, 3])
+        self.assertAllEqual(x["masked_positions"], [0, 1, 2, 3])
         self.assertAllEqual(x["mask_ids"], [5, 3, 2, 4])
 
     def test_number_of_masked_position_as_expected(self):
@@ -116,7 +116,7 @@ class MaskedLMMaskGeneratorTest(TestCase):
             mask_selection_length=mask_selection_length,
         )
         outputs = masked_lm_masker(inputs)
-        self.assertEqual(tf.reduce_sum(outputs["mask_positions"]), 0)
+        self.assertEqual(tf.reduce_sum(outputs["masked_positions"]), 0)
 
     def test_invalid_mask_token(self):
         with self.assertRaisesRegex(ValueError, "Mask token id should be*"):

--- a/keras_nlp/models/albert/albert_masked_lm.py
+++ b/keras_nlp/models/albert/albert_masked_lm.py
@@ -83,7 +83,7 @@ class AlbertMaskedLM(Task):
     features = {
         "token_ids": np.array([[1, 2, 0, 4, 0, 6, 7, 8]] * 2),
         "padding_mask": np.array([[1, 1, 1, 1, 1, 1, 1, 1]] * 2),
-        "mask_positions": np.array([[2, 4]] * 2),
+        "masked_positions": np.array([[2, 4]] * 2),
         "segment_ids": np.array([[0, 0, 0, 0, 0, 0, 0, 0]] * 2),
     }
     # Labels are the original masked values.
@@ -100,8 +100,8 @@ class AlbertMaskedLM(Task):
     def __init__(self, backbone, preprocessor=None, **kwargs):
         inputs = {
             **backbone.input,
-            "mask_positions": keras.Input(
-                shape=(None,), dtype="int32", name="mask_positions"
+            "masked_positions": keras.Input(
+                shape=(None,), dtype="int32", name="masked_positions"
             ),
         }
 
@@ -114,7 +114,7 @@ class AlbertMaskedLM(Task):
             ),
             kernel_initializer=albert_kernel_initializer(),
             name="mlm_head",
-        )(backbone_outputs["sequence_output"], inputs["mask_positions"])
+        )(backbone_outputs["sequence_output"], inputs["masked_positions"])
 
         super().__init__(
             inputs=inputs,

--- a/keras_nlp/models/albert/albert_masked_lm_preprocessor.py
+++ b/keras_nlp/models/albert/albert_masked_lm_preprocessor.py
@@ -180,7 +180,7 @@ class AlbertMaskedLMPreprocessor(AlbertPreprocessor):
             "token_ids": masker_outputs["token_ids"],
             "segment_ids": segment_ids,
             "padding_mask": padding_mask,
-            "mask_positions": masker_outputs["mask_positions"],
+            "masked_positions": masker_outputs["masked_positions"],
         }
         y = masker_outputs["mask_ids"]
         sample_weight = masker_outputs["mask_weights"]

--- a/keras_nlp/models/albert/albert_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/albert/albert_masked_lm_preprocessor_test.py
@@ -73,7 +73,7 @@ class AlbertMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["padding_mask"], [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0]
         )
-        self.assertAllEqual(x["mask_positions"], [1, 2, 3, 4])
+        self.assertAllEqual(x["masked_positions"], [1, 2, 3, 4])
         self.assertAllEqual(y, [5, 10, 6, 8])
         self.assertAllEqual(sw, [1.0, 1.0, 1.0, 1.0])
 
@@ -87,7 +87,7 @@ class AlbertMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["padding_mask"], [[1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0]] * 4
         )
-        self.assertAllEqual(x["mask_positions"], [[1, 2, 3, 4]] * 4)
+        self.assertAllEqual(x["masked_positions"], [[1, 2, 3, 4]] * 4)
         self.assertAllEqual(y, [[5, 10, 6, 8]] * 4)
         self.assertAllEqual(sw, [[1.0, 1.0, 1.0, 1.0]] * 4)
 
@@ -102,7 +102,7 @@ class AlbertMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["padding_mask"], [[1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0]] * 4
         )
-        self.assertAllEqual(x["mask_positions"], [[1, 2, 3, 4]] * 4)
+        self.assertAllEqual(x["masked_positions"], [[1, 2, 3, 4]] * 4)
         self.assertAllEqual(y, [[5, 10, 6, 8]] * 4)
         self.assertAllEqual(sw, [[1.0, 1.0, 1.0, 1.0]] * 4)
 
@@ -117,7 +117,7 @@ class AlbertMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["padding_mask"], [1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]
         )
-        self.assertAllEqual(x["mask_positions"], [1, 2, 4, 5])
+        self.assertAllEqual(x["masked_positions"], [1, 2, 4, 5])
         self.assertAllEqual(y, [5, 10, 6, 8])
         self.assertAllEqual(sw, [1.0, 1.0, 1.0, 1.0])
 
@@ -137,7 +137,7 @@ class AlbertMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["padding_mask"], [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0]
         )
-        self.assertAllEqual(x["mask_positions"], [0, 0, 0, 0])
+        self.assertAllEqual(x["masked_positions"], [0, 0, 0, 0])
         self.assertAllEqual(y, [0, 0, 0, 0])
         self.assertAllEqual(sw, [0.0, 0.0, 0.0, 0.0])
 

--- a/keras_nlp/models/bert/bert_masked_lm.py
+++ b/keras_nlp/models/bert/bert_masked_lm.py
@@ -82,7 +82,7 @@ class BertMaskedLM(Task):
     features = {
         "token_ids": np.array([[1, 2, 0, 4, 0, 6, 7, 8]] * 2),
         "padding_mask": np.array([[1, 1, 1, 1, 1, 1, 1, 1]] * 2),
-        "mask_positions": np.array([[2, 4]] * 2),
+        "masked_positions": np.array([[2, 4]] * 2),
         "segment_ids": np.array([[0, 0, 0, 0, 0, 0, 0, 0]] * 2)
     }
     # Labels are the original masked values.
@@ -104,8 +104,8 @@ class BertMaskedLM(Task):
     ):
         inputs = {
             **backbone.input,
-            "mask_positions": keras.Input(
-                shape=(None,), dtype="int32", name="mask_positions"
+            "masked_positions": keras.Input(
+                shape=(None,), dtype="int32", name="masked_positions"
             ),
         }
         backbone_outputs = backbone(backbone.input)
@@ -115,7 +115,7 @@ class BertMaskedLM(Task):
             intermediate_activation="gelu",
             kernel_initializer=bert_kernel_initializer(),
             name="mlm_head",
-        )(backbone_outputs["sequence_output"], inputs["mask_positions"])
+        )(backbone_outputs["sequence_output"], inputs["masked_positions"])
 
         # Instantiate using Functional API Model constructor
         super().__init__(

--- a/keras_nlp/models/bert/bert_masked_lm_preprocessor.py
+++ b/keras_nlp/models/bert/bert_masked_lm_preprocessor.py
@@ -184,7 +184,7 @@ class BertMaskedLMPreprocessor(BertPreprocessor):
             "token_ids": masker_outputs["token_ids"],
             "padding_mask": padding_mask,
             "segment_ids": segment_ids,
-            "mask_positions": masker_outputs["mask_positions"],
+            "masked_positions": masker_outputs["masked_positions"],
         }
         y = masker_outputs["mask_ids"]
         sample_weight = masker_outputs["mask_weights"]

--- a/keras_nlp/models/bert/bert_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/bert/bert_masked_lm_preprocessor_test.py
@@ -55,7 +55,7 @@ class BertMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["segment_ids"], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         )
-        self.assertAllEqual(x["mask_positions"], [1, 2, 3, 4])
+        self.assertAllEqual(x["masked_positions"], [1, 2, 3, 4])
         self.assertAllEqual(y, [9, 10, 11, 12])
         self.assertAllEqual(sw, [1.0, 1.0, 1.0, 1.0])
 
@@ -70,7 +70,7 @@ class BertMaskedLMPreprocessorTest(TestCase):
             x["padding_mask"],
             [[1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0]] * 4,
         )
-        self.assertAllEqual(x["mask_positions"], [[1, 2, 3, 4]] * 4)
+        self.assertAllEqual(x["masked_positions"], [[1, 2, 3, 4]] * 4)
         self.assertAllEqual(y, [[9, 10, 11, 12]] * 4)
         self.assertAllEqual(sw, [[1.0, 1.0, 1.0, 1.0]] * 4)
 
@@ -85,7 +85,7 @@ class BertMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["padding_mask"], [[1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0]] * 4
         )
-        self.assertAllEqual(x["mask_positions"], [[1, 2, 3, 4]] * 4)
+        self.assertAllEqual(x["masked_positions"], [[1, 2, 3, 4]] * 4)
         self.assertAllEqual(y, [[9, 10, 11, 12]] * 4)
         self.assertAllEqual(sw, [[1.0, 1.0, 1.0, 1.0]] * 4)
 
@@ -100,7 +100,7 @@ class BertMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["padding_mask"], [1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]
         )
-        self.assertAllEqual(x["mask_positions"], [1, 2, 4, 5])
+        self.assertAllEqual(x["masked_positions"], [1, 2, 4, 5])
         self.assertAllEqual(y, [9, 10, 11, 12])
         self.assertAllEqual(sw, [1.0, 1.0, 1.0, 1.0])
 
@@ -121,7 +121,7 @@ class BertMaskedLMPreprocessorTest(TestCase):
             x["padding_mask"],
             [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
         )
-        self.assertAllEqual(x["mask_positions"], [0, 0, 0, 0])
+        self.assertAllEqual(x["masked_positions"], [0, 0, 0, 0])
         self.assertAllEqual(y, [0, 0, 0, 0])
         self.assertAllEqual(sw, [0.0, 0.0, 0.0, 0.0])
 

--- a/keras_nlp/models/deberta_v3/deberta_v3_masked_lm.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_masked_lm.py
@@ -86,7 +86,7 @@ class DebertaV3MaskedLM(Task):
     features = {
         "token_ids": np.array([[1, 2, 0, 4, 0, 6, 7, 8]] * 2),
         "padding_mask": np.array([[1, 1, 1, 1, 1, 1, 1, 1]] * 2),
-        "mask_positions": np.array([[2, 4]] * 2),
+        "masked_positions": np.array([[2, 4]] * 2),
     }
     # Labels are the original masked values.
     labels = [[3, 5]] * 2
@@ -107,8 +107,8 @@ class DebertaV3MaskedLM(Task):
     ):
         inputs = {
             **backbone.input,
-            "mask_positions": keras.Input(
-                shape=(None,), dtype="int32", name="mask_positions"
+            "masked_positions": keras.Input(
+                shape=(None,), dtype="int32", name="masked_positions"
             ),
         }
         backbone_outputs = backbone(backbone.input)
@@ -120,7 +120,7 @@ class DebertaV3MaskedLM(Task):
             ),
             kernel_initializer=deberta_kernel_initializer(),
             name="mlm_head",
-        )(backbone_outputs, inputs["mask_positions"])
+        )(backbone_outputs, inputs["masked_positions"])
 
         # Instantiate using Functional API Model constructor
         super().__init__(

--- a/keras_nlp/models/deberta_v3/deberta_v3_masked_lm_preprocessor.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_masked_lm_preprocessor.py
@@ -176,7 +176,7 @@ class DebertaV3MaskedLMPreprocessor(DebertaV3Preprocessor):
         x = {
             "token_ids": masker_outputs["token_ids"],
             "padding_mask": padding_mask,
-            "mask_positions": masker_outputs["mask_positions"],
+            "masked_positions": masker_outputs["masked_positions"],
         }
         y = masker_outputs["mask_ids"]
         sample_weight = masker_outputs["mask_weights"]

--- a/keras_nlp/models/deberta_v3/deberta_v3_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_masked_lm_preprocessor_test.py
@@ -69,7 +69,7 @@ class DebertaV3PreprocessorTest(TestCase):
         self.assertAllEqual(
             x["padding_mask"], [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0]
         )
-        self.assertAllEqual(x["mask_positions"], [1, 2, 3, 4])
+        self.assertAllEqual(x["masked_positions"], [1, 2, 3, 4])
         self.assertAllEqual(y, [5, 10, 6, 8])
         self.assertAllEqual(sw, [1.0, 1.0, 1.0, 1.0])
 
@@ -83,7 +83,7 @@ class DebertaV3PreprocessorTest(TestCase):
         self.assertAllEqual(
             x["padding_mask"], [[1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0]] * 4
         )
-        self.assertAllEqual(x["mask_positions"], [[1, 2, 3, 4]] * 4)
+        self.assertAllEqual(x["masked_positions"], [[1, 2, 3, 4]] * 4)
         self.assertAllEqual(y, [[5, 10, 6, 8]] * 4)
         self.assertAllEqual(sw, [[1.0, 1.0, 1.0, 1.0]] * 4)
 
@@ -98,7 +98,7 @@ class DebertaV3PreprocessorTest(TestCase):
         self.assertAllEqual(
             x["padding_mask"], [[1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0]] * 4
         )
-        self.assertAllEqual(x["mask_positions"], [[1, 2, 3, 4]] * 4)
+        self.assertAllEqual(x["masked_positions"], [[1, 2, 3, 4]] * 4)
         self.assertAllEqual(y, [[5, 10, 6, 8]] * 4)
         self.assertAllEqual(sw, [[1.0, 1.0, 1.0, 1.0]] * 4)
 
@@ -113,7 +113,7 @@ class DebertaV3PreprocessorTest(TestCase):
         self.assertAllEqual(
             x["padding_mask"], [1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]
         )
-        self.assertAllEqual(x["mask_positions"], [1, 2, 4, 5])
+        self.assertAllEqual(x["masked_positions"], [1, 2, 4, 5])
         self.assertAllEqual(y, [5, 10, 6, 8])
         self.assertAllEqual(sw, [1.0, 1.0, 1.0, 1.0])
 
@@ -133,7 +133,7 @@ class DebertaV3PreprocessorTest(TestCase):
         self.assertAllEqual(
             x["padding_mask"], [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0]
         )
-        self.assertAllEqual(x["mask_positions"], [0, 0, 0, 0])
+        self.assertAllEqual(x["masked_positions"], [0, 0, 0, 0])
         self.assertAllEqual(y, [0, 0, 0, 0])
         self.assertAllEqual(sw, [0.0, 0.0, 0.0, 0.0])
 

--- a/keras_nlp/models/distil_bert/distil_bert_backbone_test.py
+++ b/keras_nlp/models/distil_bert/distil_bert_backbone_test.py
@@ -56,7 +56,7 @@ class DistilBertTest(TestCase):
         for seq_length in (2, 3, 4):
             input_data = {
                 "token_ids": np.ones((2, seq_length), dtype="int32"),
-                "mask_positions": np.ones((2, seq_length), dtype="int32"),
+                "masked_positions": np.ones((2, seq_length), dtype="int32"),
                 "padding_mask": np.ones((2, seq_length), dtype="int32"),
             }
             self.backbone(input_data)

--- a/keras_nlp/models/distil_bert/distil_bert_masked_lm.py
+++ b/keras_nlp/models/distil_bert/distil_bert_masked_lm.py
@@ -86,7 +86,7 @@ class DistilBertMaskedLM(Task):
     features = {
         "token_ids": np.array([[1, 2, 0, 4, 0, 6, 7, 8]] * 2),
         "padding_mask": np.array([[1, 1, 1, 1, 1, 1, 1, 1]] * 2),
-        "mask_positions": np.array([[2, 4]] * 2)
+        "masked_positions": np.array([[2, 4]] * 2)
     }
     # Labels are the original masked values.
     labels = [[3, 5]] * 2
@@ -107,8 +107,8 @@ class DistilBertMaskedLM(Task):
     ):
         inputs = {
             **backbone.input,
-            "mask_positions": keras.Input(
-                shape=(None,), dtype="int32", name="mask_positions"
+            "masked_positions": keras.Input(
+                shape=(None,), dtype="int32", name="masked_positions"
             ),
         }
         backbone_outputs = backbone(backbone.input)
@@ -118,7 +118,7 @@ class DistilBertMaskedLM(Task):
             intermediate_activation="gelu",
             kernel_initializer=distilbert_kernel_initializer(),
             name="mlm_head",
-        )(backbone_outputs, inputs["mask_positions"])
+        )(backbone_outputs, inputs["masked_positions"])
 
         # Instantiate using Functional API Model constructor
         super().__init__(

--- a/keras_nlp/models/distil_bert/distil_bert_masked_lm_preprocessor.py
+++ b/keras_nlp/models/distil_bert/distil_bert_masked_lm_preprocessor.py
@@ -180,7 +180,7 @@ class DistilBertMaskedLMPreprocessor(DistilBertPreprocessor):
         x = {
             "token_ids": masker_outputs["token_ids"],
             "padding_mask": padding_mask,
-            "mask_positions": masker_outputs["mask_positions"],
+            "masked_positions": masker_outputs["masked_positions"],
         }
         y = masker_outputs["mask_ids"]
         sample_weight = masker_outputs["mask_weights"]

--- a/keras_nlp/models/distil_bert/distil_bert_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/distil_bert/distil_bert_masked_lm_preprocessor_test.py
@@ -50,7 +50,7 @@ class DistilBertMaskedLMPreprocessorTest(TestCase):
         x, y, sw = self.preprocessor(input_data)
         self.assertAllEqual(x["token_ids"], [2, 4, 4, 4, 4, 4, 3, 0])
         self.assertAllEqual(x["padding_mask"], [1, 1, 1, 1, 1, 1, 1, 0])
-        self.assertAllEqual(x["mask_positions"], [1, 2, 3, 4, 5])
+        self.assertAllEqual(x["masked_positions"], [1, 2, 3, 4, 5])
         self.assertAllEqual(y, [5, 6, 7, 8, 1])
         self.assertAllEqual(sw, [1.0, 1.0, 1.0, 1.0, 1.0])
 
@@ -60,7 +60,7 @@ class DistilBertMaskedLMPreprocessorTest(TestCase):
         x, y, sw = self.preprocessor(input_data)
         self.assertAllEqual(x["token_ids"], [[2, 4, 4, 4, 4, 4, 3, 0]] * 4)
         self.assertAllEqual(x["padding_mask"], [[1, 1, 1, 1, 1, 1, 1, 0]] * 4)
-        self.assertAllEqual(x["mask_positions"], [[1, 2, 3, 4, 5]] * 4)
+        self.assertAllEqual(x["masked_positions"], [[1, 2, 3, 4, 5]] * 4)
         self.assertAllEqual(y, [[5, 6, 7, 8, 1]] * 4)
         self.assertAllEqual(sw, [[1.0, 1.0, 1.0, 1.0, 1.0]] * 4)
 
@@ -71,7 +71,7 @@ class DistilBertMaskedLMPreprocessorTest(TestCase):
         x, y, sw = ds.batch(4).take(1).get_single_element()
         self.assertAllEqual(x["token_ids"], [[2, 4, 4, 4, 4, 4, 3, 0]] * 4)
         self.assertAllEqual(x["padding_mask"], [[1, 1, 1, 1, 1, 1, 1, 0]] * 4)
-        self.assertAllEqual(x["mask_positions"], [[1, 2, 3, 4, 5]] * 4)
+        self.assertAllEqual(x["masked_positions"], [[1, 2, 3, 4, 5]] * 4)
         self.assertAllEqual(y, [[5, 6, 7, 8, 1]] * 4)
         self.assertAllEqual(sw, [[1.0, 1.0, 1.0, 1.0, 1.0]] * 4)
 
@@ -82,7 +82,7 @@ class DistilBertMaskedLMPreprocessorTest(TestCase):
         x, y, sw = self.preprocessor((sentence_one, sentence_two))
         self.assertAllEqual(x["token_ids"], [2, 4, 4, 3, 4, 4, 4, 3])
         self.assertAllEqual(x["padding_mask"], [1, 1, 1, 1, 1, 1, 1, 1])
-        self.assertAllEqual(x["mask_positions"], [1, 2, 4, 5, 6])
+        self.assertAllEqual(x["masked_positions"], [1, 2, 4, 5, 6])
         self.assertAllEqual(y, [5, 6, 7, 8, 1])
         self.assertAllEqual(sw, [1.0, 1.0, 1.0, 1.0, 1.0])
 
@@ -98,7 +98,7 @@ class DistilBertMaskedLMPreprocessorTest(TestCase):
         x, y, sw = no_mask_preprocessor(input_data)
         self.assertAllEqual(x["token_ids"], [2, 5, 6, 7, 8, 1, 3, 0])
         self.assertAllEqual(x["padding_mask"], [1, 1, 1, 1, 1, 1, 1, 0])
-        self.assertAllEqual(x["mask_positions"], [0, 0, 0, 0, 0])
+        self.assertAllEqual(x["masked_positions"], [0, 0, 0, 0, 0])
         self.assertAllEqual(y, [0, 0, 0, 0, 0])
         self.assertAllEqual(sw, [0.0, 0.0, 0.0, 0.0, 0.0])
 

--- a/keras_nlp/models/f_net/f_net_masked_lm.py
+++ b/keras_nlp/models/f_net/f_net_masked_lm.py
@@ -81,7 +81,7 @@ class FNetMaskedLM(Task):
     features = {
         "token_ids": np.array([[1, 2, 0, 4, 0, 6, 7, 8]] * 2),
         "segment_ids": np.array([[0, 0, 0, 1, 1, 1, 0, 0]] * 2),
-        "mask_positions": np.array([[2, 4]] * 2)
+        "masked_positions": np.array([[2, 4]] * 2)
     }
     # Labels are the original masked values.
     labels = [[3, 5]] * 2
@@ -102,8 +102,8 @@ class FNetMaskedLM(Task):
     ):
         inputs = {
             **backbone.input,
-            "mask_positions": keras.Input(
-                shape=(None,), dtype="int32", name="mask_positions"
+            "masked_positions": keras.Input(
+                shape=(None,), dtype="int32", name="masked_positions"
             ),
         }
         backbone_outputs = backbone(backbone.input)
@@ -113,7 +113,7 @@ class FNetMaskedLM(Task):
             intermediate_activation="gelu",
             kernel_initializer=f_net_kernel_initializer(),
             name="mlm_head",
-        )(backbone_outputs["sequence_output"], inputs["mask_positions"])
+        )(backbone_outputs["sequence_output"], inputs["masked_positions"])
 
         # Instantiate using Functional API Model constructor
         super().__init__(

--- a/keras_nlp/models/f_net/f_net_masked_lm_preprocessor.py
+++ b/keras_nlp/models/f_net/f_net_masked_lm_preprocessor.py
@@ -179,7 +179,7 @@ class FNetMaskedLMPreprocessor(FNetPreprocessor):
         x = {
             "token_ids": masker_outputs["token_ids"],
             "segment_ids": segment_ids,
-            "mask_positions": masker_outputs["mask_positions"],
+            "masked_positions": masker_outputs["masked_positions"],
         }
         y = masker_outputs["mask_ids"]
         sample_weight = masker_outputs["mask_weights"]

--- a/keras_nlp/models/f_net/f_net_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/f_net/f_net_masked_lm_preprocessor_test.py
@@ -63,7 +63,7 @@ class FNetMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["token_ids"], [1, 4, 4, 4, 4, 2, 0, 0, 0, 0, 0, 0]
         )
-        self.assertAllEqual(x["mask_positions"], [1, 2, 3, 4])
+        self.assertAllEqual(x["masked_positions"], [1, 2, 3, 4])
         self.assertAllEqual(y, [5, 10, 6, 8])
         self.assertAllEqual(sw, [1.0, 1.0, 1.0, 1.0])
 
@@ -74,7 +74,7 @@ class FNetMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["token_ids"], [[1, 4, 4, 4, 4, 2, 0, 0, 0, 0, 0, 0]] * 4
         )
-        self.assertAllEqual(x["mask_positions"], [[1, 2, 3, 4]] * 4)
+        self.assertAllEqual(x["masked_positions"], [[1, 2, 3, 4]] * 4)
         self.assertAllEqual(y, [[5, 10, 6, 8]] * 4)
         self.assertAllEqual(sw, [[1.0, 1.0, 1.0, 1.0]] * 4)
 
@@ -86,7 +86,7 @@ class FNetMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["token_ids"], [[1, 4, 4, 4, 4, 2, 0, 0, 0, 0, 0, 0]] * 4
         )
-        self.assertAllEqual(x["mask_positions"], [[1, 2, 3, 4]] * 4)
+        self.assertAllEqual(x["masked_positions"], [[1, 2, 3, 4]] * 4)
         self.assertAllEqual(y, [[5, 10, 6, 8]] * 4)
         self.assertAllEqual(sw, [[1.0, 1.0, 1.0, 1.0]] * 4)
 
@@ -98,7 +98,7 @@ class FNetMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["token_ids"], [1, 4, 4, 2, 4, 4, 2, 0, 0, 0, 0, 0]
         )
-        self.assertAllEqual(x["mask_positions"], [1, 2, 4, 5])
+        self.assertAllEqual(x["masked_positions"], [1, 2, 4, 5])
         self.assertAllEqual(y, [5, 10, 6, 8])
         self.assertAllEqual(sw, [1.0, 1.0, 1.0, 1.0])
 
@@ -115,7 +115,7 @@ class FNetMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["token_ids"], [1, 5, 10, 6, 8, 2, 0, 0, 0, 0, 0, 0]
         )
-        self.assertAllEqual(x["mask_positions"], [0, 0, 0, 0])
+        self.assertAllEqual(x["masked_positions"], [0, 0, 0, 0])
         self.assertAllEqual(y, [0, 0, 0, 0])
         self.assertAllEqual(sw, [0.0, 0.0, 0.0, 0.0])
 

--- a/keras_nlp/models/roberta/roberta_masked_lm.py
+++ b/keras_nlp/models/roberta/roberta_masked_lm.py
@@ -84,7 +84,7 @@ class RobertaMaskedLM(Task):
     features = {
         "token_ids": np.array([[1, 2, 0, 4, 0, 6, 7, 8]] * 2),
         "padding_mask": np.array([[1, 1, 1, 1, 1, 1, 1, 1]] * 2),
-        "mask_positions": np.array([[2, 4]] * 2)
+        "masked_positions": np.array([[2, 4]] * 2)
     }
     # Labels are the original masked values.
     labels = [[3, 5]] * 2
@@ -106,8 +106,8 @@ class RobertaMaskedLM(Task):
     ):
         inputs = {
             **backbone.input,
-            "mask_positions": keras.Input(
-                shape=(None,), dtype="int32", name="mask_positions"
+            "masked_positions": keras.Input(
+                shape=(None,), dtype="int32", name="masked_positions"
             ),
         }
         backbone_outputs = backbone(backbone.input)
@@ -117,7 +117,7 @@ class RobertaMaskedLM(Task):
             intermediate_activation="gelu",
             kernel_initializer=roberta_kernel_initializer(),
             name="mlm_head",
-        )(backbone_outputs, inputs["mask_positions"])
+        )(backbone_outputs, inputs["masked_positions"])
 
         # Instantiate using Functional API Model constructor
         super().__init__(

--- a/keras_nlp/models/roberta/roberta_masked_lm_preprocessor.py
+++ b/keras_nlp/models/roberta/roberta_masked_lm_preprocessor.py
@@ -181,7 +181,7 @@ class RobertaMaskedLMPreprocessor(RobertaPreprocessor):
         x = {
             "token_ids": masker_outputs["token_ids"],
             "padding_mask": padding_mask,
-            "mask_positions": masker_outputs["mask_positions"],
+            "masked_positions": masker_outputs["masked_positions"],
         }
         y = masker_outputs["mask_ids"]
         sample_weight = masker_outputs["mask_weights"]

--- a/keras_nlp/models/roberta/roberta_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/roberta/roberta_masked_lm_preprocessor_test.py
@@ -70,7 +70,7 @@ class RobertaMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["padding_mask"], [1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]
         )
-        self.assertAllEqual(x["mask_positions"], [1, 2, 3, 4, 5])
+        self.assertAllEqual(x["masked_positions"], [1, 2, 3, 4, 5])
         self.assertAllEqual(y, [3, 4, 5, 3, 6])
         self.assertAllEqual(sw, [1.0, 1.0, 1.0, 1.0, 1.0])
 
@@ -84,7 +84,7 @@ class RobertaMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["padding_mask"], [[1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]] * 4
         )
-        self.assertAllEqual(x["mask_positions"], [[1, 2, 3, 4, 5]] * 4)
+        self.assertAllEqual(x["masked_positions"], [[1, 2, 3, 4, 5]] * 4)
         self.assertAllEqual(y, [[3, 4, 5, 3, 6]] * 4)
         self.assertAllEqual(sw, [[1.0, 1.0, 1.0, 1.0, 1.0]] * 4)
 
@@ -99,7 +99,7 @@ class RobertaMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["padding_mask"], [[1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]] * 4
         )
-        self.assertAllEqual(x["mask_positions"], [[1, 2, 3, 4, 5]] * 4)
+        self.assertAllEqual(x["masked_positions"], [[1, 2, 3, 4, 5]] * 4)
         self.assertAllEqual(y, [[3, 4, 5, 3, 6]] * 4)
         self.assertAllEqual(sw, [[1.0, 1.0, 1.0, 1.0, 1.0]] * 4)
 
@@ -114,7 +114,7 @@ class RobertaMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["padding_mask"], [1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0]
         )
-        self.assertAllEqual(x["mask_positions"], [1, 2, 5, 6, 0])
+        self.assertAllEqual(x["masked_positions"], [1, 2, 5, 6, 0])
         self.assertAllEqual(y, [3, 4, 7, 8, 0])
         self.assertAllEqual(sw, [1.0, 1.0, 1.0, 1.0, 0.0])
 
@@ -134,7 +134,7 @@ class RobertaMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["padding_mask"], [1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]
         )
-        self.assertAllEqual(x["mask_positions"], [0, 0, 0, 0, 0])
+        self.assertAllEqual(x["masked_positions"], [0, 0, 0, 0, 0])
         self.assertAllEqual(y, [0, 0, 0, 0, 0])
         self.assertAllEqual(sw, [0.0, 0.0, 0.0, 0.0, 0.0])
 

--- a/keras_nlp/models/roberta/roberta_presets_test.py
+++ b/keras_nlp/models/roberta/roberta_presets_test.py
@@ -114,7 +114,7 @@ class RobertaPresetSmokeTest(TestCase):
         input_data = {
             "token_ids": ops.array([[101, 1996, 4248, 102]]),
             "padding_mask": ops.array([[1, 1, 1, 1]]),
-            "mask_positions": ops.array([[0, 0]]),
+            "masked_positions": ops.array([[0, 0]]),
         }
         model = RobertaMaskedLM.from_preset(
             "roberta_base_en",
@@ -235,7 +235,7 @@ class RobertaPresetFullTest(TestCase):
                     maxval=classifier.backbone.vocabulary_size,
                 ),
                 "padding_mask": ops.array([1] * 512, shape=(1, 512)),
-                "mask_positions": ops.array([1] * 128, shape=(1, 128)),
+                "masked_positions": ops.array([1] * 128, shape=(1, 128)),
             }
             classifier.predict(input_data)
 

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_masked_lm.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_masked_lm.py
@@ -87,7 +87,7 @@ class XLMRobertaMaskedLM(Task):
     features = {
         "token_ids": np.array([[1, 2, 0, 4, 0, 6, 7, 8]] * 2),
         "padding_mask": np.array([[1, 1, 1, 1, 1, 1, 1, 1]] * 2),
-        "mask_positions": np.array([[2, 4]] * 2)
+        "masked_positions": np.array([[2, 4]] * 2)
     }
     # Labels are the original masked values.
     labels = [[3, 5]] * 2
@@ -109,8 +109,8 @@ class XLMRobertaMaskedLM(Task):
     ):
         inputs = {
             **backbone.input,
-            "mask_positions": keras.Input(
-                shape=(None,), dtype="int32", name="mask_positions"
+            "masked_positions": keras.Input(
+                shape=(None,), dtype="int32", name="masked_positions"
             ),
         }
         backbone_outputs = backbone(backbone.input)
@@ -120,7 +120,7 @@ class XLMRobertaMaskedLM(Task):
             intermediate_activation="gelu",
             kernel_initializer=roberta_kernel_initializer(),
             name="mlm_head",
-        )(backbone_outputs, inputs["mask_positions"])
+        )(backbone_outputs, inputs["masked_positions"])
 
         # Instantiate using Functional API Model constructor.
         super().__init__(

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_masked_lm_preprocessor.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_masked_lm_preprocessor.py
@@ -181,7 +181,7 @@ class XLMRobertaMaskedLMPreprocessor(XLMRobertaPreprocessor):
         x = {
             "token_ids": masker_outputs["token_ids"],
             "padding_mask": padding_mask,
-            "mask_positions": masker_outputs["mask_positions"],
+            "masked_positions": masker_outputs["masked_positions"],
         }
         y = masker_outputs["mask_ids"]
         sample_weight = masker_outputs["mask_weights"]

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_masked_lm_preprocessor_test.py
@@ -72,7 +72,7 @@ class XLMRobertaMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["padding_mask"], [1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0]
         )
-        self.assertAllEqual(x["mask_positions"], [1, 2, 3, 0, 0])
+        self.assertAllEqual(x["masked_positions"], [1, 2, 3, 0, 0])
         self.assertAllEqual(y, [7, 9, 11, 0, 0])
         self.assertAllEqual(sw, [1.0, 1.0, 1.0, 0.0, 0.0])
 
@@ -86,7 +86,7 @@ class XLMRobertaMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["padding_mask"], [[1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0]] * 13
         )
-        self.assertAllEqual(x["mask_positions"], [[1, 2, 3, 0, 0]] * 13)
+        self.assertAllEqual(x["masked_positions"], [[1, 2, 3, 0, 0]] * 13)
         self.assertAllEqual(y, [[7, 9, 11, 0, 0]] * 13)
         self.assertAllEqual(sw, [[1.0, 1.0, 1.0, 0.0, 0.0]] * 13)
 
@@ -101,7 +101,7 @@ class XLMRobertaMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["padding_mask"], [[1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0]] * 13
         )
-        self.assertAllEqual(x["mask_positions"], [[1, 2, 3, 0, 0]] * 13)
+        self.assertAllEqual(x["masked_positions"], [[1, 2, 3, 0, 0]] * 13)
         self.assertAllEqual(y, [[7, 9, 11, 0, 0]] * 13)
         self.assertAllEqual(sw, [[1.0, 1.0, 1.0, 0.0, 0.0]] * 13)
 
@@ -116,7 +116,7 @@ class XLMRobertaMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["padding_mask"], [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0]
         )
-        self.assertAllEqual(x["mask_positions"], [4, 0, 0, 0, 0])
+        self.assertAllEqual(x["masked_positions"], [4, 0, 0, 0, 0])
         self.assertAllEqual(y, [12, 0, 0, 0, 0])
         self.assertAllEqual(sw, [1.0, 0.0, 0.0, 0.0, 0.0])
 
@@ -136,7 +136,7 @@ class XLMRobertaMaskedLMPreprocessorTest(TestCase):
         self.assertAllEqual(
             x["padding_mask"], [1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0]
         )
-        self.assertAllEqual(x["mask_positions"], [0, 0, 0, 0, 0])
+        self.assertAllEqual(x["masked_positions"], [0, 0, 0, 0, 0])
         self.assertAllEqual(y, [0, 0, 0, 0, 0])
         self.assertAllEqual(sw, [0.0, 0.0, 0.0, 0.0, 0.0])
 


### PR DESCRIPTION
This is a minor breaking change for keras-core, as keras core treats any call argument that looks like `mask_xx` as an explicit argument for a implicit keras mask attached to the `xx` argument.

This is not our case, there is no argument named positions, nor is this an actual mask, it is a list of indices that were modified during preprocessing.