### PR TITLE
 Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives us time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+You may submit the report in the following ways:
+
+- send a [private vulnerability report](https://github.com/keras-team/keras-nlp/security/advisories/new)
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is maintained by volunteers on a reasonable-effort basis. As such,
+please give us 90 days to work on a fix before public exposure.


### PR DESCRIPTION
As requested by @mattdangerw in https://github.com/keras-team/keras-cv/pull/2142#issuecomment-1811547542.

This PR adds a simple security policy to KerasNLP so users or security researchers can responsibly disclose any vulnerabilities they find.

If this PR is accepted, please remember to enable GitHub's private reporting feature in the repo [Settings > Code security & analysis](https://github.com/keras-team/keras-nlp/settings/security_analysis).

I'll also note that another possibility would be to create a SECURITY.md file in the keras-team/.github repository. This will make the policy visible in all keras-team repositories. I unfortunately can't submit a PR to that repo because it's empty.