### PR TITLE
Switch to new model parallelism api

### DIFF
--- a/keras_nlp/models/backbone.py
+++ b/keras_nlp/models/backbone.py
@@ -142,3 +142,77 @@ class Backbone(keras.Model):
                 example_preset_name=next(iter(cls.presets), ""),
                 preset_names='", "'.join(cls.presets),
             )(cls.from_preset.__func__)
+
+        # If the subclass does not define from_preset, assign a wrapper so that
+        # each class can have a distinct docstring.
+        if "create_layout_map" not in cls.__dict__:
+
+            def create_layout_map(calling_cls, *args, **kwargs):
+                return super(cls, calling_cls).create_layout_map(
+                    *args, **kwargs
+                )
+
+            cls.create_layout_map = classmethod(create_layout_map)
+
+        # Format and assign the docstring unless the subclass has overridden it.
+        if cls.create_layout_map.__doc__ is None:
+            cls.create_layout_map.__func__.__doc__ = (
+                Backbone.create_layout_map.__doc__
+            )
+            format_docstring(
+                model_name=cls.__name__,
+            )(cls.create_layout_map.__func__)
+
+    @classmethod
+    def create_layout_map(cls, device_mesh):
+        """Create a layout map for model parallel training a {{model_name}}.
+
+        This method takes in a `keras.distribution.DeviceMesh` and returns a
+        `keras.distribution.LayoutMap` that will correctly distribute weights
+        for a backbone in a model parallel setting.
+
+        Args:
+            device_mesh: A 2D `keras.distribution.DeviceMesh` describing the
+                arrangement of devices for running distributed computation. The
+                first dimension in the mesh is expected to be for data parallel
+                distribution, and the second for model parallel distribution.
+
+        Returns:
+            A `keras.distribution.LayoutMap` which contains the proper layout to
+            weights mapping for the model parallel setting.
+
+        Examples:
+        ```python
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=(2, 4),
+            axis_names=('batch', 'model'),
+            devices=keras.distribution.list_devices(),
+        )
+        layout_map = keras_nlp.models.{{model_name}}.create_layout_map(
+            device_mesh,
+        )
+        distribution = keras.distribution.ModelParallel(device_mesh, layout_map)
+        keras.distribution.set_distribution(distribution)
+        ```
+        """
+        # We assert the mesh is 2D, and assume the first mesh dim is for data
+        # parallel and the second dim is for model parallel.
+        mesh_shape = device_mesh.shape
+        if len(mesh_shape) != 2:
+            raise ValueError(f"Expect a 2D DeviceMesh, received {device_mesh}")
+        _, model_dim = device_mesh.axis_names
+
+        layout_map = keras.distribution.LayoutMap(device_mesh=device_mesh)
+        # Embedding sharding
+        layout_map[r"embeddings"] = [None, model_dim]
+        # Transformer block sharding
+        layout_map[r"(query|key|value)/kernel"] = [None, None, model_dim]
+        layout_map[r"(query|key|value)/bias"] = [model_dim, None]
+        layout_map[r"feedforward_intermediate_dense/kernel"] = [
+            None,
+            model_dim,
+        ]
+        layout_map[r"feedforward_intermediate_dense/bias"] = [model_dim]
+        layout_map[r"feedforward_output_dense/kernel"] = [model_dim, None]
+        layout_map[r"feedforward_output_dense/bias"] = [None]
+        return layout_map

--- a/keras_nlp/models/gpt2/gpt2_backbone.py
+++ b/keras_nlp/models/gpt2/gpt2_backbone.py
@@ -14,10 +14,6 @@
 
 import copy
 
-from tensorflow.experimental import dtensor
-from tensorflow.experimental.dtensor import Layout
-from tensorflow.keras.dtensor.experimental import LayoutMap
-
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.backend import keras
 from keras_nlp.layers.modeling.position_embedding import PositionEmbedding
@@ -191,71 +187,3 @@ class GPT2Backbone(Backbone):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
-
-    @classmethod
-    def create_layout_map(cls, mesh):
-        """Create a DTensor layout map for a GPT2Backbone.
-
-        Given a DTensor mesh describing a list of devices, this method returns a
-        DTensor layout map for creating a `keras_nlp.models.GPT2Backbone`
-        instance. This mapping describes how to distribute all model weights
-        across multiple devices. For an overview of DTensor concepts, see
-        [this guide](https://www.tensorflow.org/guide/dtensor_overview).
-
-        Args:
-            mesh: A 2D `tf.experimental.dtensor.Mesh` describing the arrangement
-                of devices for running distributed computation. The
-                first dimension in the mesh is expected to be for data parallel
-                distribution, and the second for model parallel distribution.
-
-        Returns:
-            A `tf.keras.dtensor.experimental.LayoutMap` which contains the
-            proper layout to weights mapping for the model parallel setting.
-
-        Examples:
-        ```python
-        keras.backend.experimental.enable_tf_random_generator()
-        keras.utils.set_random_seed(1337)
-
-        # Update both dimensions below for a multi-device setting.
-        mesh = dtensor.create_mesh([("batch", 1), ("model", 1)])
-        layout_map = keras_nlp.models.GPT2Backbone.create_layout_map(mesh)
-
-        with layout_map.scope():
-            model = keras_nlp.models.GPT2Backbone.from_preset("gpt2_base_en")
-        ```
-        """
-        # We assert the mesh is 2D, and assume the first mesh dim is for data
-        # parallel and the second dim is for model parallel.
-        mesh_shape = mesh.shape()
-        if len(mesh_shape) != 2:
-            raise ValueError(
-                f"Expect to create layout based on 2D mesh, received {mesh}"
-            )
-        _, model_dim = mesh.dim_names
-        unshard_dim = dtensor.UNSHARDED
-
-        layout_map = LayoutMap(mesh=mesh)
-        # Embedding sharding
-        layout_map[r".*embeddings"] = Layout([unshard_dim, model_dim], mesh)
-
-        # Transformer block sharding
-        layout_map[r".*_(query|key|value)_dense.kernel"] = Layout(
-            [unshard_dim, unshard_dim, model_dim], mesh
-        )
-        layout_map[r".*_(query|key|value)_dense.bias"] = Layout(
-            [model_dim, unshard_dim], mesh
-        )
-        layout_map[r".*_feedforward_intermediate_dense.kernel"] = Layout(
-            [unshard_dim, model_dim], mesh
-        )
-        layout_map[r".*_feedforward_intermediate_dense.bias"] = Layout(
-            [model_dim], mesh
-        )
-        layout_map[r".*_feedforward_output_dense.kernel"] = Layout(
-            [model_dim, unshard_dim], mesh
-        )
-        layout_map[r".*_feedforward_output_dense.bias"] = Layout(
-            [unshard_dim], mesh
-        )
-        return layout_map

--- a/keras_nlp/models/gpt2/gpt2_backbone_test.py
+++ b/keras_nlp/models/gpt2/gpt2_backbone_test.py
@@ -85,23 +85,6 @@ class GPT2Test(TestCase):
         restored_output = restored_model(self.input_batch)
         self.assertAllClose(model_output, restored_output)
 
-    def test_create_layout_map(self):
-        mesh = tf.experimental.dtensor.create_mesh([("batch", 1), ("model", 1)])
-        with GPT2Backbone.create_layout_map(mesh).scope():
-            GPT2Backbone(
-                vocabulary_size=10,
-                num_layers=2,
-                num_heads=2,
-                hidden_dim=2,
-                intermediate_dim=4,
-                max_sequence_length=5,
-            )
-        # Using DTensor enables the mlir bridge as a side effect. Eventually
-        # this will be default, but for now we have compile errors with the
-        # bridge elsewhere and must disable. See
-        # https://github.com/keras-team/keras-nlp/issues/1001
-        tf.config.experimental.disable_mlir_bridge()
-
 
 @pytest.mark.tpu
 @pytest.mark.usefixtures("tpu_test_class")

--- a/keras_nlp/models/gpt2/gpt2_causal_lm.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm.py
@@ -325,39 +325,3 @@ class GPT2CausalLM(GenerativeTask):
             "token_ids": token_ids,
             "padding_mask": padding_mask,
         }
-
-    @classmethod
-    def create_layout_map(cls, mesh):
-        """Create a DTensor layout map for a GPT2CausalLM.
-
-        Given a DTensor mesh describing a list of devices, this method returns a
-        DTensor layout map for creating a `keras_nlp.models.GPT2CausalLM`
-        instance. This mapping describes how to distribute all model weights
-        across multiple devices. For an overview of DTensor concepts, see
-        [this guide](https://www.tensorflow.org/guide/dtensor_overview).
-
-        Args:
-            mesh: A 2D `tf.experimental.dtensor.Mesh` describing the arrangement
-                of devices for running distributed computation. The
-                first dimension in the mesh is expected to be for data parallel
-                distribution, and the second for model parallel distribution.
-
-        Returns:
-            A `keras.dtensor.experimental.LayoutMap` which contains the
-            proper layout to weights mapping for the model parallel setting.
-
-        Examples:
-        ```python
-        keras.backend.experimental.enable_tf_random_generator()
-        keras.utils.set_random_seed(1337)
-
-        # Update both dimensions below for a multi-device setting.
-        mesh = tf.experimental.dtensor.create_mesh([("batch", 1), ("model", 1)])
-        layout_map = keras_nlp.models.GPT2CausalLM.create_layout_map(mesh)
-
-        with layout_map.scope():
-            gpt2_lm = keras_nlp.models.GPT2CausalLM.from_preset("gpt2_base_en")
-        ```
-        """
-        # As this task has no new variables, we just re-use the backbone method.
-        return cls.backbone_cls.create_layout_map(mesh)

--- a/keras_nlp/models/gpt2/gpt2_causal_lm_test.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm_test.py
@@ -165,13 +165,3 @@ class GPT2CausalLMTest(TestCase):
         keras.utils.set_random_seed(42)
         restored_output = restored_model.predict(self.raw_batch)
         self.assertAllClose(model_output, restored_output)
-
-    def test_create_layout_map(self):
-        mesh = tf.experimental.dtensor.create_mesh([("batch", 1), ("model", 1)])
-        with GPT2CausalLM.create_layout_map(mesh).scope():
-            GPT2CausalLM(backbone=self.backbone)
-        # Using DTensor enables the mlir bridge as a side effect. Eventually
-        # this will be default, but for now we have compile errors with the
-        # bridge elsewhere and must disable. See
-        # https://github.com/keras-team/keras-nlp/issues/1001
-        tf.config.experimental.disable_mlir_bridge()

--- a/keras_nlp/models/opt/opt_backbone.py
+++ b/keras_nlp/models/opt/opt_backbone.py
@@ -14,10 +14,6 @@
 
 import copy
 
-from tensorflow.experimental import dtensor
-from tensorflow.experimental.dtensor import Layout
-from tensorflow.keras.dtensor.experimental import LayoutMap
-
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.backend import keras
 from keras_nlp.layers.modeling.token_and_position_embedding import (
@@ -168,71 +164,3 @@ class OPTBackbone(Backbone):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
-
-    @classmethod
-    def create_layout_map(cls, mesh):
-        """Create a DTensor layout map for an OPTBackbone.
-
-        Given a DTensor mesh describing a list of devices, this method returns a
-        DTensor layout map for creating a `keras_nlp.models.OPTBackbone`
-        instance. This mapping describes how to distribute all model weights
-        across multiple devices. For an overview of DTensor concepts, see
-        [this guide](https://www.tensorflow.org/guide/dtensor_overview).
-
-        Args:
-            mesh: A 2D `tf.experimental.dtensor.Mesh` describing the arrangement
-                of devices for running distributed computation. The
-                first dimension in the mesh is expected to be for data parallel
-                distribution, and the second for model parallel distribution.
-
-        Returns:
-            A `tf.keras.dtensor.experimental.LayoutMap` which contains the
-            proper layout to weights mapping for the model parallel setting.
-
-        Examples:
-        ```python
-        keras.backend.experimental.enable_tf_random_generator()
-        keras.utils.set_random_seed(1337)
-
-        # Update both dimensions below for a multi-device setting.
-        mesh = dtensor.create_mesh([("batch", 1), ("model", 1)])
-        layout_map = keras_nlp.models.OPTBackbone.create_layout_map(mesh)
-
-        with layout_map.scope():
-            model = keras_nlp.models.OPTBackbone.from_preset("opt_125m_en")
-        ```
-        """
-        # We assert the mesh is 2D, and assume the first mesh dim is for data
-        # parallel and the second dim is for model parallel.
-        mesh_shape = mesh.shape()
-        if len(mesh_shape) != 2:
-            raise ValueError(
-                f"Expect to create layout based on 2D mesh, received {mesh}"
-            )
-        _, model_dim = mesh.dim_names
-        unshard_dim = dtensor.UNSHARDED
-
-        layout_map = LayoutMap(mesh=mesh)
-        # Embedding sharding
-        layout_map[r".*embeddings"] = Layout([unshard_dim, model_dim], mesh)
-
-        # Transformer block sharding
-        layout_map[r".*_(query|key|value)_dense.kernel"] = Layout(
-            [unshard_dim, unshard_dim, model_dim], mesh
-        )
-        layout_map[r".*_(query|key|value)_dense.bias"] = Layout(
-            [model_dim, unshard_dim], mesh
-        )
-        layout_map[r".*_feedforward_intermediate_dense.kernel"] = Layout(
-            [unshard_dim, model_dim], mesh
-        )
-        layout_map[r".*_feedforward_intermediate_dense.bias"] = Layout(
-            [model_dim], mesh
-        )
-        layout_map[r".*_feedforward_output_dense.kernel"] = Layout(
-            [model_dim, unshard_dim], mesh
-        )
-        layout_map[r".*_feedforward_output_dense.bias"] = Layout(
-            [unshard_dim], mesh
-        )
-        return layout_map

--- a/keras_nlp/models/opt/opt_backbone_test.py
+++ b/keras_nlp/models/opt/opt_backbone_test.py
@@ -85,23 +85,6 @@ class OPTBackboneTest(TestCase):
         restored_output = restored_model(self.input_batch)
         self.assertAllClose(model_output, restored_output)
 
-    def test_create_layout_map(self):
-        mesh = tf.experimental.dtensor.create_mesh([("batch", 1), ("model", 1)])
-        with OPTBackbone.create_layout_map(mesh).scope():
-            OPTBackbone(
-                vocabulary_size=10,
-                num_layers=2,
-                num_heads=2,
-                hidden_dim=2,
-                intermediate_dim=4,
-                max_sequence_length=5,
-            )
-        # Using DTensor enables the mlir bridge as a side effect. Eventually
-        # this will be default, but for now we have compile errors with the
-        # bridge elsewhere and must disable. See
-        # https://github.com/keras-team/keras-nlp/issues/1001
-        tf.config.experimental.disable_mlir_bridge()
-
 
 @pytest.mark.tpu
 @pytest.mark.usefixtures("tpu_test_class")

--- a/keras_nlp/models/opt/opt_causal_lm.py
+++ b/keras_nlp/models/opt/opt_causal_lm.py
@@ -321,39 +321,3 @@ class OPTCausalLM(GenerativeTask):
             "token_ids": token_ids,
             "padding_mask": padding_mask,
         }
-
-    @classmethod
-    def create_layout_map(cls, mesh):
-        """Create a DTensor layout map for an OPTCausalLM.
-
-        Given a DTensor mesh describing a list of devices, this method returns a
-        DTensor layout map for creating a `keras_nlp.models.OPTCausalLM`
-        instance. This mapping describes how to distribute all model weights
-        across multiple devices. For an overview of DTensor concepts, see
-        [this guide](https://www.tensorflow.org/guide/dtensor_overview).
-
-        Args:
-            mesh: A 2D `tf.experimental.dtensor.Mesh` describing the arrangement
-                of devices for running distributed computation. The
-                first dimension in the mesh is expected to be for data parallel
-                distribution, and the second for model parallel distribution.
-
-        Returns:
-            A `tf.keras.dtensor.experimental.LayoutMap` which contains the
-            proper layout to weights mapping for the model parallel setting.
-
-        Examples:
-        ```python
-        keras.backend.experimental.enable_tf_random_generator()
-        keras.utils.set_random_seed(1337)
-
-        # Update both dimensions below for a multi-device setting.
-        mesh = tf.experimental.dtensor.create_mesh([("batch", 1), ("model", 1)])
-        layout_map = keras_nlp.models.OPTCausalLM.create_layout_map(mesh)
-
-        with layout_map.scope():
-            opt_lm = keras_nlp.models.OPTCausalLM.from_preset("opt_125m_en")
-        ```
-        """
-        # As this task has no new variables, we just re-use the backbone method.
-        return cls.backbone_cls.create_layout_map(mesh)

--- a/keras_nlp/models/opt/opt_causal_lm_test.py
+++ b/keras_nlp/models/opt/opt_causal_lm_test.py
@@ -171,13 +171,3 @@ class OPTCausalLMTest(TestCase):
         keras.utils.set_random_seed(42)
         restored_output = restored_model.predict(self.raw_batch)
         self.assertAllClose(model_output, restored_output)
-
-    def test_create_layout_map(self):
-        mesh = tf.experimental.dtensor.create_mesh([("batch", 1), ("model", 1)])
-        with OPTCausalLM.create_layout_map(mesh).scope():
-            OPTCausalLM(backbone=self.backbone)
-        # Using DTensor enables the mlir bridge as a side effect. Eventually
-        # this will be default, but for now we have compile errors with the
-        # bridge elsewhere and must disable. See
-        # https://github.com/keras-team/keras-nlp/issues/1001
-        tf.config.experimental.disable_mlir_bridge()

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -230,6 +230,26 @@ class Task(PipelineModel):
                 preset_names='", "'.join(cls.presets),
             )(cls.from_preset.__func__)
 
+        # If the subclass does not define from_preset, assign a wrapper so that
+        # each class can have a distinct docstring.
+        if "create_layout_map" not in cls.__dict__:
+
+            def create_layout_map(calling_cls, *args, **kwargs):
+                return super(cls, calling_cls).create_layout_map(
+                    *args, **kwargs
+                )
+
+            cls.create_layout_map = classmethod(create_layout_map)
+
+        # Format and assign the docstring unless the subclass has overridden it.
+        if cls.create_layout_map.__doc__ is None:
+            cls.create_layout_map.__func__.__doc__ = (
+                Task.create_layout_map.__doc__
+            )
+            format_docstring(
+                model_task_name=cls.__name__,
+            )(cls.create_layout_map.__func__)
+
     @property
     def layers(self):
         # Remove preprocessor from layers so it does not show up in the summary.
@@ -323,3 +343,37 @@ class Task(PipelineModel):
             print_fn=print_fn,
             **kwargs,
         )
+
+    @classmethod
+    def create_layout_map(cls, device_mesh):
+        """Create a layout map for model parallel training a {{model_task_name}}.
+
+        This method takes in a `keras.distribution.DeviceMesh` and returns a
+        `keras.distribution.LayoutMap` that will correctly distribute weights
+        for a task in a model parallel setting.
+
+        Args:
+            device_mesh: A 2D `keras.distribution.DeviceMesh` describing the
+                arrangement of devices for running distributed computation. The
+                first dimension in the mesh is expected to be for data parallel
+                distribution, and the second for model parallel distribution.
+
+        Returns:
+            A `keras.distribution.LayoutMap` which contains the proper layout to
+            weights mapping for the model parallel setting.
+
+        Examples:
+        ```python
+        device_mesh = keras.distribution.DeviceMesh(
+            shape=(2, 4),
+            axis_names=('batch', 'model'),
+            devices=keras.distribution.list_devices(),
+        )
+        layout_map = keras_nlp.models.{{model_task_name}}.create_layout_map(
+            device_mesh,
+        )
+        distribution = keras.distribution.ModelParallel(device_mesh, layout_map)
+        keras.distribution.set_distribution(distribution)
+        ```
+        """
+        return cls.backbone_cls.create_layout_map(device_mesh)


### PR DESCRIPTION
Move from `DTensor` to the `keras.distribution` API in Keras 3.

The overall plan is that we will have a default layout map that will work with most of backbones (because most of our backbones share the same weights structure). A backbone that needs a separate layout map should override `create_layout_map`.

Note that this will not pass on CI for a while, because we need to tests agains the latest keras-nightlies for this to work. That is blocked on the `keras-nightly` being available and `tensorflow-text-nightly` no longer being a month+ old. Both in route I think.