### PR TITLE
Add compat shims for the upcoming keras-core release

### DIFF
--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -246,6 +246,17 @@ class Task(PipelineModel):
         **kwargs,
     ):
         """Override `model.summary()` to show a preprocessor if set."""
+
+        # Compat fixes for tf.keras.
+        if not hasattr(self, "compiled"):
+            self.compiled = getattr(self.optimizer, "_is_compiled", False)
+        if (
+            self.compiled
+            and self.optimizer
+            and not hasattr(self.optimizer, "built")
+        ):
+            self.optimizer.built = getattr(self.optimizer, "_built", False)
+
         # Below is copied from keras-core for now.
         # We should consider an API contract.
         line_length = line_length or 108


### PR DESCRIPTION
https://github.com/keras-team/keras-core/pull/859 will break out model summary code when it makes its way into a release.

This adds the compat shims we need to not break out ci and actual `summary()` calls when on the `tf.keras` backend.

We wouldn't get coverage for this without running an extra set of tests against unreleased keras-core `main` branch.