### PR TITLE
Update MaskedLMHead to support dtype=bfloat16/float16/float64

### DIFF
--- a/keras_nlp/layers/modeling/masked_lm_head.py
+++ b/keras_nlp/layers/modeling/masked_lm_head.py
@@ -183,25 +183,18 @@ class MaskedLMHead(keras.layers.Layer):
         # Gather the encoded tokens at the masked indices.
         masked_positions = ops.expand_dims(masked_positions, axis=-1)
         x = ops.take_along_axis(inputs, masked_positions, axis=1)
-        print("XXX/1", x.dtype)
 
         # Apply a trainable linear transformation and a layer norm.
         x = self._dense(x)
-        print("XXX/2", x.dtype)
         x = self._layer_norm(x)
-        print("XXX/3", x.dtype)
 
         # Transform encodings to vocabulary_size predictions.
         if self.embedding_weights is None:
             kernel = self._kernel
-            print("XXX/4", kernel)
         else:
             kernel = ops.cast(self.embedding_weights, self.compute_dtype)
-            print("XXX/5", kernel)
             kernel = ops.transpose(kernel)
-            print("XXX/6", kernel)
         outputs = ops.matmul(x, kernel)
-        print("XXX", outputs.dtype, self._bias.dtype)
         outputs = outputs + self._bias
 
         # Apply a final activation.


### PR DESCRIPTION
- Update MaskedLMHead to support dtype=bfloat16/float16/float64.

Inspired by https://github.com/keras-team/keras/commit/397ad5771574dd96e8aa47c5d52735ad860ecd0f
i.e. using the idiom (?) of `dtype=self._dtype_policy`.

This is to fix https://github.com/keras-team/keras-nlp/issues/1195

I had a previous try at this where I accidentally included print statements, sorry.
