### PR TITLE
Make gelu a function, not a lambda so it can be loaded without safe_mode=False

### DIFF
--- a/keras_nlp/models/albert/albert_backbone.py
+++ b/keras_nlp/models/albert/albert_backbone.py
@@ -21,6 +21,7 @@ from keras_nlp.layers.modeling.reversible_embedding import ReversibleEmbedding
 from keras_nlp.layers.modeling.transformer_encoder import TransformerEncoder
 from keras_nlp.models.albert.albert_presets import backbone_presets
 from keras_nlp.models.backbone import Backbone
+from keras_nlp.utils.keras_utils import gelu_approximate
 from keras_nlp.utils.python_utils import classproperty
 
 
@@ -180,9 +181,7 @@ class AlbertBackbone(Backbone):
                 TransformerEncoder(
                     num_heads=num_heads,
                     intermediate_dim=intermediate_dim,
-                    activation=lambda x: keras.activations.gelu(
-                        x, approximate=True
-                    ),
+                    activation=gelu_approximate,
                     dropout=dropout,
                     layer_norm_epsilon=1e-12,
                     kernel_initializer=albert_kernel_initializer(),

--- a/keras_nlp/models/albert/albert_masked_lm.py
+++ b/keras_nlp/models/albert/albert_masked_lm.py
@@ -24,6 +24,7 @@ from keras_nlp.models.albert.albert_masked_lm_preprocessor import (
 )
 from keras_nlp.models.albert.albert_presets import backbone_presets
 from keras_nlp.models.task import Task
+from keras_nlp.utils.keras_utils import gelu_approximate
 from keras_nlp.utils.python_utils import classproperty
 
 
@@ -107,9 +108,7 @@ class AlbertMaskedLM(Task):
         outputs = MaskedLMHead(
             vocabulary_size=backbone.vocabulary_size,
             token_embedding=backbone.token_embedding,
-            intermediate_activation=lambda x: keras.activations.gelu(
-                x, approximate=True
-            ),
+            intermediate_activation=gelu_approximate,
             kernel_initializer=albert_kernel_initializer(),
             name="mlm_head",
         )(backbone_outputs["sequence_output"], inputs["mask_positions"])

--- a/keras_nlp/models/bart/bart_backbone.py
+++ b/keras_nlp/models/bart/bart_backbone.py
@@ -157,9 +157,7 @@ class BartBackbone(Backbone):
             x = TransformerEncoder(
                 num_heads=num_heads,
                 intermediate_dim=intermediate_dim,
-                activation=lambda x: keras.activations.gelu(
-                    x, approximate=False
-                ),
+                activation=keras.activations.gelu,
                 dropout=dropout,
                 layer_norm_epsilon=1e-5,
                 kernel_initializer=bart_kernel_initializer(),
@@ -200,9 +198,7 @@ class BartBackbone(Backbone):
                 intermediate_dim=intermediate_dim,
                 num_heads=num_heads,
                 dropout=dropout,
-                activation=lambda x: keras.activations.gelu(
-                    x, approximate=False
-                ),
+                activation=keras.activations.gelu,
                 layer_norm_epsilon=1e-5,
                 kernel_initializer=bart_kernel_initializer(),
                 name=f"transformer_decoder_layer_{i}",

--- a/keras_nlp/models/bert/bert_backbone.py
+++ b/keras_nlp/models/bert/bert_backbone.py
@@ -28,6 +28,10 @@ def bert_kernel_initializer(stddev=0.02):
     return keras.initializers.TruncatedNormal(stddev=stddev)
 
 
+def gelu_approximate(x):
+    return keras.activations.gelu(x, approximate=True)
+
+
 @keras_nlp_export("keras_nlp.models.BertBackbone")
 class BertBackbone(Backbone):
     """A BERT encoder network.
@@ -151,9 +155,7 @@ class BertBackbone(Backbone):
             x = TransformerEncoder(
                 num_heads=num_heads,
                 intermediate_dim=intermediate_dim,
-                activation=lambda x: keras.activations.gelu(
-                    x, approximate=True
-                ),
+                activation=gelu_approximate,
                 dropout=dropout,
                 layer_norm_epsilon=1e-12,
                 kernel_initializer=bert_kernel_initializer(),

--- a/keras_nlp/models/bert/bert_backbone.py
+++ b/keras_nlp/models/bert/bert_backbone.py
@@ -21,15 +21,12 @@ from keras_nlp.layers.modeling.reversible_embedding import ReversibleEmbedding
 from keras_nlp.layers.modeling.transformer_encoder import TransformerEncoder
 from keras_nlp.models.backbone import Backbone
 from keras_nlp.models.bert.bert_presets import backbone_presets
+from keras_nlp.utils.keras_utils import gelu_approximate
 from keras_nlp.utils.python_utils import classproperty
 
 
 def bert_kernel_initializer(stddev=0.02):
     return keras.initializers.TruncatedNormal(stddev=stddev)
-
-
-def gelu_approximate(x):
-    return keras.activations.gelu(x, approximate=True)
 
 
 @keras_nlp_export("keras_nlp.models.BertBackbone")

--- a/keras_nlp/models/deberta_v3/deberta_v3_backbone.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_backbone.py
@@ -153,9 +153,7 @@ class DebertaV3Backbone(Backbone):
                 max_position_embeddings=max_sequence_length,
                 bucket_size=bucket_size,
                 dropout=dropout,
-                activation=lambda x: keras.activations.gelu(
-                    x, approximate=False
-                ),
+                activation=keras.activations.gelu,
                 layer_norm_epsilon=1e-7,
                 kernel_initializer=deberta_kernel_initializer(),
                 name=f"disentangled_attention_encoder_layer_{i}",

--- a/keras_nlp/models/deberta_v3/deberta_v3_classifier.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_classifier.py
@@ -170,7 +170,7 @@ class DebertaV3Classifier(Task):
         x = keras.layers.Dropout(dropout, name="pooled_dropout")(x)
         x = keras.layers.Dense(
             hidden_dim,
-            activation=lambda x: keras.activations.gelu(x, approximate=False),
+            activation=keras.activations.gelu,
             name="pooled_dense",
         )(x)
         x = keras.layers.Dropout(backbone.dropout, name="classifier_dropout")(x)

--- a/keras_nlp/models/deberta_v3/deberta_v3_masked_lm.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_masked_lm.py
@@ -114,9 +114,7 @@ class DebertaV3MaskedLM(Task):
         outputs = MaskedLMHead(
             vocabulary_size=backbone.vocabulary_size,
             token_embedding=backbone.token_embedding,
-            intermediate_activation=lambda x: keras.activations.gelu(
-                x, approximate=False
-            ),
+            intermediate_activation=keras.activations.gelu,
             kernel_initializer=deberta_kernel_initializer(),
             name="mlm_head",
         )(backbone_outputs, inputs["mask_positions"])

--- a/keras_nlp/models/f_net/f_net_backbone.py
+++ b/keras_nlp/models/f_net/f_net_backbone.py
@@ -21,6 +21,7 @@ from keras_nlp.layers.modeling.position_embedding import PositionEmbedding
 from keras_nlp.layers.modeling.reversible_embedding import ReversibleEmbedding
 from keras_nlp.models.backbone import Backbone
 from keras_nlp.models.f_net.f_net_presets import backbone_presets
+from keras_nlp.utils.keras_utils import gelu_approximate
 from keras_nlp.utils.python_utils import classproperty
 
 
@@ -156,9 +157,7 @@ class FNetBackbone(Backbone):
         for i in range(num_layers):
             x = FNetEncoder(
                 intermediate_dim=intermediate_dim,
-                activation=lambda x: keras.activations.gelu(
-                    x, approximate=True
-                ),
+                activation=gelu_approximate,
                 dropout=dropout,
                 layer_norm_epsilon=1e-12,
                 kernel_initializer=f_net_kernel_initializer(),

--- a/keras_nlp/models/gpt2/gpt2_backbone.py
+++ b/keras_nlp/models/gpt2/gpt2_backbone.py
@@ -25,6 +25,7 @@ from keras_nlp.layers.modeling.reversible_embedding import ReversibleEmbedding
 from keras_nlp.layers.modeling.transformer_decoder import TransformerDecoder
 from keras_nlp.models.backbone import Backbone
 from keras_nlp.models.gpt2.gpt2_presets import backbone_presets
+from keras_nlp.utils.keras_utils import gelu_approximate
 from keras_nlp.utils.python_utils import classproperty
 
 
@@ -139,9 +140,7 @@ class GPT2Backbone(Backbone):
                 num_heads=num_heads,
                 dropout=dropout,
                 layer_norm_epsilon=1e-05,
-                activation=lambda x: keras.activations.gelu(
-                    x, approximate=True
-                ),
+                activation=gelu_approximate,
                 kernel_initializer=_gpt_2_kernel_initializer(stddev=0.02),
                 normalize_first=True,
                 name=f"transformer_layer_{i}",

--- a/keras_nlp/models/gpt_neo_x/gpt_neo_x_backbone.py
+++ b/keras_nlp/models/gpt_neo_x/gpt_neo_x_backbone.py
@@ -17,6 +17,7 @@ from keras_nlp.backend import keras
 from keras_nlp.layers.modeling.reversible_embedding import ReversibleEmbedding
 from keras_nlp.models.backbone import Backbone
 from keras_nlp.models.gpt_neo_x.gpt_neo_x_decoder import GPTNeoXDecoder
+from keras_nlp.utils.keras_utils import gelu_approximate
 
 
 def _gpt_neo_x_kernel_initializer(stddev=0.02):
@@ -106,9 +107,7 @@ class GPTNeoXBackbone(Backbone):
                 rotary_percentage=rotary_percentage,
                 rotary_max_wavelength=rotary_max_wavelength,
                 layer_norm_epsilon=layer_norm_epsilon,
-                activation=lambda x: keras.activations.gelu(
-                    x, approximate=True
-                ),
+                activation=gelu_approximate,
                 kernel_initializer=_gpt_neo_x_kernel_initializer(stddev=0.02),
                 name=f"transformer_layer_{i}",
             )(x, decoder_padding_mask=padding_mask)

--- a/keras_nlp/models/whisper/whisper_backbone.py
+++ b/keras_nlp/models/whisper/whisper_backbone.py
@@ -187,9 +187,7 @@ class WhisperBackbone(Backbone):
             x = WhisperEncoder(
                 num_heads=num_heads,
                 intermediate_dim=intermediate_dim,
-                activation=lambda x: keras.activations.gelu(
-                    x, approximate=False
-                ),
+                activation=keras.activations.gelu,
                 layer_norm_epsilon=1e-5,
                 dropout=dropout,
                 kernel_initializer=whisper_kernel_initializer(),
@@ -229,9 +227,7 @@ class WhisperBackbone(Backbone):
                 intermediate_dim=intermediate_dim,
                 num_heads=num_heads,
                 dropout=dropout,
-                activation=lambda x: keras.activations.gelu(
-                    x, approximate=False
-                ),
+                activation=keras.activations.gelu,
                 layer_norm_epsilon=1e-5,
                 kernel_initializer=whisper_kernel_initializer(),
                 normalize_first=True,

--- a/keras_nlp/utils/keras_utils.py
+++ b/keras_nlp/utils/keras_utils.py
@@ -155,3 +155,8 @@ def print_row(fields, positions, print_fn, nested_level=0):
                 line += " " * (positions[col] - len(line))
         line += "|" * nested_level
         print_fn(line)
+
+
+@keras.saving.register_keras_serializable(package="keras_nlp")
+def gelu_approximate(x):
+    return keras.activations.gelu(x, approximate=True)


### PR DESCRIPTION
Currently, saving a BertBackbone in keras format results in:
```
UserWarning: The object being serialized includes a `lambda`. This is unsafe. In order to reload the object, you will have to pass `safe_mode=False` to the loading function. Please avoid using `lambda` in the future, and use named Python functions instead. This is the `lambda` being serialized:                 activation=lambda x: keras.activations.gelu(
                    x, approximate=True
                ),
```

This MR moves the code into a named python function, as suggested by the keras warning.