### PR TITLE
Fix the publish to pypi action

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,11 +11,11 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  keras_2:
     name: Test the code with Keras 2
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.9
         uses: actions/setup-python@v1
         with:
@@ -43,7 +43,7 @@ jobs:
       - name: Run integration tests
         run: |
           python pip_build.py --install && cd integration_tests && pytest .
-  multibackend:
+  keras_3:
     name: Test the code with Keras 3
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
         backend: [tensorflow, jax, torch]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
@@ -77,11 +77,11 @@ jobs:
         KERAS_BACKEND: ${{ matrix.backend }}
       run: |
         pytest keras_nlp/
-  format:
+  check_format:
     name: Check the code format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.9
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,15 +10,31 @@ jobs:
     name: Build and publish to PyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Install dependencies
-      run: |
-          pip install -r requirements.txt --progress-bar off
-    - name: Build a binary wheel and a source tarball
-      run: >-
-        python pip_build.py
-    - name: Publish distribution to PyPI
-      if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          python -m pip install --upgrade pip setuptools
+          echo "::set-output name=dir::$(pip cache dir)"
+      - name: pip cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: |
+            pip install -r requirements.txt --progress-bar off
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python pip_build.py
+      - name: Publish distribution to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -1,6 +1,6 @@
 # Tensorflow cpu-only version.
-tf-nightly-cpu==2.16.0.dev20231107  # Pin a working nightly until rc0.
-tensorflow-text-nightly==2.16.0.dev20231107  # Pin a working nightly until rc0.
+tf-nightly-cpu==2.16.0.dev20231109  # Pin a working nightly until rc0.
+tensorflow-text-nightly==2.16.0.dev20231109  # Pin a working nightly until rc0.
 
 # Torch cpu-only version.
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -1,7 +1,7 @@
 # Tensorflow with cuda support.
 --extra-index-url https://pypi.nvidia.com
-tf-nightly[and-cuda]==2.16.0.dev20231107  # Pin a working nightly until rc0.
-tensorflow-text-nightly==2.16.0.dev20231107  # Pin a working nightly until rc0.
+tf-nightly[and-cuda]==2.16.0.dev20231109  # Pin a working nightly until rc0.
+tensorflow-text-nightly==2.16.0.dev20231109  # Pin a working nightly until rc0.
 
 # Torch cpu-only version.
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -1,6 +1,6 @@
 # Tensorflow cpu-only version.
-tf-nightly-cpu==2.16.0.dev20231107  # Pin a working nightly until rc0.
-tensorflow-text-nightly==2.16.0.dev20231107  # Pin a working nightly until rc0.
+tf-nightly-cpu==2.16.0.dev20231109  # Pin a working nightly until rc0.
+tensorflow-text-nightly==2.16.0.dev20231109  # Pin a working nightly until rc0.
 
 # Torch with cuda support.
 --extra-index-url https://download.pytorch.org/whl/cu118

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Tensorflow.
-tf-nightly-cpu==2.16.0.dev20231107  # Pin a working nightly until rc0.
-tensorflow-text-nightly==2.16.0.dev20231107  # Pin a working nightly until rc0.
+tf-nightly-cpu==2.16.0.dev20231109  # Pin a working nightly until rc0.
+tensorflow-text-nightly==2.16.0.dev20231109  # Pin a working nightly until rc0.
 
 # Torch.
 --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
It has been failing since #1309, see
https://github.com/keras-team/keras-nlp/actions/runs/6819858177/job/18547841938

I believe what is happening is that newly pinned nightly only had linux wheels for 3.9. And our publish to pypi flow did not specify the python version.
https://pypi.org/project/tensorflow-text-nightly/2.16.0.dev20231107/#files

Doing a few things here:
- Updating the pinned package to a version where tensorflow-text-nightly has support for python 3.9, 3.10, and 3.11 on linux.
- Fixing out publish to pypi workflow to set the python version like other workflow versions.
- Some other cleanups for consistency with our github actions.