### PR TITLE
Switch deberta to use the "int" dtype

### DIFF
--- a/keras_nlp/models/deberta_v3/disentangled_self_attention.py
+++ b/keras_nlp/models/deberta_v3/disentangled_self_attention.py
@@ -232,12 +232,13 @@ class DisentangledSelfAttention(keras.layers.Layer):
             x1=rel_pos,
             x2=log_pos * sign,
         )
-        bucket_pos = ops.cast(bucket_pos, dtype="int64")
+        bucket_pos = ops.cast(bucket_pos, dtype="int")
 
         return bucket_pos
 
     def _get_rel_pos(self, num_positions):
-        ids = ops.arange(num_positions, dtype="int64")
+        ids = ops.arange(num_positions)
+        ids = ops.cast(ids, dtype="int")
         query_ids = ops.expand_dims(ids, axis=-1)
         key_ids = ops.expand_dims(ids, axis=0)
         key_ids = ops.repeat(key_ids, repeats=num_positions, axis=0)


### PR DESCRIPTION
This will be int32 on jax and torch, but int64 on tf, which is what we need for proper accelerator support