### PR TITLE
Bump master branch version number to 0.7.0.dev0

### DIFF
--- a/keras_nlp/__init__.py
+++ b/keras_nlp/__init__.py
@@ -28,4 +28,4 @@ from keras_nlp import tokenizers
 from keras_nlp import utils
 
 # This is the global source of truth for the version number.
-__version__ = "0.6.0.dev0"
+__version__ = "0.7.0.dev0"


### PR DESCRIPTION
I have been forgetting to increment our master branch release number, so it's now less than our pip release :)

I think we can consider the master branch a preview of our 0.7.0 release at this point.