### PR TITLE
Run workflows with read-only tokens

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   release:
     types: [created]
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Test the code with Keras 2

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,6 +1,10 @@
 name: Publish to PyPI
 
 on: push
+
+permissions:
+  contents: read
+
 jobs:
   build-and-publish:
     name: Build and publish to PyPI


### PR DESCRIPTION
Fixes https://github.com/keras-team/keras-nlp/issues/1304.

This PR ensures all KerasNLP workflows run with read-only tokens, protecting the project from supply-chain risks.