### PR TITLE
Support Keras 3 installation

### DIFF
--- a/keras_nlp/backend/keras.py
+++ b/keras_nlp/backend/keras.py
@@ -16,9 +16,11 @@ import types
 
 import tensorflow as tf
 
-from keras_nlp.backend.config import multi_backend
+from keras_nlp.backend import config
 
-if multi_backend():
+if config.keras_3():
+    from keras import *  # noqa: F403, F401
+elif config.multi_backend():
     from keras_core import *  # noqa: F403, F401
 else:
     from tensorflow.keras import *  # noqa: F403, F401

--- a/keras_nlp/backend/ops.py
+++ b/keras_nlp/backend/ops.py
@@ -12,22 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import keras_core
-import tensorflow as tf
+from keras_nlp.backend import config
 
-from keras_nlp.backend.config import multi_backend
-
-if multi_backend():
-    from keras_core.src.ops import *  # noqa: F403, F401
+if config.keras_3():
+    from keras.ops import *  # noqa: F403, F401
 else:
-    from keras_core.src.backend.tensorflow import *  # noqa: F403, F401
-    from keras_core.src.backend.tensorflow.core import *  # noqa: F403, F401
-    from keras_core.src.backend.tensorflow.math import *  # noqa: F403, F401
-    from keras_core.src.backend.tensorflow.nn import *  # noqa: F403, F401
-    from keras_core.src.backend.tensorflow.numpy import *  # noqa: F403, F401
+    from keras_core.ops import *  # noqa: F403, F401
 
-
-if keras_core.config.backend() == "tensorflow" or not multi_backend():
+if config.backend() == "tensorflow":
+    import tensorflow as tf
+    from tensorflow.experimental import numpy as tfnp
 
     def take_along_axis(x, indices, axis=None):
         # TODO: move this workaround for dynamic shapes into keras-core.
@@ -46,6 +40,4 @@ if keras_core.config.backend() == "tensorflow" or not multi_backend():
                 indices = tf.squeeze(indices, leftover_axes)
             return tf.gather(x, indices, batch_dims=axis)
         # Otherwise, fall back to the tfnp call.
-        return keras_core.src.backend.tensorflow.numpy.take_along_axis(
-            x, indices, axis=axis
-        )
+        return tfnp.take_along_axis(x, indices, axis=axis)

--- a/keras_nlp/backend/random.py
+++ b/keras_nlp/backend/random.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from keras_nlp.backend.config import multi_backend
+from keras_nlp.backend import config
 
-if multi_backend():
-    from keras_core.random import *  # noqa: F403, F401
+if config.keras_3():
+    from keras.random import *  # noqa: F403, F401
 else:
-    from keras_core.src.backend.tensorflow.random import *  # noqa: F403, F401
+    from keras_core.random import *  # noqa: F403, F401

--- a/keras_nlp/layers/modeling/cached_multi_head_attention_test.py
+++ b/keras_nlp/layers/modeling/cached_multi_head_attention_test.py
@@ -14,6 +14,7 @@
 
 from keras_nlp.backend import config
 from keras_nlp.backend import ops
+from keras_nlp.backend import random
 from keras_nlp.layers.modeling.cached_multi_head_attention import (
     CachedMultiHeadAttention,
 )
@@ -29,8 +30,8 @@ class CachedMultiHeadAttentionTest(TestCase):
                 "key_dim": 4,
             },
             input_data={
-                "query": ops.random.uniform(shape=(2, 4, 6)),
-                "value": ops.random.uniform(shape=(2, 4, 6)),
+                "query": random.uniform(shape=(2, 4, 6)),
+                "value": random.uniform(shape=(2, 4, 6)),
             },
             expected_output_shape=(2, 4, 6),
             expected_num_trainable_weights=8,
@@ -48,7 +49,7 @@ class CachedMultiHeadAttentionTest(TestCase):
         hidden_dim = num_heads * key_dim
 
         input_shape = (batch_size, seq_len, hidden_dim)
-        x = ops.random.uniform(shape=input_shape)
+        x = random.uniform(shape=input_shape)
         input_cache = ops.zeros((batch_size, 2, seq_len, num_heads, key_dim))
         # Use a causal mask.
         mask = ops.tril(ops.ones((seq_len, seq_len)))

--- a/keras_nlp/layers/modeling/f_net_encoder_test.py
+++ b/keras_nlp/layers/modeling/f_net_encoder_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from keras_nlp.backend import ops
+from keras_nlp.backend import random
 from keras_nlp.layers.modeling.f_net_encoder import FNetEncoder
 from keras_nlp.tests.test_case import TestCase
 
@@ -29,7 +29,7 @@ class FNetEncoderTest(TestCase):
                 "kernel_initializer": "HeNormal",
                 "bias_initializer": "Zeros",
             },
-            input_data=ops.random.uniform(shape=(2, 4, 6)),
+            input_data=random.uniform(shape=(2, 4, 6)),
             expected_output_shape=(2, 4, 6),
             expected_num_trainable_weights=8,
             expected_num_non_trainable_variables=1,

--- a/keras_nlp/layers/modeling/masked_lm_head_test.py
+++ b/keras_nlp/layers/modeling/masked_lm_head_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from keras_nlp.backend import ops
+from keras_nlp.backend import random
 from keras_nlp.layers.modeling.masked_lm_head import MaskedLMHead
 from keras_nlp.layers.modeling.reversible_embedding import ReversibleEmbedding
 from keras_nlp.tests.test_case import TestCase
@@ -29,8 +29,8 @@ class MaskedLMHeadTest(TestCase):
                 "bias_initializer": "Zeros",
             },
             input_data={
-                "inputs": ops.random.uniform(shape=(4, 10, 16)),
-                "mask_positions": ops.random.randint(
+                "inputs": random.uniform(shape=(4, 10, 16)),
+                "mask_positions": random.randint(
                     minval=0, maxval=10, shape=(4, 5)
                 ),
             },
@@ -51,8 +51,8 @@ class MaskedLMHeadTest(TestCase):
                 "token_embedding": embedding,
             },
             input_data={
-                "inputs": ops.random.uniform(shape=(4, 10, 16)),
-                "mask_positions": ops.random.randint(
+                "inputs": random.uniform(shape=(4, 10, 16)),
+                "mask_positions": random.randint(
                     minval=0, maxval=10, shape=(4, 5)
                 ),
             },

--- a/keras_nlp/layers/modeling/position_embedding_test.py
+++ b/keras_nlp/layers/modeling/position_embedding_test.py
@@ -16,6 +16,7 @@ import numpy as np
 
 from keras_nlp.backend import keras
 from keras_nlp.backend import ops
+from keras_nlp.backend import random
 from keras_nlp.layers.modeling.position_embedding import PositionEmbedding
 from keras_nlp.tests.test_case import TestCase
 
@@ -34,7 +35,7 @@ class PositionEmbeddingTest(TestCase):
             init_kwargs={
                 "sequence_length": 21,
             },
-            input_data=ops.random.uniform(shape=(4, 21, 30)),
+            input_data=random.uniform(shape=(4, 21, 30)),
             expected_output_shape=(4, 21, 30),
             expected_num_trainable_weights=1,
         )
@@ -45,7 +46,7 @@ class PositionEmbeddingTest(TestCase):
             init_kwargs={
                 "sequence_length": 21,
             },
-            input_data=ops.random.uniform(shape=(4, 5, 21, 30)),
+            input_data=random.uniform(shape=(4, 5, 21, 30)),
             expected_output_shape=(4, 5, 21, 30),
             expected_num_trainable_weights=1,
         )
@@ -145,7 +146,7 @@ class PositionEmbeddingTest(TestCase):
     def test_start_index(self):
         batch_size, seq_length, feature_size = 2, 3, 4
         layer = PositionEmbedding(seq_length)
-        data = ops.random.uniform(shape=(batch_size, seq_length, feature_size))
+        data = random.uniform(shape=(batch_size, seq_length, feature_size))
         full_output = layer(data)
         sequential_output = ops.zeros((batch_size, seq_length, feature_size))
         for i in range(seq_length):

--- a/keras_nlp/layers/modeling/reversible_embedding_test.py
+++ b/keras_nlp/layers/modeling/reversible_embedding_test.py
@@ -20,6 +20,7 @@ from absl.testing import parameterized
 from keras_nlp.backend import config
 from keras_nlp.backend import keras
 from keras_nlp.backend import ops
+from keras_nlp.backend import random
 from keras_nlp.layers.modeling.reversible_embedding import ReversibleEmbedding
 from keras_nlp.tests.test_case import TestCase
 
@@ -38,7 +39,7 @@ class ReversibleEmbeddingTest(TestCase):
                 "tie_weights": tie_weights,
                 "embeddings_initializer": "HeNormal",
             },
-            input_data=ops.random.randint(minval=0, maxval=100, shape=(4, 10)),
+            input_data=random.randint(minval=0, maxval=100, shape=(4, 10)),
             expected_output_shape=(4, 10, 32),
             expected_num_trainable_weights=1 if tie_weights else 2,
         )

--- a/keras_nlp/layers/modeling/rotary_embedding_test.py
+++ b/keras_nlp/layers/modeling/rotary_embedding_test.py
@@ -14,6 +14,7 @@
 
 from keras_nlp.backend import keras
 from keras_nlp.backend import ops
+from keras_nlp.backend import random
 from keras_nlp.layers.modeling.rotary_embedding import RotaryEmbedding
 from keras_nlp.tests.test_case import TestCase
 
@@ -28,7 +29,7 @@ class RotaryEmbeddingTest(TestCase):
                 "sequence_axis": 1,
                 "feature_axis": -1,
             },
-            input_data=ops.random.uniform(shape=(2, 4, 6)),
+            input_data=random.uniform(shape=(2, 4, 6)),
             expected_output_shape=(2, 4, 6),
         )
 
@@ -38,7 +39,7 @@ class RotaryEmbeddingTest(TestCase):
             init_kwargs={
                 "max_wavelength": 1000,
             },
-            input_data=ops.random.uniform(shape=(2, 8, 4, 6)),
+            input_data=random.uniform(shape=(2, 8, 4, 6)),
             expected_output_shape=(2, 8, 4, 6),
         )
 
@@ -86,7 +87,7 @@ class RotaryEmbeddingTest(TestCase):
     def test_start_index(self):
         batch_size, seq_length, feature_size = 2, 3, 4
         layer = RotaryEmbedding(seq_length)
-        data = ops.random.uniform(shape=(batch_size, seq_length, feature_size))
+        data = random.uniform(shape=(batch_size, seq_length, feature_size))
         full_output = layer(data)
         sequential_output = ops.zeros((batch_size, seq_length, feature_size))
         for i in range(seq_length):

--- a/keras_nlp/layers/modeling/sine_position_encoding_test.py
+++ b/keras_nlp/layers/modeling/sine_position_encoding_test.py
@@ -14,6 +14,7 @@
 
 from keras_nlp.backend import keras
 from keras_nlp.backend import ops
+from keras_nlp.backend import random
 from keras_nlp.layers.modeling.sine_position_encoding import (
     SinePositionEncoding,
 )
@@ -27,7 +28,7 @@ class SinePositionEncodingTest(TestCase):
             init_kwargs={
                 "max_wavelength": 10000,
             },
-            input_data=ops.random.uniform(shape=(2, 4, 6)),
+            input_data=random.uniform(shape=(2, 4, 6)),
             expected_output_shape=(2, 4, 6),
         )
 
@@ -37,7 +38,7 @@ class SinePositionEncodingTest(TestCase):
             init_kwargs={
                 "max_wavelength": 10000,
             },
-            input_data=ops.random.uniform(shape=(1, 2, 4, 6)),
+            input_data=random.uniform(shape=(1, 2, 4, 6)),
             expected_output_shape=(1, 2, 4, 6),
         )
 
@@ -85,7 +86,7 @@ class SinePositionEncodingTest(TestCase):
                 pos_encoding,
             ]
         )
-        input = ops.random.uniform(shape=[1, 4, 6])
+        input = random.uniform(shape=[1, 4, 6])
         output = model(input)
 
         # comapre position encoding values for position 0 and 3
@@ -97,7 +98,7 @@ class SinePositionEncodingTest(TestCase):
     def test_start_index(self):
         batch_size, seq_length, feature_size = 2, 3, 4
         layer = SinePositionEncoding()
-        data = ops.random.uniform(shape=(batch_size, seq_length, feature_size))
+        data = random.uniform(shape=(batch_size, seq_length, feature_size))
         full_output = layer(data)
         sequential_output = ops.zeros((batch_size, seq_length, feature_size))
         for i in range(seq_length):

--- a/keras_nlp/layers/modeling/token_and_position_embedding_test.py
+++ b/keras_nlp/layers/modeling/token_and_position_embedding_test.py
@@ -16,6 +16,7 @@ import numpy as np
 
 from keras_nlp.backend import keras
 from keras_nlp.backend import ops
+from keras_nlp.backend import random
 from keras_nlp.layers.modeling.token_and_position_embedding import (
     TokenAndPositionEmbedding,
 )
@@ -32,7 +33,7 @@ class TokenAndPositionEmbeddingTest(TestCase):
                 "embedding_dim": 3,
                 "embeddings_initializer": keras.initializers.Constant(1.0),
             },
-            input_data=ops.random.randint(minval=0, maxval=5, shape=(2, 4)),
+            input_data=random.randint(minval=0, maxval=5, shape=(2, 4)),
             expected_output_shape=(2, 4, 3),
             expected_output_data=ops.ones((2, 4, 3)) * 2,
             expected_num_trainable_weights=2,

--- a/keras_nlp/layers/modeling/transformer_decoder_test.py
+++ b/keras_nlp/layers/modeling/transformer_decoder_test.py
@@ -15,6 +15,7 @@
 from absl.testing import parameterized
 
 from keras_nlp.backend import ops
+from keras_nlp.backend import random
 from keras_nlp.layers.modeling.transformer_decoder import TransformerDecoder
 from keras_nlp.tests.test_case import TestCase
 
@@ -36,7 +37,7 @@ class TransformerDecoderTest(TestCase):
                 "kernel_initializer": "HeNormal",
                 "bias_initializer": "Zeros",
             },
-            input_data=ops.random.uniform(shape=(2, 4, 6)),
+            input_data=random.uniform(shape=(2, 4, 6)),
             expected_output_shape=(2, 4, 6),
             expected_num_trainable_weights=16,
             expected_num_non_trainable_variables=3,  # dropout rng seeds
@@ -60,8 +61,8 @@ class TransformerDecoderTest(TestCase):
                 "bias_initializer": "Zeros",
             },
             input_data={
-                "decoder_sequence": ops.random.uniform(shape=(2, 4, 6)),
-                "encoder_sequence": ops.random.uniform(shape=(2, 4, 6)),
+                "decoder_sequence": random.uniform(shape=(2, 4, 6)),
+                "encoder_sequence": random.uniform(shape=(2, 4, 6)),
             },
             expected_output_shape=(2, 4, 6),
             expected_num_trainable_weights=26,
@@ -106,8 +107,8 @@ class TransformerDecoderTest(TestCase):
             intermediate_dim=4,
             num_heads=2,
         )
-        decoder_sequence = ops.random.uniform(shape=[1, 4, 6])
-        encoder_sequence = ops.random.uniform(shape=[1, 4, 6])
+        decoder_sequence = random.uniform(shape=[1, 4, 6])
+        encoder_sequence = random.uniform(shape=[1, 4, 6])
         mask = ops.array([[True, True, False, False]])
         decoder_sequence._keras_mask = mask
         outputs = decoder(decoder_sequence, encoder_sequence)
@@ -118,7 +119,7 @@ class TransformerDecoderTest(TestCase):
             intermediate_dim=4,
             num_heads=2,
         )
-        decoder_sequence = ops.random.uniform(shape=[1, 4, 6])
+        decoder_sequence = random.uniform(shape=[1, 4, 6])
         mask = ops.array([[True, True, False, False]])
         decoder_sequence._keras_mask = mask
         outputs = decoder(decoder_sequence)
@@ -132,7 +133,7 @@ class TransformerDecoderTest(TestCase):
         hidden_dim = num_heads * key_dim
 
         input_shape = (batch_size, seq_len, hidden_dim)
-        x = ops.random.uniform(shape=input_shape)
+        x = random.uniform(shape=input_shape)
         input_cache = ops.zeros((batch_size, 2, seq_len, num_heads, key_dim))
         outputs = ops.zeros_like(x)
 
@@ -174,6 +175,6 @@ class TransformerDecoderTest(TestCase):
             intermediate_dim=4,
             num_heads=2,
         )
-        decoder_sequence = ops.random.uniform(shape=[1, 4, 6])
-        encoder_sequence = ops.random.uniform(shape=[1, 4, 5])
+        decoder_sequence = random.uniform(shape=[1, 4, 6])
+        encoder_sequence = random.uniform(shape=[1, 4, 5])
         decoder(decoder_sequence, encoder_sequence)

--- a/keras_nlp/layers/modeling/transformer_encoder_test.py
+++ b/keras_nlp/layers/modeling/transformer_encoder_test.py
@@ -16,6 +16,7 @@ from absl.testing import parameterized
 
 from keras_nlp.backend import keras
 from keras_nlp.backend import ops
+from keras_nlp.backend import random
 from keras_nlp.layers.modeling.transformer_encoder import TransformerEncoder
 from keras_nlp.tests.test_case import TestCase
 
@@ -37,7 +38,7 @@ class TransformerEncoderTest(TestCase):
                 "kernel_initializer": "HeNormal",
                 "bias_initializer": "Zeros",
             },
-            input_data=ops.random.uniform(shape=(2, 4, 6)),
+            input_data=random.uniform(shape=(2, 4, 6)),
             expected_output_shape=(2, 4, 6),
             expected_num_trainable_weights=16,
             expected_num_non_trainable_variables=3,  # dropout rng seeds
@@ -59,7 +60,7 @@ class TransformerEncoderTest(TestCase):
                 encoder,
             ]
         )
-        input = ops.random.uniform(shape=[2, 4, 6])
+        input = random.uniform(shape=[2, 4, 6])
         model(input)
 
     def test_valid_call_with_mask(self):
@@ -68,7 +69,7 @@ class TransformerEncoderTest(TestCase):
             num_heads=2,
         )
         encoder.build([2, 4, 6])
-        input = ops.random.uniform(shape=[2, 4, 6])
+        input = random.uniform(shape=[2, 4, 6])
         mask = input[:, :, 0] < 0.5
         encoder(input, mask)
 
@@ -86,7 +87,7 @@ class TransformerEncoderTest(TestCase):
             intermediate_dim=4,
             num_heads=2,
         )
-        inputs = ops.random.uniform(shape=[1, 4, 6])
+        inputs = random.uniform(shape=[1, 4, 6])
         mask = ops.array([[True, True, False, False]])
         inputs._keras_mask = mask
         outputs = encoder(inputs)

--- a/keras_nlp/layers/modeling/transformer_layer_utils_test.py
+++ b/keras_nlp/layers/modeling/transformer_layer_utils_test.py
@@ -14,6 +14,7 @@
 
 import keras_nlp.layers.modeling.transformer_layer_utils as utils
 from keras_nlp.backend import ops
+from keras_nlp.backend import random
 from keras_nlp.tests.test_case import TestCase
 
 
@@ -25,7 +26,7 @@ class TransformerLayerUtilsTest(TestCase):
     def test_merge_padding_and_attention_mask(self):
         padding_mask = ops.array([[1, 1, 0]])
         attention_mask = ops.array([[[0, 0, 1], [0, 1, 0], [1, 0, 0]]])
-        inputs = ops.random.uniform(shape=[1, 3, 2])
+        inputs = random.uniform(shape=[1, 3, 2])
         merged_mask = utils.merge_padding_and_attention_mask(
             inputs,
             padding_mask,
@@ -37,7 +38,7 @@ class TransformerLayerUtilsTest(TestCase):
         with self.assertRaises(ValueError):
             padding_mask = ops.array([[[1, 1, 0], [1, 0, 0]]])
             attention_mask = ops.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])
-            inputs = ops.random.uniform(shape=[1, 3, 2])
+            inputs = random.uniform(shape=[1, 3, 2])
             utils.merge_padding_and_attention_mask(
                 inputs,
                 padding_mask,
@@ -47,7 +48,7 @@ class TransformerLayerUtilsTest(TestCase):
         with self.assertRaises(ValueError):
             padding_mask = ops.array([[1, 1, 0]])
             attention_mask = ops.array([[0, 0, 1], [1, 0, 0]])
-            inputs = ops.random.uniform(shape=[1, 3, 2])
+            inputs = random.uniform(shape=[1, 3, 2])
             utils.merge_padding_and_attention_mask(
                 inputs,
                 padding_mask,

--- a/keras_nlp/layers/preprocessing/random_deletion.py
+++ b/keras_nlp/layers/preprocessing/random_deletion.py
@@ -21,7 +21,7 @@ from keras_nlp.layers.preprocessing.preprocessing_layer import (
     PreprocessingLayer,
 )
 from keras_nlp.utils.tensor_utils import convert_to_ragged_batch
-from keras_nlp.utils.tensor_utils import is_integer_dtype
+from keras_nlp.utils.tensor_utils import is_int_dtype
 from keras_nlp.utils.tensor_utils import is_string_dtype
 
 
@@ -125,7 +125,7 @@ class RandomDeletion(PreprocessingLayer):
         dtype="int32",
         **kwargs,
     ):
-        if not is_integer_dtype(dtype) and not is_string_dtype(dtype):
+        if not is_int_dtype(dtype) and not is_string_dtype(dtype):
             raise ValueError(
                 "Output dtype must be an integer type or a string. "
                 f"Received: dtype={dtype}"

--- a/keras_nlp/layers/preprocessing/random_swap.py
+++ b/keras_nlp/layers/preprocessing/random_swap.py
@@ -21,7 +21,7 @@ from keras_nlp.layers.preprocessing.preprocessing_layer import (
     PreprocessingLayer,
 )
 from keras_nlp.utils.tensor_utils import convert_to_ragged_batch
-from keras_nlp.utils.tensor_utils import is_integer_dtype
+from keras_nlp.utils.tensor_utils import is_int_dtype
 from keras_nlp.utils.tensor_utils import is_string_dtype
 
 
@@ -127,7 +127,7 @@ class RandomSwap(PreprocessingLayer):
         dtype="int32",
         **kwargs,
     ):
-        if not is_integer_dtype(dtype) and not is_string_dtype(dtype):
+        if not is_int_dtype(dtype) and not is_string_dtype(dtype):
             raise ValueError(
                 "Output dtype must be an integer type or a string. "
                 f"Received: dtype={dtype}"

--- a/keras_nlp/metrics/bleu.py
+++ b/keras_nlp/metrics/bleu.py
@@ -20,7 +20,7 @@ import tensorflow as tf
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.backend import keras
 from keras_nlp.backend import ops
-from keras_nlp.utils.tensor_utils import is_floating_dtype
+from keras_nlp.utils.tensor_utils import is_float_dtype
 from keras_nlp.utils.tensor_utils import tensor_to_list
 
 REPLACE_SUBSTRINGS = [
@@ -112,7 +112,7 @@ class Bleu(keras.metrics.Metric):
     ):
         super().__init__(name=name, dtype=dtype, **kwargs)
 
-        if not is_floating_dtype(dtype):
+        if not is_float_dtype(dtype):
             raise ValueError(
                 "`dtype` must be a floating point type. "
                 f"Received: dtype={dtype}"

--- a/keras_nlp/metrics/edit_distance.py
+++ b/keras_nlp/metrics/edit_distance.py
@@ -16,7 +16,7 @@ import tensorflow as tf
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.backend import keras
-from keras_nlp.utils.tensor_utils import is_floating_dtype
+from keras_nlp.utils.tensor_utils import is_float_dtype
 
 
 @keras_nlp_export("keras_nlp.metrics.EditDistance")
@@ -87,7 +87,7 @@ class EditDistance(keras.metrics.Metric):
     ):
         super().__init__(name=name, dtype=dtype, **kwargs)
 
-        if not is_floating_dtype(dtype):
+        if not is_float_dtype(dtype):
             raise ValueError(
                 "`dtype` must be a floating point type. "
                 f"Received: dtype={dtype}"

--- a/keras_nlp/metrics/perplexity.py
+++ b/keras_nlp/metrics/perplexity.py
@@ -15,7 +15,7 @@
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.backend import keras
 from keras_nlp.backend import ops
-from keras_nlp.utils.tensor_utils import is_floating_dtype
+from keras_nlp.utils.tensor_utils import is_float_dtype
 
 
 @keras_nlp_export("keras_nlp.metrics.Perplexity")
@@ -88,7 +88,7 @@ class Perplexity(keras.metrics.Metric):
         name="perplexity",
         **kwargs,
     ):
-        if not is_floating_dtype(dtype):
+        if not is_float_dtype(dtype):
             raise ValueError(
                 "`dtype` must be a floating point type. "
                 f"Received: dtype={dtype}"

--- a/keras_nlp/metrics/rouge_base.py
+++ b/keras_nlp/metrics/rouge_base.py
@@ -16,7 +16,7 @@ import tensorflow as tf
 
 from keras_nlp.backend import keras
 from keras_nlp.backend import ops
-from keras_nlp.utils.tensor_utils import is_floating_dtype
+from keras_nlp.utils.tensor_utils import is_float_dtype
 from keras_nlp.utils.tensor_utils import tensor_to_list
 
 try:
@@ -65,7 +65,7 @@ class RougeBase(keras.metrics.Metric):
                 "package. Please install it with `pip install rouge-score`."
             )
 
-        if not is_floating_dtype(dtype):
+        if not is_float_dtype(dtype):
             raise ValueError(
                 "`dtype` must be a floating point type. "
                 f"Received: dtype={dtype}"

--- a/keras_nlp/models/albert/albert_presets_test.py
+++ b/keras_nlp/models/albert/albert_presets_test.py
@@ -16,6 +16,7 @@ import pytest
 from absl.testing import parameterized
 
 from keras_nlp.backend import ops
+from keras_nlp.backend import random
 from keras_nlp.models.albert.albert_backbone import AlbertBackbone
 from keras_nlp.models.albert.albert_classifier import AlbertClassifier
 from keras_nlp.models.albert.albert_preprocessor import AlbertPreprocessor
@@ -138,7 +139,7 @@ class AlbertPresetFullTest(TestCase):
                 preset, load_weights=load_weights
             )
             input_data = {
-                "token_ids": ops.random.uniform(
+                "token_ids": random.uniform(
                     shape=(1, 512), dtype="int64", maxval=model.vocabulary_size
                 ),
                 "segment_ids": ops.array([0] * 200 + [1] * 312, shape=(1, 512)),
@@ -171,7 +172,7 @@ class AlbertPresetFullTest(TestCase):
                 load_weights=load_weights,
             )
             input_data = {
-                "token_ids": ops.random.uniform(
+                "token_ids": random.uniform(
                     shape=(1, 512),
                     dtype="int64",
                     maxval=classifier.backbone.vocabulary_size,

--- a/keras_nlp/models/bart/bart_presets_test.py
+++ b/keras_nlp/models/bart/bart_presets_test.py
@@ -15,6 +15,7 @@
 #
 
 from keras_nlp.backend import ops
+from keras_nlp.backend import random
 from keras_nlp.tests.test_case import TestCase
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -117,7 +118,7 @@ class BartPresetFullTest(TestCase):
         for preset in BartBackbone.presets:
             model = BartBackbone.from_preset(preset, load_weights=load_weights)
             input_data = {
-                "encoder_token_ids": ops.random.uniform(
+                "encoder_token_ids": random.uniform(
                     shape=(1, 1024),
                     dtype="int64",
                     maxval=model.vocabulary_size,
@@ -125,7 +126,7 @@ class BartPresetFullTest(TestCase):
                 "encoder_padding_mask": ops.array(
                     [1] * 768 + [0] * 256, shape=(1, 1024)
                 ),
-                "decoder_token_ids": ops.random.uniform(
+                "decoder_token_ids": random.uniform(
                     shape=(1, 1024),
                     dtype="int64",
                     maxval=model.vocabulary_size,

--- a/keras_nlp/models/bert/bert_presets_test.py
+++ b/keras_nlp/models/bert/bert_presets_test.py
@@ -16,6 +16,7 @@ import pytest
 from absl.testing import parameterized
 
 from keras_nlp.backend import ops
+from keras_nlp.backend import random
 from keras_nlp.models.bert.bert_backbone import BertBackbone
 from keras_nlp.models.bert.bert_classifier import BertClassifier
 from keras_nlp.models.bert.bert_preprocessor import BertPreprocessor
@@ -186,7 +187,7 @@ class BertPresetFullTest(TestCase):
         for preset in BertBackbone.presets:
             model = BertBackbone.from_preset(preset, load_weights=load_weights)
             input_data = {
-                "token_ids": ops.random.uniform(
+                "token_ids": random.uniform(
                     shape=(1, 512), dtype="int64", maxval=model.vocabulary_size
                 ),
                 "segment_ids": ops.array([0] * 200 + [1] * 312, shape=(1, 512)),
@@ -219,7 +220,7 @@ class BertPresetFullTest(TestCase):
                 load_weights=load_weights,
             )
             input_data = {
-                "token_ids": ops.random.uniform(
+                "token_ids": random.uniform(
                     shape=(1, 512),
                     dtype="int64",
                     maxval=classifier.backbone.vocabulary_size,

--- a/keras_nlp/models/deberta_v3/deberta_v3_presets_test.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_presets_test.py
@@ -16,6 +16,7 @@ import pytest
 from absl.testing import parameterized
 
 from keras_nlp.backend import ops
+from keras_nlp.backend import random
 from keras_nlp.models.deberta_v3.deberta_v3_backbone import DebertaV3Backbone
 from keras_nlp.models.deberta_v3.deberta_v3_classifier import (
     DebertaV3Classifier,
@@ -150,7 +151,7 @@ class DebertaV3PresetFullTest(TestCase):
                 preset, load_weights=load_weights
             )
             input_data = {
-                "token_ids": ops.random.uniform(
+                "token_ids": random.uniform(
                     shape=(1, 512), dtype="int64", maxval=model.vocabulary_size
                 ),
                 "padding_mask": ops.array([1] * 512, shape=(1, 512)),
@@ -182,7 +183,7 @@ class DebertaV3PresetFullTest(TestCase):
                 preprocessor=None,
             )
             input_data = {
-                "token_ids": ops.random.uniform(
+                "token_ids": random.uniform(
                     shape=(1, 512),
                     dtype="int64",
                     maxval=classifier.backbone.vocabulary_size,

--- a/keras_nlp/models/distil_bert/distil_bert_presets_test.py
+++ b/keras_nlp/models/distil_bert/distil_bert_presets_test.py
@@ -16,6 +16,7 @@ import pytest
 from absl.testing import parameterized
 
 from keras_nlp.backend import ops
+from keras_nlp.backend import random
 from keras_nlp.models.distil_bert.distil_bert_backbone import DistilBertBackbone
 from keras_nlp.models.distil_bert.distil_bert_classifier import (
     DistilBertClassifier,
@@ -141,7 +142,7 @@ class DistilBertPresetFullTest(TestCase):
                 preset, load_weights=load_weights
             )
             input_data = {
-                "token_ids": ops.random.uniform(
+                "token_ids": random.uniform(
                     shape=(1, 512), dtype="int64", maxval=model.vocabulary_size
                 ),
                 "padding_mask": ops.array([1] * 512, shape=(1, 512)),
@@ -173,7 +174,7 @@ class DistilBertPresetFullTest(TestCase):
                 preprocessor=None,
             )
             input_data = {
-                "token_ids": ops.random.uniform(
+                "token_ids": random.uniform(
                     shape=(1, 512),
                     dtype="int64",
                     maxval=classifier.backbone.vocabulary_size,

--- a/keras_nlp/models/f_net/f_net_presets_test.py
+++ b/keras_nlp/models/f_net/f_net_presets_test.py
@@ -16,6 +16,7 @@ import pytest
 from absl.testing import parameterized
 
 from keras_nlp.backend import ops
+from keras_nlp.backend import random
 from keras_nlp.models.f_net.f_net_backbone import FNetBackbone
 from keras_nlp.models.f_net.f_net_classifier import FNetClassifier
 from keras_nlp.models.f_net.f_net_preprocessor import FNetPreprocessor
@@ -126,7 +127,7 @@ class FNetPresetFullTest(TestCase):
         for preset in FNetBackbone.presets:
             model = FNetBackbone.from_preset(preset, load_weights=load_weights)
             input_data = {
-                "token_ids": ops.random.uniform(
+                "token_ids": random.uniform(
                     shape=(1, 512), dtype="int64", maxval=model.vocabulary_size
                 ),
                 "segment_ids": ops.array([0] * 200 + [1] * 312, shape=(1, 512)),
@@ -158,7 +159,7 @@ class FNetPresetFullTest(TestCase):
                 load_weights=load_weights,
             )
             input_data = {
-                "token_ids": ops.random.uniform(
+                "token_ids": random.uniform(
                     shape=(1, 512),
                     dtype="int64",
                     maxval=classifier.backbone.vocabulary_size,

--- a/keras_nlp/models/gpt2/gpt2_presets_test.py
+++ b/keras_nlp/models/gpt2/gpt2_presets_test.py
@@ -16,6 +16,7 @@ import pytest
 from absl.testing import parameterized
 
 from keras_nlp.backend import ops
+from keras_nlp.backend import random
 from keras_nlp.models.gpt2.gpt2_backbone import GPT2Backbone
 from keras_nlp.models.gpt2.gpt2_tokenizer import GPT2Tokenizer
 from keras_nlp.tests.test_case import TestCase
@@ -94,7 +95,7 @@ class GPT2PresetFullTest(TestCase):
         for preset in GPT2Backbone.presets:
             model = GPT2Backbone.from_preset(preset, load_weights=load_weights)
             input_data = {
-                "token_ids": ops.random.uniform(
+                "token_ids": random.uniform(
                     shape=(1, 1024),
                     dtype="int64",
                     maxval=model.vocabulary_size,

--- a/keras_nlp/models/opt/opt_presets_test.py
+++ b/keras_nlp/models/opt/opt_presets_test.py
@@ -16,6 +16,7 @@ import pytest
 from absl.testing import parameterized
 
 from keras_nlp.backend import ops
+from keras_nlp.backend import random
 from keras_nlp.models.opt.opt_backbone import OPTBackbone
 from keras_nlp.models.opt.opt_tokenizer import OPTTokenizer
 from keras_nlp.tests.test_case import TestCase
@@ -94,7 +95,7 @@ class OPTPresetFullTest(TestCase):
         for preset in OPTBackbone.presets:
             model = OPTBackbone.from_preset(preset, load_weights=load_weights)
             input_data = {
-                "token_ids": ops.random.uniform(
+                "token_ids": random.uniform(
                     shape=(1, 1024),
                     dtype="int64",
                     maxval=model.vocabulary_size,

--- a/keras_nlp/models/roberta/roberta_presets_test.py
+++ b/keras_nlp/models/roberta/roberta_presets_test.py
@@ -16,6 +16,7 @@ import pytest
 from absl.testing import parameterized
 
 from keras_nlp.backend import ops
+from keras_nlp.backend import random
 from keras_nlp.models.roberta.roberta_backbone import RobertaBackbone
 from keras_nlp.models.roberta.roberta_classifier import RobertaClassifier
 from keras_nlp.models.roberta.roberta_masked_lm import RobertaMaskedLM
@@ -167,7 +168,7 @@ class RobertaPresetFullTest(TestCase):
                 preset, load_weights=load_weights
             )
             input_data = {
-                "token_ids": ops.random.uniform(
+                "token_ids": random.uniform(
                     shape=(1, 512), dtype="int64", maxval=model.vocabulary_size
                 ),
                 "padding_mask": ops.array([1] * 512, shape=(1, 512)),
@@ -197,7 +198,7 @@ class RobertaPresetFullTest(TestCase):
                 load_weights=load_weights,
             )
             input_data = {
-                "token_ids": ops.random.uniform(
+                "token_ids": random.uniform(
                     shape=(1, 512),
                     dtype="int64",
                     maxval=classifier.backbone.vocabulary_size,
@@ -228,7 +229,7 @@ class RobertaPresetFullTest(TestCase):
                 load_weights=load_weights,
             )
             input_data = {
-                "token_ids": ops.random.uniform(
+                "token_ids": random.uniform(
                     shape=(1, 512),
                     dtype="int64",
                     maxval=classifier.backbone.vocabulary_size,

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -14,11 +14,11 @@
 
 import os
 
-import keras_core
 from rich import console as rich_console
 from rich import markup
 from rich import table as rich_table
 
+from keras_nlp.backend import config
 from keras_nlp.backend import keras
 from keras_nlp.utils.keras_utils import print_msg
 from keras_nlp.utils.pipeline_model import PipelineModel
@@ -315,11 +315,21 @@ class Task(PipelineModel):
             if print_fn:
                 print_fn(console.end_capture(), line_break=False)
 
-        # Hardcode summary from keras_core for now.
-        keras_core.Model.summary(
-            self,
-            line_length=line_length,
-            positions=positions,
-            print_fn=print_fn,
-            **kwargs,
-        )
+        # Avoid `tf.keras.Model.summary()`, so the above output matches.
+        if config.multi_backend():
+            super().summary(
+                line_length=line_length,
+                positions=positions,
+                print_fn=print_fn,
+                **kwargs,
+            )
+        else:
+            import keras_core
+
+            keras_core.Model.summary(
+                self,
+                line_length=line_length,
+                positions=positions,
+                print_fn=print_fn,
+                **kwargs,
+            )

--- a/keras_nlp/models/whisper/whisper_audio_feature_extractor_test.py
+++ b/keras_nlp/models/whisper/whisper_audio_feature_extractor_test.py
@@ -42,10 +42,10 @@ class WhisperAudioFeatureExtractorTest(TestCase):
         outputs = self.audio_feature_extractor(audio_tensor)
 
         # Verify shape.
-        self.assertEqual(outputs.shape, (1, 5, self.num_mels))
+        self.assertEqual(outputs.shape, (5, self.num_mels))
         # Verify output.
         expected = [1.1656, 1.0151, -0.8343, -0.8343, -0.8343]
-        self.assertAllClose(outputs[0, :, 0], expected, atol=0.01, rtol=0.01)
+        self.assertAllClose(outputs[:, 0], expected, atol=0.01, rtol=0.01)
 
     def test_batched_inputs(self):
         audio_tensor_1 = tf.ones((2,), dtype="float32")

--- a/keras_nlp/models/whisper/whisper_preprocessor.py
+++ b/keras_nlp/models/whisper/whisper_preprocessor.py
@@ -14,7 +14,6 @@
 
 import copy
 
-import tensorflow as tf
 from absl import logging
 
 from keras_nlp.api_export import keras_nlp_export
@@ -278,9 +277,6 @@ class WhisperPreprocessor(Preprocessor):
             )
 
         encoder_features = self.audio_feature_extractor(encoder_audio[0])
-        if encoder_audio[0].shape.rank < 2:
-            encoder_features = tf.squeeze(encoder_features, axis=0)
-
         decoder_sequence_length = (
             decoder_sequence_length or self.decoder_sequence_length
         )

--- a/keras_nlp/models/whisper/whisper_preprocessor_test.py
+++ b/keras_nlp/models/whisper/whisper_preprocessor_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import tensorflow as tf
 
 from keras_nlp.backend import keras
@@ -89,8 +90,8 @@ class WhisperPreprocessorTest(TestCase):
 
     def test_unbatched_preprocess(self):
         input_data = {
-            "encoder_audio": tf.ones((200,)),
-            "decoder_text": tf.constant(" airplane at airport"),
+            "encoder_audio": np.ones((200,)),
+            "decoder_text": " airplane at airport",
         }
 
         x = self.preprocessor(input_data)
@@ -106,8 +107,8 @@ class WhisperPreprocessorTest(TestCase):
 
     def test_preprocess_batch(self):
         input_data = {
-            "encoder_audio": tf.ones((4, 200)),
-            "decoder_text": tf.constant([" airplane at airport"] * 4),
+            "encoder_audio": np.ones((4, 200)),
+            "decoder_text": [" airplane at airport"] * 4,
         }
 
         x = self.preprocessor(input_data)
@@ -125,11 +126,11 @@ class WhisperPreprocessorTest(TestCase):
 
     def test_preprocess_labeled_batch(self):
         x = {
-            "encoder_audio": tf.ones((4, 200)),
-            "decoder_text": tf.constant([" airplane at airport"] * 4),
+            "encoder_audio": np.ones((4, 200)),
+            "decoder_text": [" airplane at airport"] * 4,
         }
-        y_in = tf.constant([1] * 4)
-        sw_in = tf.constant([1.0] * 4)
+        y_in = np.ones((4,))
+        sw_in = np.ones((4,))
         x, y, sw = self.preprocessor(x, y_in, sw_in)
         self.assertAllEqual(
             x["encoder_features"].shape, [4, self.output_length, self.num_mels]
@@ -147,8 +148,8 @@ class WhisperPreprocessorTest(TestCase):
 
     def test_preprocess_dataset(self):
         x = {
-            "encoder_audio": tf.ones((4, 200)),
-            "decoder_text": tf.constant([" airplane at airport"] * 4),
+            "encoder_audio": np.ones((4, 200)),
+            "decoder_text": [" airplane at airport"] * 4,
         }
         ds = tf.data.Dataset.from_tensor_slices(x)
         ds = ds.map(self.preprocessor)
@@ -167,8 +168,8 @@ class WhisperPreprocessorTest(TestCase):
 
     def test_sequence_length_override(self):
         input_data = {
-            "encoder_audio": tf.ones((200,)),
-            "decoder_text": tf.constant(" airplane at airport"),
+            "encoder_audio": np.ones((200,)),
+            "decoder_text": " airplane at airport",
         }
         x = self.preprocessor(input_data, decoder_sequence_length=6)
         self.assertAllEqual(x["decoder_token_ids"], [9, 14, 13, 11, 0, 10])

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_presets_test.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_presets_test.py
@@ -16,6 +16,7 @@ import pytest
 from absl.testing import parameterized
 
 from keras_nlp.backend import ops
+from keras_nlp.backend import random
 from keras_nlp.models.xlm_roberta.xlm_roberta_backbone import XLMRobertaBackbone
 from keras_nlp.models.xlm_roberta.xlm_roberta_classifier import (
     XLMRobertaClassifier,
@@ -143,7 +144,7 @@ class XLMRobertaPresetFullTest(TestCase):
                 preset, load_weights=load_weights
             )
             input_data = {
-                "token_ids": ops.random.uniform(
+                "token_ids": random.uniform(
                     shape=(1, 512), dtype="int64", maxval=model.vocabulary_size
                 ),
                 "padding_mask": ops.array([1] * 512, shape=(1, 512)),
@@ -177,7 +178,7 @@ class XLMRobertaPresetFullTest(TestCase):
                 preprocessor=None,
             )
             input_data = {
-                "token_ids": ops.random.uniform(
+                "token_ids": random.uniform(
                     shape=(1, 512),
                     dtype="int64",
                     maxval=classifier.backbone.vocabulary_size,

--- a/keras_nlp/tests/test_case.py
+++ b/keras_nlp/tests/test_case.py
@@ -17,12 +17,12 @@ import json
 import tensorflow as tf
 import tree
 from absl.testing import parameterized
-from keras_core.backend import is_float_dtype
-from keras_core.backend import standardize_dtype
 
 from keras_nlp.backend import config
 from keras_nlp.backend import keras
 from keras_nlp.backend import ops
+from keras_nlp.utils.tensor_utils import is_float_dtype
+from keras_nlp.utils.tensor_utils import standardize_dtype
 
 
 def convert_to_comparible_type(x):
@@ -39,7 +39,7 @@ def convert_to_comparible_type(x):
         return tree.map_structure(lambda x: x.decode("utf-8"), x)
     if isinstance(x, (tf.Tensor, tf.RaggedTensor)):
         return x
-    if ops.is_tensor(x):
+    if hasattr(x, "__array__"):
         return ops.convert_to_numpy(x)
     return x
 

--- a/keras_nlp/tokenizers/byte_pair_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer.py
@@ -34,7 +34,7 @@ from keras_nlp.utils.python_utils import classproperty
 from keras_nlp.utils.python_utils import format_docstring
 from keras_nlp.utils.tensor_utils import assert_tf_text_installed
 from keras_nlp.utils.tensor_utils import convert_to_ragged_batch
-from keras_nlp.utils.tensor_utils import is_integer_dtype
+from keras_nlp.utils.tensor_utils import is_int_dtype
 from keras_nlp.utils.tensor_utils import is_string_dtype
 
 try:
@@ -283,7 +283,7 @@ class BytePairTokenizer(tokenizer.Tokenizer):
     ) -> None:
         assert_tf_text_installed(self.__class__.__name__)
 
-        if not is_integer_dtype(dtype) and not is_string_dtype(dtype):
+        if not is_int_dtype(dtype) and not is_string_dtype(dtype):
             raise ValueError(
                 "Output dtype must be an integer type or a string. "
                 f"Received: dtype={dtype}"

--- a/keras_nlp/tokenizers/byte_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_tokenizer.py
@@ -19,7 +19,7 @@ from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.tokenizers import tokenizer
 from keras_nlp.utils.tensor_utils import assert_tf_text_installed
 from keras_nlp.utils.tensor_utils import convert_to_ragged_batch
-from keras_nlp.utils.tensor_utils import is_integer_dtype
+from keras_nlp.utils.tensor_utils import is_int_dtype
 
 try:
     import tensorflow_text as tf_text
@@ -165,7 +165,7 @@ class ByteTokenizer(tokenizer.Tokenizer):
     ):
         assert_tf_text_installed(self.__class__.__name__)
 
-        if not is_integer_dtype(dtype):
+        if not is_int_dtype(dtype):
             raise ValueError(
                 "Output dtype must be an integer type. "
                 f"Received: dtype={dtype}"

--- a/keras_nlp/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/sentence_piece_tokenizer.py
@@ -26,7 +26,7 @@ from keras_nlp.utils.python_utils import classproperty
 from keras_nlp.utils.python_utils import format_docstring
 from keras_nlp.utils.tensor_utils import assert_tf_text_installed
 from keras_nlp.utils.tensor_utils import convert_to_ragged_batch
-from keras_nlp.utils.tensor_utils import is_integer_dtype
+from keras_nlp.utils.tensor_utils import is_int_dtype
 from keras_nlp.utils.tensor_utils import is_string_dtype
 from keras_nlp.utils.tensor_utils import tensor_to_list
 
@@ -113,7 +113,7 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
     ) -> None:
         assert_tf_text_installed(self.__class__.__name__)
 
-        if not is_integer_dtype(dtype) and not is_string_dtype(dtype):
+        if not is_int_dtype(dtype) and not is_string_dtype(dtype):
             raise ValueError(
                 "Output dtype must be an integer type or a string. "
                 f"Received: dtype={dtype}"

--- a/keras_nlp/tokenizers/unicode_codepoint_tokenizer.py
+++ b/keras_nlp/tokenizers/unicode_codepoint_tokenizer.py
@@ -18,7 +18,7 @@ from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.tokenizers import tokenizer
 from keras_nlp.utils.tensor_utils import assert_tf_text_installed
 from keras_nlp.utils.tensor_utils import convert_to_ragged_batch
-from keras_nlp.utils.tensor_utils import is_integer_dtype
+from keras_nlp.utils.tensor_utils import is_int_dtype
 
 try:
     import tensorflow_text as tf_text
@@ -219,7 +219,7 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
     ) -> None:
         assert_tf_text_installed(self.__class__.__name__)
 
-        if not is_integer_dtype(dtype):
+        if not is_int_dtype(dtype):
             raise ValueError(
                 "Output dtype must be an integer type. "
                 f"Received: dtype={dtype}"

--- a/keras_nlp/tokenizers/word_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer.py
@@ -25,7 +25,7 @@ from keras_nlp.utils.python_utils import classproperty
 from keras_nlp.utils.python_utils import format_docstring
 from keras_nlp.utils.tensor_utils import assert_tf_text_installed
 from keras_nlp.utils.tensor_utils import convert_to_ragged_batch
-from keras_nlp.utils.tensor_utils import is_integer_dtype
+from keras_nlp.utils.tensor_utils import is_int_dtype
 from keras_nlp.utils.tensor_utils import is_string_dtype
 
 try:
@@ -305,7 +305,7 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
     ) -> None:
         assert_tf_text_installed(self.__class__.__name__)
 
-        if not is_integer_dtype(dtype) and not is_string_dtype(dtype):
+        if not is_int_dtype(dtype) and not is_string_dtype(dtype):
             raise ValueError(
                 "Output dtype must be an integer type or a string. "
                 f"Received: dtype={dtype}"

--- a/keras_nlp/utils/tensor_utils.py
+++ b/keras_nlp/utils/tensor_utils.py
@@ -15,6 +15,7 @@
 import tensorflow as tf
 
 from keras_nlp.backend import config
+from keras_nlp.backend import keras
 from keras_nlp.backend import ops
 
 try:
@@ -151,19 +152,21 @@ def is_tensor_type(x):
     return hasattr(x, "__array__")
 
 
-def is_floating_dtype(dtype):
+def standardize_dtype(dtype):
+    if config.multi_backend():
+        return keras.backend.standardize_dtype(dtype)
     if hasattr(dtype, "name"):
-        dtype = dtype.name
-    return "float" in dtype
+        return dtype.name
+    return dtype
 
 
-def is_integer_dtype(dtype):
-    if hasattr(dtype, "name"):
-        dtype = dtype.name
-    return "int" in dtype
+def is_float_dtype(dtype):
+    return "float" in standardize_dtype(dtype)
+
+
+def is_int_dtype(dtype):
+    return "int" in standardize_dtype(dtype)
 
 
 def is_string_dtype(dtype):
-    if hasattr(dtype, "name"):
-        dtype = dtype.name
-    return "string" in dtype
+    return "string" in standardize_dtype(dtype)


### PR DESCRIPTION
Currently this is only available via github.
Eventually this will be available via `pip install keras`.
We need it now to support testing against the latest keras changes.

As part of this changes, we will also move our off any private, unexported symbols (no more keras_core.src).