### PR TITLE
Changed default TokenAndPositionEmbedding initializer to 'uniform'

### DIFF
--- a/keras_nlp/layers/modeling/token_and_position_embedding.py
+++ b/keras_nlp/layers/modeling/token_and_position_embedding.py
@@ -62,7 +62,7 @@ class TokenAndPositionEmbedding(keras.layers.Layer):
         sequence_length,
         embedding_dim,
         tie_weights=True,
-        embeddings_initializer="glorot_uniform",
+        embeddings_initializer="uniform",
         mask_zero=False,
         **kwargs
     ):


### PR DESCRIPTION
`TokenAndPositionEmbedding` advertises itself as a combination of a `Embedding` and `PositionEmbedding`, but the inconsistency in initializer leads to a surprising degradation of performance, e.g. replacing the custom layer in [this example](https://github.com/keras-team/keras-nlp/blob/60af93f596863f51dee73228c04d1b27d00415d0/examples/machine_translation/model.py#L21C4-L21C4) with `TokenAndPositionEmbedding` makes results significantly worse (unless you manually specify the initializer). AFAIK there is no theoretical reason why glorot initialization should be here.