### PR TITLE
Port metrics to multi-backend

### DIFF
--- a/keras_nlp/metrics/bleu_test.py
+++ b/keras_nlp/metrics/bleu_test.py
@@ -22,7 +22,6 @@ from keras_nlp.tests.test_case import TestCase
 from keras_nlp.tokenizers.byte_tokenizer import ByteTokenizer
 
 
-@pytest.mark.tf_only
 class BleuTest(TestCase):
     def test_initialization(self):
         bleu = Bleu()
@@ -69,64 +68,38 @@ class BleuTest(TestCase):
         bleu_val = bleu(y_true, y_pred)
         self.assertAlmostEqual(bleu_val, 0.243, delta=1e-3)
 
-    def test_1d_tensor_input(self):
-        bleu = Bleu()
-        y_true = tf.ragged.constant(
-            [
-                ["He eats a sweet apple."],
-                ["Silicon Valley is one of my favourite shows!"],
-            ]
-        )
-        y_pred = tf.constant(
-            [
-                "He He He eats sweet apple which is a fruit.",
-                "I love Silicon Valley, it's one of my favourite shows.",
-            ]
-        )
-
-        bleu_val = bleu(y_true, y_pred)
-        self.assertAlmostEqual(bleu_val, 0.243, delta=1e-3)
-
-    def test_2d_tensor_input(self):
-        bleu = Bleu()
-        y_true = tf.constant(
-            [
-                [["He eats a sweet apple."]],
-                [["Silicon Valley is one of my favourite shows!"]],
-            ]
-        )
-        y_pred = tf.constant(
-            [
-                ["He He He eats sweet apple which is a fruit."],
-                ["I love Silicon Valley, it's one of my favourite shows."],
-            ]
-        )
-
-        bleu_val = bleu(y_true, y_pred)
-        self.assertAlmostEqual(bleu_val, 0.243, delta=1e-3)
-
     def test_custom_tokenizer(self):
         byte_tokenizer = ByteTokenizer()
         bleu = Bleu(tokenizer=byte_tokenizer)
-        y_true = tf.ragged.constant(
-            [
-                ["He eats a sweet apple."],
-                ["Silicon Valley is one of my favourite shows!"],
-            ]
-        )
-        y_pred = tf.constant(
-            [
-                "He He He eats sweet apple which is a fruit.",
-                "I love Silicon Valley, it's one of my favourite shows.",
-            ]
-        )
+        y_true = [
+            ["He eats a sweet apple."],
+            ["Silicon Valley is one of my favourite shows!"],
+        ]
+        y_pred = [
+            "He He He eats sweet apple which is a fruit.",
+            "I love Silicon Valley, it's one of my favourite shows.",
+        ]
 
         bleu_val = bleu(y_true, y_pred)
         self.assertAlmostEqual(bleu_val, 0.609, delta=1e-3)
 
     def test_different_order(self):
         bleu = Bleu(max_order=5)
-        y_true = tf.ragged.constant(
+        y_true = [
+            ["He eats a sweet apple."],
+            ["Silicon Valley is one of my favourite shows!"],
+        ]
+        y_pred = [
+            "He He He eats sweet apple which is a fruit.",
+            "I love Silicon Valley, it's one of my favourite shows.",
+        ]
+
+        bleu_val = bleu(y_true, y_pred)
+        self.assertAlmostEqual(bleu_val, 0.188, delta=1e-3)
+
+    def test_tensor_input(self):
+        bleu = Bleu()
+        y_true = tf.constant(
             [
                 ["He eats a sweet apple."],
                 ["Silicon Valley is one of my favourite shows!"],
@@ -140,8 +113,9 @@ class BleuTest(TestCase):
         )
 
         bleu_val = bleu(y_true, y_pred)
-        self.assertAlmostEqual(bleu_val, 0.188, delta=1e-3)
+        self.assertAlmostEqual(bleu_val, 0.243, delta=1e-3)
 
+    @pytest.mark.tf_only  # string model output only applies to tf.
     def test_model_compile(self):
         inputs = keras.Input(shape=(), dtype="string")
         outputs = keras.layers.Identity()(inputs)
@@ -166,18 +140,14 @@ class BleuTest(TestCase):
 
     def test_reset_state(self):
         bleu = Bleu()
-        y_true = tf.ragged.constant(
-            [
-                ["He eats a sweet apple."],
-                ["Silicon Valley is one of my favourite shows!"],
-            ]
-        )
-        y_pred = tf.constant(
-            [
-                "He He He eats sweet apple which is a fruit.",
-                "I love Silicon Valley, it's one of my favourite shows.",
-            ]
-        )
+        y_true = [
+            ["He eats a sweet apple."],
+            ["Silicon Valley is one of my favourite shows!"],
+        ]
+        y_pred = [
+            "He He He eats sweet apple which is a fruit.",
+            "I love Silicon Valley, it's one of my favourite shows.",
+        ]
 
         bleu.update_state(y_true, y_pred)
         bleu_val = bleu.result()
@@ -189,25 +159,21 @@ class BleuTest(TestCase):
 
     def test_update_state(self):
         bleu = Bleu()
-        y_true_1 = tf.ragged.constant(
-            [
-                ["He eats a sweet apple."],
-                ["Silicon Valley is one of my favourite shows!"],
-            ]
-        )
-        y_pred_1 = tf.constant(
-            [
-                "He He He eats sweet apple which is a fruit.",
-                "I love Silicon Valley, it's one of my favourite shows.",
-            ]
-        )
+        y_true_1 = [
+            ["He eats a sweet apple."],
+            ["Silicon Valley is one of my favourite shows!"],
+        ]
+        y_pred_1 = [
+            "He He He eats sweet apple which is a fruit.",
+            "I love Silicon Valley, it's one of my favourite shows.",
+        ]
 
         bleu.update_state(y_true_1, y_pred_1)
         bleu_val = bleu.result()
         self.assertAlmostEqual(bleu_val, 0.243, delta=1e-3)
 
-        y_true_2 = tf.constant(["Virat Kohli is the GOAT."])
-        y_pred_2 = tf.constant("Virat Kohli is the greatest of all time!")
+        y_true_2 = ["Virat Kohli is the GOAT."]
+        y_pred_2 = "Virat Kohli is the greatest of all time!"
 
         bleu.update_state(y_true_2, y_pred_2)
         bleu_val = bleu.result()

--- a/keras_nlp/metrics/edit_distance.py
+++ b/keras_nlp/metrics/edit_distance.py
@@ -18,7 +18,6 @@ import tensorflow as tf
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.backend import keras
-from keras_nlp.utils.tensor_utils import assert_tf_backend
 from keras_nlp.utils.tensor_utils import is_floating_dtype
 
 
@@ -67,13 +66,6 @@ class EditDistance(keras.metrics.Metric):
     >>> edit_distance(y_true, y_pred)
     <tf.Tensor: shape=(), dtype=float32, numpy=0.36363637>
 
-    Rank 1 tensor.
-    >>> edit_distance = keras_nlp.metrics.EditDistance()
-    >>> y_true = tf.strings.split("the tiny little cat was found under the big funny bed")
-    >>> y_pred = tf.strings.split("the cat was found under the bed")
-    >>> edit_distance(y_true, y_pred)
-    <tf.Tensor: shape=(), dtype=float32, numpy=0.36363637>
-
     Nested Python list.
     >>> edit_distance = keras_nlp.metrics.EditDistance()
     >>> y_true = [
@@ -86,19 +78,6 @@ class EditDistance(keras.metrics.Metric):
     ... ]
     >>> edit_distance(y_true, y_pred)
     <tf.Tensor: shape=(), dtype=float32, numpy=0.73333335>
-
-    Rank 2 tensor.
-    >>> edit_distance = keras_nlp.metrics.EditDistance()
-    >>> y_true = tf.strings.split([
-    ...     "the tiny little cat was found under the big funny bed",
-    ...     "it is sunny today",
-    ... ])
-    >>> y_pred = tf.strings.split([
-    ...     "the cat was found under the bed",
-    ...     "it is sunny but with a hint of cloud cover",
-    ... ])
-    >>> edit_distance(y_true, y_pred)
-    <tf.Tensor: shape=(), dtype=float32, numpy=0.73333335>
     """
 
     def __init__(
@@ -108,8 +87,6 @@ class EditDistance(keras.metrics.Metric):
         name="edit_distance",
         **kwargs,
     ):
-        assert_tf_backend(self.__class__.__name__)
-
         super().__init__(name=name, dtype=dtype, **kwargs)
 
         if not is_floating_dtype(dtype):

--- a/keras_nlp/metrics/edit_distance_test.py
+++ b/keras_nlp/metrics/edit_distance_test.py
@@ -21,7 +21,6 @@ from keras_nlp.metrics.edit_distance import EditDistance
 from keras_nlp.tests.test_case import TestCase
 
 
-@pytest.mark.tf_only
 class EditDistanceTest(TestCase):
     def test_initialization(self):
         edit_distance = EditDistance()
@@ -51,17 +50,29 @@ class EditDistanceTest(TestCase):
         edit_distance_val = edit_distance(y_true, y_pred)
         self.assertAlmostEqual(edit_distance_val, 0.733, delta=1e-3)
 
-    def test_rank_1_tensor_input_normalize(self):
-        edit_distance = EditDistance()
-        y_true = tf.strings.split(
-            "the tiny little cat was found under the big funny bed"
-        )
-        y_pred = tf.strings.split("the cat was found under the bed")
+    def test_1d_list_input_normalize_false(self):
+        edit_distance = EditDistance(normalize=False)
+        y_true = "the tiny little cat was found under the big funny bed".split()
+        y_pred = "the cat was found under the bed".split()
 
         edit_distance_val = edit_distance(y_true, y_pred)
-        self.assertAlmostEqual(edit_distance_val, 0.364, delta=1e-3)
+        self.assertAlmostEqual(edit_distance_val, 4.0, delta=1e-3)
 
-    def test_rank_2_tensor_input_normalize(self):
+    def test_2d_list_input_normalize_false(self):
+        edit_distance = EditDistance(normalize=False)
+        y_true = [
+            "the tiny little cat was found under the big funny bed".split(),
+            "it is sunny today".split(),
+        ]
+        y_pred = [
+            "the cat was found under the bed".split(),
+            "it is sunny but with a hint of cloud cover".split(),
+        ]
+
+        edit_distance_val = edit_distance(y_true, y_pred)
+        self.assertAlmostEqual(edit_distance_val, 5.5, delta=1e-3)
+
+    def test_tensor_input(self):
         edit_distance = EditDistance()
         y_true = tf.strings.split(
             [
@@ -79,34 +90,7 @@ class EditDistanceTest(TestCase):
         edit_distance_val = edit_distance(y_true, y_pred)
         self.assertAlmostEqual(edit_distance_val, 0.733, delta=1e-3)
 
-    def test_rank_1_tensor_input_normalize_false(self):
-        edit_distance = EditDistance(normalize=False)
-        y_true = tf.strings.split(
-            "the tiny little cat was found under the big funny bed"
-        )
-        y_pred = tf.strings.split("the cat was found under the bed")
-
-        edit_distance_val = edit_distance(y_true, y_pred)
-        self.assertAlmostEqual(edit_distance_val, 4.0, delta=1e-3)
-
-    def test_rank_2_tensor_input_normalize_false(self):
-        edit_distance = EditDistance(normalize=False)
-        y_true = tf.strings.split(
-            [
-                "the tiny little cat was found under the big funny bed",
-                "it is sunny today",
-            ]
-        )
-        y_pred = tf.strings.split(
-            [
-                "the cat was found under the bed",
-                "it is sunny but with a hint of cloud cover",
-            ]
-        )
-
-        edit_distance_val = edit_distance(y_true, y_pred)
-        self.assertAlmostEqual(edit_distance_val, 5.5, delta=1e-3)
-
+    @pytest.mark.tf_only  # string model output only applies to tf.
     def test_model_compile_normalize(self):
         inputs = keras.Input(shape=(None,), dtype="string")
         outputs = keras.layers.Identity()(inputs)
@@ -122,6 +106,7 @@ class EditDistanceTest(TestCase):
         output = model.compute_metrics(x, y, y_pred, sample_weight=None)
         self.assertAlmostEqual(output["edit_distance"], 0.364, delta=1e-3)
 
+    @pytest.mark.tf_only  # string model output only applies to tf.
     def test_model_compile_normalize_false(self):
         inputs = keras.Input(shape=(None,), dtype="string")
         outputs = keras.layers.Identity()(inputs)
@@ -137,20 +122,26 @@ class EditDistanceTest(TestCase):
         output = model.compute_metrics(x, y, y_pred, sample_weight=None)
         self.assertAlmostEqual(output["edit_distance"], 4.0, delta=1e-3)
 
-    def test_reset_state_normalize(self):
+    def test_rank_1_tensor_input_normalize(self):
         edit_distance = EditDistance()
         y_true = tf.strings.split(
-            [
-                "the tiny little cat was found under the big funny bed",
-                "it is sunny today",
-            ]
+            "the tiny little cat was found under the big funny bed"
         )
-        y_pred = tf.strings.split(
-            [
-                "the cat was found under the bed",
-                "it is sunny but with a hint of cloud cover",
-            ]
-        )
+        y_pred = tf.strings.split("the cat was found under the bed")
+
+        edit_distance_val = edit_distance(y_true, y_pred)
+        self.assertAlmostEqual(edit_distance_val, 0.364, delta=1e-3)
+
+    def test_reset_state_normalize(self):
+        edit_distance = EditDistance()
+        y_true = [
+            "the tiny little cat was found under the big funny bed".split(),
+            "it is sunny today".split(),
+        ]
+        y_pred = [
+            "the cat was found under the bed".split(),
+            "it is sunny but with a hint of cloud cover".split(),
+        ]
 
         edit_distance.update_state(y_true, y_pred)
         edit_distance_val = edit_distance.result()
@@ -162,18 +153,14 @@ class EditDistanceTest(TestCase):
 
     def test_update_state_normalize(self):
         edit_distance = EditDistance()
-        y_true_1 = tf.strings.split(
-            [
-                "the tiny little cat was found under the big funny bed",
-                "it is sunny today",
-            ]
-        )
-        y_pred_1 = tf.strings.split(
-            [
-                "the cat was found under the bed",
-                "it is sunny but with a hint of cloud cover",
-            ]
-        )
+        y_true_1 = [
+            "the tiny little cat was found under the big funny bed".split(),
+            "it is sunny today".split(),
+        ]
+        y_pred_1 = [
+            "the cat was found under the bed".split(),
+            "it is sunny but with a hint of cloud cover".split(),
+        ]
 
         edit_distance.update_state(y_true_1, y_pred_1)
         edit_distance_val = edit_distance.result()
@@ -188,18 +175,14 @@ class EditDistanceTest(TestCase):
 
     def test_update_state_normalize_false(self):
         edit_distance = EditDistance(normalize=False)
-        y_true_1 = tf.strings.split(
-            [
-                "the tiny little cat was found under the big funny bed",
-                "it is sunny today",
-            ]
-        )
-        y_pred_1 = tf.strings.split(
-            [
-                "the cat was found under the bed",
-                "it is sunny but with a hint of cloud cover",
-            ]
-        )
+        y_true_1 = [
+            "the tiny little cat was found under the big funny bed".split(),
+            "it is sunny today".split(),
+        ]
+        y_pred_1 = [
+            "the cat was found under the bed".split(),
+            "it is sunny but with a hint of cloud cover".split(),
+        ]
 
         edit_distance.update_state(y_true_1, y_pred_1)
         edit_distance_val = edit_distance.result()

--- a/keras_nlp/metrics/perplexity_test.py
+++ b/keras_nlp/metrics/perplexity_test.py
@@ -13,14 +13,11 @@
 # limitations under the License.
 
 """Tests for Perplexity."""
-import pytest
-import tensorflow as tf
-
+from keras_nlp.backend import ops
 from keras_nlp.metrics.perplexity import Perplexity
 from keras_nlp.tests.test_case import TestCase
 
 
-@pytest.mark.tf_only
 class PerplexityTest(TestCase):
     def test_vars_after_initializing_class(self):
         perplexity = Perplexity()
@@ -28,8 +25,8 @@ class PerplexityTest(TestCase):
 
     def test_from_logits_without_masking(self):
         perplexity = Perplexity(from_logits=True)
-        y_true = tf.constant([[1, 3, 0], [2, 1, 3]])
-        y_pred = tf.constant(
+        y_true = ops.array([[1, 3, 0], [2, 1, 3]])
+        y_pred = ops.array(
             [
                 [
                     [1.034, 4.797, 2.82, 1.154],
@@ -50,8 +47,8 @@ class PerplexityTest(TestCase):
     def test_from_logits_with_sample_weight(self):
         perplexity = Perplexity(from_logits=True)
 
-        y_true = tf.constant([[1, 3, 0], [2, 1, 3]])
-        y_pred = tf.constant(
+        y_true = ops.array([[1, 3, 0], [2, 1, 3]])
+        y_pred = ops.array(
             [
                 [
                     [1.034, 4.797, 2.82, 1.154],
@@ -65,7 +62,7 @@ class PerplexityTest(TestCase):
                 ],
             ]
         )
-        sample_wt = tf.cast(y_true != 0, "int32")
+        sample_wt = ops.cast(y_true != 0, "int32")
 
         perplexity_val = perplexity(y_true, y_pred, sample_wt)
         self.assertAlmostEqual(perplexity_val, 2.8789, delta=1e-3)
@@ -73,8 +70,8 @@ class PerplexityTest(TestCase):
     def test_from_logits_with_mask_token_id(self):
         perplexity = Perplexity(from_logits=True, mask_token_id=0)
 
-        y_true = tf.constant([[1, 3, 0], [2, 1, 3]])
-        y_pred = tf.constant(
+        y_true = ops.array([[1, 3, 0], [2, 1, 3]])
+        y_pred = ops.array(
             [
                 [
                     [1.034, 4.797, 2.82, 1.154],
@@ -95,8 +92,8 @@ class PerplexityTest(TestCase):
     def test_from_logits_with_mask_token_id_and_sample_weight(self):
         perplexity = Perplexity(from_logits=True, mask_token_id=0)
 
-        y_true = tf.constant([[1, 3, 0], [2, 1, 3]])
-        y_pred = tf.constant(
+        y_true = ops.array([[1, 3, 0], [2, 1, 3]])
+        y_pred = ops.array(
             [
                 [
                     [1.034, 4.797, 2.82, 1.154],
@@ -110,7 +107,7 @@ class PerplexityTest(TestCase):
                 ],
             ]
         )
-        sample_weight = tf.constant([[0.5, 0.1, 0.9], [1, 0.7, 0.5]])
+        sample_weight = ops.array([[0.5, 0.1, 0.9], [1, 0.7, 0.5]])
 
         perplexity_val = perplexity(y_true, y_pred, sample_weight)
         self.assertAlmostEqual(perplexity_val, 2.9442, delta=1e-3)
@@ -118,8 +115,8 @@ class PerplexityTest(TestCase):
     def test_two_inputs_from_logits(self):
         perplexity = Perplexity(from_logits=True, mask_token_id=0)
 
-        y_true_1 = tf.constant([[1, 3, 0], [2, 1, 3]])
-        y_pred_1 = tf.constant(
+        y_true_1 = ops.array([[1, 3, 0], [2, 1, 3]])
+        y_pred_1 = ops.array(
             [
                 [
                     [1.034, 4.797, 2.82, 1.154],
@@ -137,8 +134,8 @@ class PerplexityTest(TestCase):
         perplexity_val = perplexity(y_true_1, y_pred_1)
         self.assertAlmostEqual(perplexity_val, 2.8789, delta=1e-3)
 
-        y_true_2 = tf.constant([[2, 0, 0], [1, 2, 3]])
-        y_pred_2 = tf.constant(
+        y_true_2 = ops.array([[2, 0, 0], [1, 2, 3]])
+        y_pred_2 = ops.array(
             [
                 [
                     [2.887, 0.885, 2.973, 2.582],
@@ -158,8 +155,8 @@ class PerplexityTest(TestCase):
     def test_from_probs_with_sample_weight(self):
         perplexity = Perplexity(from_logits=False)
 
-        y_true = tf.constant([[1, 3, 0], [2, 1, 3]])
-        y_pred = tf.constant(
+        y_true = ops.array([[1, 3, 0], [2, 1, 3]])
+        y_pred = ops.array(
             [
                 [
                     [1.034, 4.797, 2.82, 1.154],
@@ -173,9 +170,9 @@ class PerplexityTest(TestCase):
                 ],
             ]
         )
-        y_prob = tf.nn.softmax(y_pred, axis=-1)
+        y_prob = ops.softmax(y_pred, axis=-1)
 
-        sample_wt = tf.cast(y_true != 0, "int32")
+        sample_wt = ops.cast(y_true != 0, "int32")
 
         perplexity_val = perplexity(y_true, y_prob, sample_wt)
         self.assertAlmostEqual(perplexity_val, 2.8789, delta=1e-3)
@@ -183,8 +180,8 @@ class PerplexityTest(TestCase):
     def test_from_probs_with_pad_token(self):
         perplexity = Perplexity(from_logits=False, mask_token_id=0)
 
-        y_true = tf.constant([[1, 3, 0], [2, 1, 3]])
-        y_pred = tf.constant(
+        y_true = ops.array([[1, 3, 0], [2, 1, 3]])
+        y_pred = ops.array(
             [
                 [
                     [1.034, 4.797, 2.82, 1.154],
@@ -198,14 +195,14 @@ class PerplexityTest(TestCase):
                 ],
             ]
         )
-        y_prob = tf.nn.softmax(y_pred, axis=-1)
+        y_prob = ops.softmax(y_pred, axis=-1)
 
         perplexity_val = perplexity(y_true, y_prob)
         self.assertAlmostEqual(perplexity_val, 2.8789, delta=1e-3)
 
     def test_reset_state(self):
-        y_true = tf.constant([[1, 3, 0], [2, 1, 3]])
-        y_pred = tf.constant(
+        y_true = ops.array([[1, 3, 0], [2, 1, 3]])
+        y_pred = ops.array(
             [
                 [
                     [1.034, 4.797, 2.82, 1.154],
@@ -231,8 +228,8 @@ class PerplexityTest(TestCase):
     def test_update_state(self):
         perplexity = Perplexity(from_logits=True, mask_token_id=0)
 
-        y_true_1 = tf.constant([[1, 3, 0], [2, 1, 3]])
-        y_pred_1 = tf.constant(
+        y_true_1 = ops.array([[1, 3, 0], [2, 1, 3]])
+        y_pred_1 = ops.array(
             [
                 [
                     [1.034, 4.797, 2.82, 1.154],
@@ -251,8 +248,8 @@ class PerplexityTest(TestCase):
         perplexity_val = perplexity.result()
         self.assertAlmostEqual(perplexity_val, 2.8789, delta=1e-3)
 
-        y_true_2 = tf.constant([[2, 0, 0], [1, 2, 3]])
-        y_pred_2 = tf.constant(
+        y_true_2 = ops.array([[2, 0, 0], [1, 2, 3]])
+        y_pred_2 = ops.array(
             [
                 [
                     [2.887, 0.885, 2.973, 2.582],

--- a/keras_nlp/metrics/rouge_l.py
+++ b/keras_nlp/metrics/rouge_l.py
@@ -44,15 +44,14 @@ class RougeL(RougeBase):
 
     Examples:
 
-    1. Various Input Types.
-    1.1. Python string.
+    1. Python string.
     >>> rouge_l = keras_nlp.metrics.RougeL()
     >>> y_true = "the tiny little cat was found under the big funny bed"
     >>> y_pred = "the cat was under the bed"
     >>> rouge_l(y_true, y_pred)["f1_score"]
     <tf.Tensor: shape=(), dtype=float32, numpy=0.7058824>
 
-    1.2. rank 1 inputs.
+    2. List inputs.
     a. Python list.
     >>> rouge_l = keras_nlp.metrics.RougeL()
     >>> y_true = [
@@ -66,49 +65,19 @@ class RougeL(RougeBase):
     >>> rouge_l(y_true, y_pred)["f1_score"]
     <tf.Tensor: shape=(), dtype=float32, numpy=0.80748665>
 
-    b. Tensor
+
+    3. 2D inputs.
     >>> rouge_l = keras_nlp.metrics.RougeL()
-    >>> y_true = tf.constant(
-    ...     [
-    ...         "the tiny little cat was found under the big funny bed",
-    ...         "i really love contributing to KerasNLP",
-    ...     ]
-    ... )
-    >>> y_pred = tf.constant(
-    ...     [
-    ...         "the cat was under the bed",
-    ...         "i love contributing to KerasNLP",
-    ...     ]
-    ... )
+    >>> y_true = [
+    ...     ["the tiny little cat was found under the big funny bed"],
+    ...     ["i really love contributing to KerasNLP"],
+    ... ]
+    >>> y_pred = [
+    ...     ["the cat was under the bed"],
+    ...     ["i love contributing to KerasNLP"],
+    ... ]
     >>> rouge_l(y_true, y_pred)["f1_score"]
     <tf.Tensor: shape=(), dtype=float32, numpy=0.80748665>
-
-    1.3. rank 2 inputs.
-    >>> rouge_l = keras_nlp.metrics.RougeL()
-    >>> y_true = tf.constant(
-    ...     [
-    ...         ["the tiny little cat was found under the big funny bed"],
-    ...         ["i really love contributing to KerasNLP"],
-    ...     ]
-    ... )
-    >>> y_pred = tf.constant(
-    ...     [
-    ...         ["the cat was under the bed"],
-    ...         ["i love contributing to KerasNLP"],
-    ...     ]
-    ... )
-    >>> rouge_l(y_true, y_pred)["f1_score"]
-    <tf.Tensor: shape=(), dtype=float32, numpy=0.80748665>
-
-    3. Pass the metric to `model.compile()`.
-    >>> inputs = keras.Input(shape=(), dtype='string')
-    >>> outputs = keras.layers.Identity()(inputs)
-    >>> model = keras.Model(inputs, outputs)
-    >>> model.compile(metrics=[keras_nlp.metrics.RougeL()])
-    >>> y_pred = x = tf.constant(["hello this is fun"])
-    >>> y = tf.constant(["hello this is awesome"])
-    >>> model.compute_metrics(x, y, y_pred, sample_weight=None)["f1_score"]
-    0.75
     """
 
     def __init__(

--- a/keras_nlp/metrics/rouge_l_test.py
+++ b/keras_nlp/metrics/rouge_l_test.py
@@ -13,14 +13,12 @@
 # limitations under the License.
 
 """Tests for RougeL."""
-import pytest
 import tensorflow as tf
 
 from keras_nlp.metrics.rouge_l import RougeL
 from keras_nlp.tests.test_case import TestCase
 
 
-@pytest.mark.tf_only
 class RougeLTest(TestCase):
     def test_initialization(self):
         rouge = RougeL()
@@ -77,35 +75,13 @@ class RougeLTest(TestCase):
             {"precision": 1.0, "recall": 0.689393, "f1_score": 0.807486},
         )
 
-    def test_rank_2_input(self):
-        rouge = RougeL(use_stemmer=False)
-        y_true = tf.constant(
-            [
-                ["the tiny little cat was found under the big funny bed"],
-                ["i really love contributing to KerasNLP"],
-            ]
-        )
-        y_pred = tf.constant(
-            [["the cat was under the bed"], ["i love contributing to KerasNLP"]]
-        )
-
-        rouge_val = rouge(y_true, y_pred)
-        self.assertAllClose(
-            rouge_val,
-            {"precision": 1.0, "recall": 0.689393, "f1_score": 0.807486},
-        )
-
     def test_reset_state(self):
         rouge = RougeL()
-        y_true = tf.constant(
-            ["hey, this is great fun", "i love contributing to KerasNLP"]
-        )
-        y_pred = tf.constant(
-            [
-                "great fun indeed",
-                "KerasNLP is awesome, i love contributing to it",
-            ]
-        )
+        y_true = ["hey, this is great fun", "i love contributing to KerasNLP"]
+        y_pred = [
+            "great fun indeed",
+            "KerasNLP is awesome, i love contributing to it",
+        ]
 
         rouge.update_state(y_true, y_pred)
         rouge_val = rouge.result()
@@ -123,15 +99,14 @@ class RougeLTest(TestCase):
 
     def test_update_state(self):
         rouge = RougeL()
-        y_true_1 = tf.constant(
-            [
-                "the tiny little cat was found under the big funny bed",
-                "i really love contributing to KerasNLP",
-            ]
-        )
-        y_pred_1 = tf.constant(
-            ["the cat was under the bed", "i love contributing to KerasNLP"]
-        )
+        y_true_1 = [
+            "the tiny little cat was found under the big funny bed",
+            "i really love contributing to KerasNLP",
+        ]
+        y_pred_1 = [
+            "the cat was under the bed",
+            "i love contributing to KerasNLP",
+        ]
 
         rouge.update_state(y_true_1, y_pred_1)
         rouge_val = rouge.result()
@@ -140,8 +115,8 @@ class RougeLTest(TestCase):
             {"precision": 1.0, "recall": 0.689393, "f1_score": 0.807486},
         )
 
-        y_true_2 = tf.constant(["what is your favourite show"])
-        y_pred_2 = tf.constant(["my favourite show is silicon valley"])
+        y_true_2 = ["what is your favourite show"]
+        y_pred_2 = ["my favourite show is silicon valley"]
 
         rouge.update_state(y_true_2, y_pred_2)
         rouge_val = rouge.result()

--- a/keras_nlp/metrics/rouge_n.py
+++ b/keras_nlp/metrics/rouge_n.py
@@ -46,16 +46,14 @@ class RougeN(RougeBase):
 
     Examples:
 
-    1. Various Input Types.
-    1.1. Python string.
+    1. Python string.
     >>> rouge_n = keras_nlp.metrics.RougeN(order=2)
     >>> y_true = "the tiny little cat was found under the big funny bed"
     >>> y_pred = "the cat was under the bed"
     >>> rouge_n(y_true, y_pred)["f1_score"]
     <tf.Tensor: shape=(), dtype=float32, numpy=0.26666668>
 
-    1.2. rank 1 inputs.
-    a. Python list.
+    2. List inputs.
     >>> rouge_n = keras_nlp.metrics.RougeN(order=2)
     >>> y_true = [
     ...     "the tiny little cat was found under the big funny bed",
@@ -68,66 +66,31 @@ class RougeN(RougeBase):
     >>> rouge_n(y_true, y_pred)["f1_score"]
     <tf.Tensor: shape=(), dtype=float32, numpy=0.4666667>
 
-    b. Tensor.
+    3. 2D inputs.
     >>> rouge_n = keras_nlp.metrics.RougeN(order=2)
-    >>> y_true = tf.constant(
-    ...     [
-    ...         "the tiny little cat was found under the big funny bed",
-    ...         "i really love contributing to KerasNLP",
-    ...     ]
-    ... )
-    >>> y_pred = tf.constant(
-    ...     [
-    ...         "the cat was under the bed",
-    ...         "i love contributing to KerasNLP",
-    ...     ]
-    ... )
+    >>> y_true =[
+    ...     ["the tiny little cat was found under the big funny bed"],
+    ...     ["i really love contributing to KerasNLP"],
+    ... ]
+    >>> y_pred =[
+    ...     ["the cat was under the bed"],
+    ...     ["i love contributing to KerasNLP"],
+    ... ]
     >>> rouge_n(y_true, y_pred)["f1_score"]
     <tf.Tensor: shape=(), dtype=float32, numpy=0.4666667>
 
-    1.3. rank 2 inputs.
-    >>> rouge_n = keras_nlp.metrics.RougeN(order=2)
-    >>> y_true = tf.constant(
-    ...     [
-    ...         ["the tiny little cat was found under the big funny bed"],
-    ...         ["i really love contributing to KerasNLP"],
-    ...     ]
-    ... )
-    >>> y_pred = tf.constant(
-    ...     [
-    ...         ["the cat was under the bed"],
-    ...         ["i love contributing to KerasNLP"],
-    ...     ]
-    ... )
-    >>> rouge_n(y_true, y_pred)["f1_score"]
-    <tf.Tensor: shape=(), dtype=float32, numpy=0.4666667>
-
-    2. Consider trigrams for calculating ROUGE-N.
+    4. Trigrams.
     >>> rouge_n = keras_nlp.metrics.RougeN(order=3)
-    >>> y_true = tf.constant(
-    ...     [
-    ...         "the tiny little cat was found under the big funny bed",
-    ...         "i really love contributing to KerasNLP",
-    ...     ]
-    ... )
-    >>> y_pred = tf.constant(
-    ...     [
-    ...         "the cat was under the bed",
-    ...         "i love contributing to KerasNLP",
-    ...     ]
-    ... )
+    >>> y_true = [
+    ...     "the tiny little cat was found under the big funny bed",
+    ...     "i really love contributing to KerasNLP",
+    ... ]
+    >>> y_pred = [
+    ...     "the cat was under the bed",
+    ...     "i love contributing to KerasNLP",
+    ... ]
     >>> rouge_n(y_true, y_pred)["f1_score"]
     <tf.Tensor: shape=(), dtype=float32, numpy=0.2857143>
-
-    3. Pass the metric to `model.compile()`.
-    >>> inputs = keras.Input(shape=(), dtype='string')
-    >>> outputs = keras.layers.Identity()(inputs)
-    >>> model = keras.Model(inputs, outputs)
-    >>> model.compile(metrics=[keras_nlp.metrics.RougeN()])
-    >>> y_pred = x = tf.constant(["hello this is fun"])
-    >>> y = tf.constant(["hello this is awesome"])
-    >>> model.compute_metrics(x, y, y_pred, sample_weight=None)["f1_score"]
-    0.6666666865348816
     """
 
     def __init__(

--- a/keras_nlp/metrics/rouge_n_test.py
+++ b/keras_nlp/metrics/rouge_n_test.py
@@ -21,7 +21,6 @@ from keras_nlp.metrics.rouge_n import RougeN
 from keras_nlp.tests.test_case import TestCase
 
 
-@pytest.mark.tf_only
 class RougeNTest(TestCase):
     def test_initialization(self):
         rouge = RougeN()
@@ -78,24 +77,7 @@ class RougeNTest(TestCase):
             {"precision": 0.575, "recall": 0.4, "f1_score": 0.466666},
         )
 
-    def test_rank_2_input(self):
-        rouge = RougeN(order=2, use_stemmer=False)
-        y_true = tf.constant(
-            [
-                ["the tiny little cat was found under the big funny bed"],
-                ["i really love contributing to KerasNLP"],
-            ]
-        )
-        y_pred = tf.constant(
-            [["the cat was under the bed"], ["i love contributing to KerasNLP"]]
-        )
-
-        rouge_val = rouge(y_true, y_pred)
-        self.assertAllClose(
-            rouge_val,
-            {"precision": 0.575, "recall": 0.4, "f1_score": 0.466666},
-        )
-
+    @pytest.mark.tf_only  # string model output only applies to tf.
     def test_model_compile(self):
         inputs = keras.Input(shape=(None,), dtype="string")
         outputs = keras.layers.Identity()(inputs)
@@ -117,15 +99,14 @@ class RougeNTest(TestCase):
 
     def test_different_order(self):
         rouge = RougeN(order=3, use_stemmer=False)
-        y_true = tf.constant(
-            [
-                "the tiny little cat was found under the big funny bed",
-                "i really love contributing to KerasNLP",
-            ]
-        )
-        y_pred = tf.constant(
-            ["the cat was under the bed", "i love contributing to KerasNLP"]
-        )
+        y_true = [
+            "the tiny little cat was found under the big funny bed",
+            "i really love contributing to KerasNLP",
+        ]
+        y_pred = [
+            "the cat was under the bed",
+            "i love contributing to KerasNLP",
+        ]
 
         rouge_val = rouge(y_true, y_pred)
         self.assertAllClose(
@@ -135,15 +116,11 @@ class RougeNTest(TestCase):
 
     def test_reset_state(self):
         rouge = RougeN()
-        y_true = tf.constant(
-            ["hey, this is great fun", "i love contributing to KerasNLP"]
-        )
-        y_pred = tf.constant(
-            [
-                "great fun indeed",
-                "KerasNLP is awesome, i love contributing to it",
-            ]
-        )
+        y_true = ["hey, this is great fun", "i love contributing to KerasNLP"]
+        y_pred = [
+            "great fun indeed",
+            "KerasNLP is awesome, i love contributing to it",
+        ]
 
         rouge.update_state(y_true, y_pred)
         rouge_val = rouge.result()
@@ -161,15 +138,14 @@ class RougeNTest(TestCase):
 
     def test_update_state(self):
         rouge = RougeN()
-        y_true_1 = tf.constant(
-            [
-                "the tiny little cat was found under the big funny bed",
-                "i really love contributing to KerasNLP",
-            ]
-        )
-        y_pred_1 = tf.constant(
-            ["the cat was under the bed", "i love contributing to KerasNLP"]
-        )
+        y_true_1 = [
+            "the tiny little cat was found under the big funny bed",
+            "i really love contributing to KerasNLP",
+        ]
+        y_pred_1 = [
+            "the cat was under the bed",
+            "i love contributing to KerasNLP",
+        ]
 
         rouge.update_state(y_true_1, y_pred_1)
         rouge_val = rouge.result()
@@ -178,8 +154,8 @@ class RougeNTest(TestCase):
             {"precision": 0.575, "recall": 0.4, "f1_score": 0.466666},
         )
 
-        y_true_2 = tf.constant(["what is your favourite show"])
-        y_pred_2 = tf.constant(["my favourite show is silicon valley"])
+        y_true_2 = ["what is your favourite show"]
+        y_pred_2 = ["my favourite show is silicon valley"]
 
         rouge.update_state(y_true_2, y_pred_2)
         rouge_val = rouge.result()


### PR DESCRIPTION
Probably more we could do here, but here is a quick port of our metrics to multi-backend.

In short, we will leave them as eager-only metrics, and all "string metrics" will use `tf.Tensor` as an intermediate data type. This is really cross-platform offering that makes sense for these metrics as we lack string types in other platforms. It's not a huge loss either, as most of these metrics are things you want to apply to generated sequences from a model, so you could never really bake most of these in as "live" metrics computed during a `train_step`.

The one exception here is perplexity. This metric is fully in integer space, and we can write it entirely with out `ops` layer, and compile it across platforms.