### PR TITLE
Raise ValueError when number of dims evaluate to zero

### DIFF
--- a/keras_nlp/layers/modeling/transformer_decoder.py
+++ b/keras_nlp/layers/modeling/transformer_decoder.py
@@ -148,6 +148,12 @@ class TransformerDecoder(keras.layers.Layer):
         hidden_dim = decoder_sequence_shape[-1]
         # Attention head size is `hidden_dim` over the number of heads.
         head_dim = int(hidden_dim // self.num_heads)
+        if head_dim == 0:
+            raise ValueError(
+                "Attention `head_dim` computed cannot be zero. "
+                f"The `hidden_dim` value of {hidden_dim} has to be equal to "
+                f"or greater than `num_heads` value of {self.num_heads}."
+            )
 
         # Self attention layers.
         self._self_attention_layer = CachedMultiHeadAttention(

--- a/keras_nlp/layers/modeling/transformer_encoder.py
+++ b/keras_nlp/layers/modeling/transformer_encoder.py
@@ -95,7 +95,7 @@ class TransformerEncoder(keras.layers.Layer):
         bias_initializer="zeros",
         normalize_first=False,
         name=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(name=name, **kwargs)
         self.intermediate_dim = intermediate_dim
@@ -113,6 +113,12 @@ class TransformerEncoder(keras.layers.Layer):
         hidden_dim = inputs_shape[-1]
         # Attention head size is `hidden_dim` over the number of heads.
         key_dim = int(hidden_dim // self.num_heads)
+        if key_dim == 0:
+            raise ValueError(
+                "Attention `key_dim` computed cannot be zero. "
+                f"The `hidden_dim` value of {hidden_dim} has to be equal to "
+                f"or greater than `num_heads` value of {self.num_heads}."
+            )
 
         # Self attention layers.
         self._self_attention_layer = keras.layers.MultiHeadAttention(


### PR DESCRIPTION
When `TransformerEncoder` and `TransformerDecoder` is used in a Model with insufficient `embedding_size` for `EmbeddingLayer`, it can create divide by zero error.

For example - 
```
model = Sequential(layers=[
    Embedding(50, embedding_size=2, input_length=10, name='embedding'),
    TransformerEncoder(intermediate_dim=64, num_heads=8),
    Flatten(),
    Dense(16, activation="relu"),
    Dropout(0.2),
    Dense(1, activation="linear")
])
```
Fails with divide by zero error since `embedding_size` of 2 // `num_heads` results in zero.  This PR will provide a more meaning ful message on why this happens.