### PR TITLE
Support loading keras 3 nightly

### DIFF
--- a/keras_nlp/backend/config.py
+++ b/keras_nlp/backend/config.py
@@ -66,7 +66,7 @@ if "KERAS_BACKEND" in os.environ and os.environ["KERAS_BACKEND"]:
     _MULTI_BACKEND = True
 
 # If keras is version 3, use multi-backend keras (our only option).
-_IS_KERAS_3 = version.parse(keras.__version__) >= version.parse("3.0.0")
+_IS_KERAS_3 = version.parse(keras.__version__) >= version.parse("3.0.0.dev0")
 if _IS_KERAS_3:
     _MULTI_BACKEND = True
 


### PR DESCRIPTION
The nightly version will actually be consider to have a value less that "3.0.0" by python packaging, as the dev prefix indicates a pre-release.