### PR TITLE
Version bump to 0.6.2

### DIFF
--- a/keras_nlp/__init__.py
+++ b/keras_nlp/__init__.py
@@ -28,4 +28,4 @@ from keras_nlp import tokenizers
 from keras_nlp import utils
 
 # This is the global source of truth for the version number.
-__version__ = "0.6.2.dev0"
+__version__ = "0.6.2"


### PR DESCRIPTION
I'll do the cherry picks soon for an 0.6.2 release that will fix mixed precision support on keras-core. This is just the version bump.