### PR TITLE
Removed the undefined self.sequence_length

### DIFF
--- a/keras_nlp/tokenizers/tokenizer.py
+++ b/keras_nlp/tokenizers/tokenizer.py
@@ -123,6 +123,3 @@ class Tokenizer(PreprocessingLayer):
 
     def call(self, inputs, *args, training=None, **kwargs):
         return self.tokenize(inputs, *args, **kwargs)
-
-    def compute_output_shape(self, inputs_shape):
-        return tuple(inputs_shape)

--- a/keras_nlp/tokenizers/tokenizer.py
+++ b/keras_nlp/tokenizers/tokenizer.py
@@ -125,4 +125,4 @@ class Tokenizer(PreprocessingLayer):
         return self.tokenize(inputs, *args, **kwargs)
 
     def compute_output_shape(self, inputs_shape):
-        return tuple(inputs_shape) + (self.sequence_length,)
+        return tuple(inputs_shape)


### PR DESCRIPTION
There is a **compute_output_shape** method in the Tokenizer class that uses self.sequence_length, which is not defined in the Tokenizer class itself. removed it