### PR TITLE
Switch byte pair tokenizer to save_assets/load_assets

### DIFF
--- a/keras_nlp/models/bart/bart_seq_2_seq_lm_preprocessor_test.py
+++ b/keras_nlp/models/bart/bart_seq_2_seq_lm_preprocessor_test.py
@@ -21,7 +21,7 @@ from keras_nlp.models.bart.bart_tokenizer import BartTokenizer
 from keras_nlp.tests.test_case import TestCase
 
 
-class BartPreprocessorTest(TestCase):
+class BartSeq2SeqLMPreprocessorTest(TestCase):
     def setUp(self):
         self.vocab = ["<s>", "<pad>", "</s>", "air", "Ġair", "plane", "Ġat"]
         self.vocab += ["port", "<mask>"]

--- a/keras_nlp/models/bart/bart_tokenizer.py
+++ b/keras_nlp/models/bart/bart_tokenizer.py
@@ -78,34 +78,45 @@ class BartTokenizer(BytePairTokenizer):
 
     def __init__(
         self,
-        vocabulary,
-        merges,
+        vocabulary=None,
+        merges=None,
         **kwargs,
     ):
-        # Special tokens.
-        start_token = "<s>"
-        pad_token = "<pad>"
-        end_token = "</s>"
+        self.start_token = "<s>"
+        self.pad_token = "<pad>"
+        self.end_token = "</s>"
 
         super().__init__(
             vocabulary=vocabulary,
             merges=merges,
-            unsplittable_tokens=[start_token, pad_token, end_token],
+            unsplittable_tokens=[
+                self.start_token,
+                self.pad_token,
+                self.end_token,
+            ],
             **kwargs,
         )
 
-        # Check whether special tokens are present in the vocabulary.
-        for token in [start_token, pad_token, end_token]:
-            if token not in self.get_vocabulary():
-                raise ValueError(
-                    f"Cannot find token `'{token}'` in the provided "
-                    f"`vocabulary`. Please provide `'{token}'` in your "
-                    "`vocabulary` or use a pretrained `vocabulary` name."
-                )
+    def set_vocabulary_and_merges(self, vocabulary, merges):
+        super().set_vocabulary_and_merges(vocabulary, merges)
 
-        self.start_token_id = self.token_to_id(start_token)
-        self.pad_token_id = self.token_to_id(pad_token)
-        self.end_token_id = self.token_to_id(end_token)
+        if vocabulary is not None:
+            # Check for necessary special tokens.
+            for token in [self.start_token, self.pad_token, self.end_token]:
+                if token not in self.vocabulary:
+                    raise ValueError(
+                        f"Cannot find token `'{token}'` in the provided "
+                        f"`vocabulary`. Please provide `'{token}'` in your "
+                        "`vocabulary` or use a pretrained `vocabulary` name."
+                    )
+
+            self.start_token_id = self.token_to_id(self.start_token)
+            self.pad_token_id = self.token_to_id(self.pad_token)
+            self.end_token_id = self.token_to_id(self.end_token)
+        else:
+            self.start_token_id = None
+            self.pad_token_id = None
+            self.end_token_id = None
 
     @classproperty
     def presets(cls):

--- a/keras_nlp/models/bert/bert_preprocessor.py
+++ b/keras_nlp/models/bert/bert_preprocessor.py
@@ -143,16 +143,6 @@ class BertPreprocessor(Preprocessor):
         self.truncate = truncate
         self.packer = None
 
-    def get_config(self):
-        config = super().get_config()
-        config.update(
-            {
-                "sequence_length": self.sequence_length,
-                "truncate": self.truncate,
-            }
-        )
-        return config
-
     def build(self, input_shape):
         # Defer packer creation to `build()` so that we can be sure tokenizer
         # assets have loaded when restoring a saved model.
@@ -175,6 +165,16 @@ class BertPreprocessor(Preprocessor):
             "padding_mask": token_ids != self.tokenizer.pad_token_id,
         }
         return pack_x_y_sample_weight(x, y, sample_weight)
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "sequence_length": self.sequence_length,
+                "truncate": self.truncate,
+            }
+        )
+        return config
 
     @classproperty
     def tokenizer_cls(cls):

--- a/keras_nlp/models/bert/bert_tokenizer.py
+++ b/keras_nlp/models/bert/bert_tokenizer.py
@@ -78,6 +78,10 @@ class BertTokenizer(WordPieceTokenizer):
         lowercase=False,
         **kwargs,
     ):
+        self.cls_token = "[CLS]"
+        self.sep_token = "[SEP]"
+        self.pad_token = "[PAD]"
+        self.mask_token = "[MASK]"
         super().__init__(
             vocabulary=vocabulary,
             lowercase=lowercase,
@@ -89,11 +93,7 @@ class BertTokenizer(WordPieceTokenizer):
 
         if vocabulary is not None:
             # Check for necessary special tokens.
-            cls_token = "[CLS]"
-            sep_token = "[SEP]"
-            pad_token = "[PAD]"
-            mask_token = "[MASK]"
-            for token in [cls_token, pad_token, sep_token]:
+            for token in [self.cls_token, self.pad_token, self.sep_token]:
                 if token not in self.vocabulary:
                     raise ValueError(
                         f"Cannot find token `'{token}'` in the provided "
@@ -101,10 +101,10 @@ class BertTokenizer(WordPieceTokenizer):
                         "`vocabulary` or use a pretrained `vocabulary` name."
                     )
 
-            self.cls_token_id = self.token_to_id(cls_token)
-            self.sep_token_id = self.token_to_id(sep_token)
-            self.pad_token_id = self.token_to_id(pad_token)
-            self.mask_token_id = self.token_to_id(mask_token)
+            self.cls_token_id = self.token_to_id(self.cls_token)
+            self.sep_token_id = self.token_to_id(self.sep_token)
+            self.pad_token_id = self.token_to_id(self.pad_token)
+            self.mask_token_id = self.token_to_id(self.mask_token)
         else:
             self.cls_token_id = None
             self.sep_token_id = None

--- a/keras_nlp/models/distil_bert/distil_bert_tokenizer.py
+++ b/keras_nlp/models/distil_bert/distil_bert_tokenizer.py
@@ -76,6 +76,10 @@ class DistilBertTokenizer(WordPieceTokenizer):
         lowercase=False,
         **kwargs,
     ):
+        self.cls_token = "[CLS]"
+        self.sep_token = "[SEP]"
+        self.pad_token = "[PAD]"
+        self.mask_token = "[MASK]"
         super().__init__(
             vocabulary=vocabulary,
             lowercase=lowercase,
@@ -87,22 +91,18 @@ class DistilBertTokenizer(WordPieceTokenizer):
 
         if vocabulary is not None:
             # Check for necessary special tokens.
-            cls_token = "[CLS]"
-            sep_token = "[SEP]"
-            pad_token = "[PAD]"
-            mask_token = "[MASK]"
-            for token in [cls_token, pad_token, sep_token]:
-                if token not in self.get_vocabulary():
+            for token in [self.cls_token, self.pad_token, self.sep_token]:
+                if token not in self.vocabulary:
                     raise ValueError(
                         f"Cannot find token `'{token}'` in the provided "
                         f"`vocabulary`. Please provide `'{token}'` in your "
                         "`vocabulary` or use a pretrained `vocabulary` name."
                     )
 
-            self.cls_token_id = self.token_to_id(cls_token)
-            self.sep_token_id = self.token_to_id(sep_token)
-            self.pad_token_id = self.token_to_id(pad_token)
-            self.mask_token_id = self.token_to_id(mask_token)
+            self.cls_token_id = self.token_to_id(self.cls_token)
+            self.sep_token_id = self.token_to_id(self.sep_token)
+            self.pad_token_id = self.token_to_id(self.pad_token)
+            self.mask_token_id = self.token_to_id(self.mask_token)
         else:
             self.cls_token_id = None
             self.sep_token_id = None

--- a/keras_nlp/models/gpt2/gpt2_causal_lm_preprocessor.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm_preprocessor.py
@@ -142,6 +142,9 @@ class GPT2CausalLMPreprocessor(GPT2Preprocessor):
         the sequence (as generation is expected to continue at the end of the
         inputted prompt).
         """
+        if not self.built:
+            self.build(None)
+
         x = convert_inputs_to_list_of_tensor_segments(x)[0]
         x = self.tokenizer(x)
         token_ids, padding_mask = self.packer(
@@ -162,6 +165,9 @@ class GPT2CausalLMPreprocessor(GPT2Preprocessor):
         padding and start/end tokens, and then converting the integer sequence
         back to a string.
         """
+        if not self.built:
+            self.build(None)
+
         token_ids, padding_mask = x["token_ids"], x["padding_mask"]
         token_ids = ops.convert_to_numpy(token_ids)
         padding_mask = ops.convert_to_numpy(padding_mask)

--- a/keras_nlp/models/gpt2/gpt2_causal_lm_test.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm_test.py
@@ -44,7 +44,7 @@ class GPT2CausalLMTest(TestCase):
             num_heads=2,
             hidden_dim=4,
             intermediate_dim=8,
-            max_sequence_length=self.preprocessor.packer.sequence_length,
+            max_sequence_length=self.preprocessor.sequence_length,
         )
         self.init_kwargs = {
             "preprocessor": self.preprocessor,

--- a/keras_nlp/models/gpt2/gpt2_tokenizer.py
+++ b/keras_nlp/models/gpt2/gpt2_tokenizer.py
@@ -70,32 +70,39 @@ class GPT2Tokenizer(BytePairTokenizer):
 
     def __init__(
         self,
-        vocabulary,
-        merges,
+        vocabulary=None,
+        merges=None,
         **kwargs,
     ):
-        # Special tokens.
-        end_token = "<|endoftext|>"
+        # GPT2 uses the same start as end token, i.e., "<|endoftext|>".
+        self.end_token = self.start_token = "<|endoftext|>"
 
         super().__init__(
             vocabulary=vocabulary,
             merges=merges,
-            unsplittable_tokens=[end_token],
+            unsplittable_tokens=[self.end_token],
             **kwargs,
         )
 
-        # Check whether special tokens are present in the vocabulary.
-        if end_token not in self.get_vocabulary():
-            raise ValueError(
-                f"Cannot find token `'{end_token}'` in the provided "
-                f"`vocabulary`. Please provide `'{end_token}'` in your "
-                "`vocabulary` or use a pretrained `vocabulary` name."
-            )
+    def set_vocabulary_and_merges(self, vocabulary, merges):
+        super().set_vocabulary_and_merges(vocabulary, merges)
 
-        self.end_token_id = self.token_to_id(end_token)
-        # GPT2 uses the same start as end token, i.e., "<|endoftext|>".
-        self.start_token_id = self.end_token_id
-        self.pad_token_id = 0
+        if vocabulary is not None:
+            # Check for necessary special tokens.
+            if self.end_token not in self.get_vocabulary():
+                raise ValueError(
+                    f"Cannot find token `'{self.end_token}'` in the provided "
+                    f"`vocabulary`. Please provide `'{self.end_token}'` in "
+                    "your `vocabulary` or use a pretrained `vocabulary` name."
+                )
+
+            self.end_token_id = self.token_to_id(self.end_token)
+            self.start_token_id = self.end_token_id
+            self.pad_token_id = 0
+        else:
+            self.end_token_id = None
+            self.start_token_id = None
+            self.pad_token_id = None
 
     @classproperty
     def presets(cls):

--- a/keras_nlp/models/gpt_neo_x/gpt_neo_x_causal_lm_preprocessor.py
+++ b/keras_nlp/models/gpt_neo_x/gpt_neo_x_causal_lm_preprocessor.py
@@ -110,6 +110,9 @@ class GPTNeoXCausalLMPreprocessor(GPTNeoXPreprocessor):
         the sequence (as generation is expected to continue at the end of the
         inputted prompt).
         """
+        if not self.built:
+            self.build(None)
+
         x = convert_inputs_to_list_of_tensor_segments(x)[0]
         x = self.tokenizer(x)
         token_ids, padding_mask = self.packer(
@@ -130,6 +133,9 @@ class GPTNeoXCausalLMPreprocessor(GPTNeoXPreprocessor):
         padding and start/end tokens, and then converting the integer sequence
         back to a string.
         """
+        if not self.built:
+            self.build(None)
+
         token_ids, padding_mask = x["token_ids"], x["padding_mask"]
         if not isinstance(token_ids, tf.Tensor):
             token_ids = ops.convert_to_numpy(token_ids)

--- a/keras_nlp/models/gpt_neo_x/gpt_neo_x_causal_lm_test.py
+++ b/keras_nlp/models/gpt_neo_x/gpt_neo_x_causal_lm_test.py
@@ -44,7 +44,7 @@ class GPTNeoXCausalLMTest(TestCase):
             num_heads=2,
             hidden_dim=4,
             intermediate_dim=8,
-            max_sequence_length=self.preprocessor.packer.sequence_length,
+            max_sequence_length=self.preprocessor.sequence_length,
         )
         self.init_kwargs = {
             "preprocessor": self.preprocessor,

--- a/keras_nlp/models/gpt_neo_x/gpt_neo_x_preprocessor.py
+++ b/keras_nlp/models/gpt_neo_x/gpt_neo_x_preprocessor.py
@@ -79,24 +79,19 @@ class GPTNeoXPreprocessor(Preprocessor):
         self.sequence_length = sequence_length
         self.add_start_token = add_start_token
         self.add_end_token = add_end_token
+        self.packer = None
+
+    def build(self, input_shape):
+        # Defer packer creation to `build()` so that we can be sure tokenizer
+        # assets have loaded when restoring a saved model.
         self.packer = StartEndPacker(
-            start_value=tokenizer.start_token_id,
-            end_value=tokenizer.end_token_id,
-            pad_value=tokenizer.pad_token_id,
-            sequence_length=sequence_length,
+            start_value=self.tokenizer.start_token_id,
+            end_value=self.tokenizer.end_token_id,
+            pad_value=self.tokenizer.pad_token_id,
+            sequence_length=self.sequence_length,
             return_padding_mask=True,
         )
-
-    def get_config(self):
-        config = super().get_config()
-        config.update(
-            {
-                "sequence_length": self.sequence_length,
-                "add_start_token": self.add_start_token,
-                "add_end_token": self.add_end_token,
-            }
-        )
-        return config
+        self.built = True
 
     def call(
         self,
@@ -125,6 +120,17 @@ class GPTNeoXPreprocessor(Preprocessor):
             "padding_mask": padding_mask,
         }
         return pack_x_y_sample_weight(x, y, sample_weight)
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "sequence_length": self.sequence_length,
+                "add_start_token": self.add_start_token,
+                "add_end_token": self.add_end_token,
+            }
+        )
+        return config
 
     @classproperty
     def tokenizer_cls(cls):

--- a/keras_nlp/models/gpt_neo_x/gpt_neo_x_tokenizer.py
+++ b/keras_nlp/models/gpt_neo_x/gpt_neo_x_tokenizer.py
@@ -45,32 +45,39 @@ class GPTNeoXTokenizer(BytePairTokenizer):
 
     def __init__(
         self,
-        vocabulary,
-        merges,
+        vocabulary=None,
+        merges=None,
         **kwargs,
     ):
-        # Special tokens.
-        end_token = "<|endoftext|>"
+        # GPTNeoX uses the same start as end token, i.e., "<|endoftext|>".
+        self.end_token = self.start_token = "<|endoftext|>"
 
         super().__init__(
             vocabulary=vocabulary,
             merges=merges,
-            unsplittable_tokens=[end_token],
+            unsplittable_tokens=[self.end_token],
             **kwargs,
         )
 
-        # Check whether special tokens are present in the vocabulary.
-        if end_token not in self.get_vocabulary():
-            raise ValueError(
-                f"Cannot find token `'{end_token}'` in the provided "
-                f"`vocabulary`. Please provide `'{end_token}'` in your "
-                "`vocabulary` or use a pretrained `vocabulary` name."
-            )
+    def set_vocabulary_and_merges(self, vocabulary, merges):
+        super().set_vocabulary_and_merges(vocabulary, merges)
 
-        self.end_token_id = self.token_to_id(end_token)
-        # GPTNeoX uses the same start as end token, i.e., "<|endoftext|>".
-        self.start_token_id = self.end_token_id
-        self.pad_token_id = 0
+        if vocabulary is not None:
+            # Check for necessary special tokens.
+            if self.end_token not in self.get_vocabulary():
+                raise ValueError(
+                    f"Cannot find token `'{self.end_token}'` in the provided "
+                    f"`vocabulary`. Please provide `'{self.end_token}'` in "
+                    "your `vocabulary` or use a pretrained `vocabulary` name."
+                )
+
+            self.end_token_id = self.token_to_id(self.end_token)
+            self.start_token_id = self.end_token_id
+            self.pad_token_id = 0
+        else:
+            self.end_token_id = None
+            self.start_token_id = None
+            self.pad_token_id = None
 
     def get_config(self):
         config = super().get_config()

--- a/keras_nlp/models/opt/opt_causal_lm_preprocessor.py
+++ b/keras_nlp/models/opt/opt_causal_lm_preprocessor.py
@@ -143,6 +143,9 @@ class OPTCausalLMPreprocessor(OPTPreprocessor):
         the sequence (as generation is expected to continue at the end of the
         inputted prompt).
         """
+        if not self.built:
+            self.build(None)
+
         x = convert_inputs_to_list_of_tensor_segments(x)[0]
         x = self.tokenizer(x)
         token_ids, padding_mask = self.packer(
@@ -163,6 +166,9 @@ class OPTCausalLMPreprocessor(OPTPreprocessor):
         padding and start/end tokens, and then converting the integer sequence
         back to a string.
         """
+        if not self.built:
+            self.build(None)
+
         token_ids, padding_mask = x["token_ids"], x["padding_mask"]
         token_ids = ops.convert_to_numpy(token_ids)
         padding_mask = ops.convert_to_numpy(padding_mask)

--- a/keras_nlp/models/opt/opt_causal_lm_test.py
+++ b/keras_nlp/models/opt/opt_causal_lm_test.py
@@ -43,7 +43,7 @@ class OPTCausalLMTest(TestCase):
             num_heads=2,
             hidden_dim=4,
             intermediate_dim=8,
-            max_sequence_length=self.preprocessor.packer.sequence_length,
+            max_sequence_length=self.preprocessor.sequence_length,
         )
         self.init_kwargs = {
             "preprocessor": self.preprocessor,

--- a/keras_nlp/models/opt/opt_preprocessor.py
+++ b/keras_nlp/models/opt/opt_preprocessor.py
@@ -123,13 +123,19 @@ class OPTPreprocessor(Preprocessor):
         self.sequence_length = sequence_length
         self.add_start_token = add_start_token
         self.add_end_token = add_end_token
+        self.packer = None
+
+    def build(self, input_shape):
+        # Defer packer creation to `build()` so that we can be sure tokenizer
+        # assets have loaded when restoring a saved model.
         self.packer = StartEndPacker(
-            start_value=tokenizer.start_token_id,
-            end_value=tokenizer.end_token_id,
-            pad_value=tokenizer.pad_token_id,
-            sequence_length=sequence_length,
+            start_value=self.tokenizer.start_token_id,
+            end_value=self.tokenizer.end_token_id,
+            pad_value=self.tokenizer.pad_token_id,
+            sequence_length=self.sequence_length,
             return_padding_mask=True,
         )
+        self.built = True
 
     def get_config(self):
         config = super().get_config()

--- a/keras_nlp/models/opt/opt_tokenizer.py
+++ b/keras_nlp/models/opt/opt_tokenizer.py
@@ -70,35 +70,45 @@ class OPTTokenizer(BytePairTokenizer):
 
     def __init__(
         self,
-        vocabulary,
-        merges,
+        vocabulary=None,
+        merges=None,
         **kwargs,
     ):
-        # Special tokens. We use `"</s>"` as both a start and end token, as OPT
-        # was only pre-trained with `"</s>"` marking document boundaries.
-        start_token = "</s>"
-        pad_token = "<pad>"
-        end_token = "</s>"
+        self.start_token = "</s>"
+        self.pad_token = "<pad>"
+        self.end_token = "</s>"
 
         super().__init__(
             vocabulary=vocabulary,
             merges=merges,
-            unsplittable_tokens=[start_token, pad_token, end_token],
+            unsplittable_tokens=[
+                self.start_token,
+                self.pad_token,
+                self.end_token,
+            ],
             **kwargs,
         )
 
-        # Check whether special tokens are present in the vocabulary.
-        for token in [start_token, pad_token, end_token]:
-            if token not in self.get_vocabulary():
-                raise ValueError(
-                    f"Cannot find token `'{token}'` in the provided "
-                    f"`vocabulary`. Please provide `'{token}'` in your "
-                    "`vocabulary` or use a pretrained `vocabulary` name."
-                )
+    def set_vocabulary_and_merges(self, vocabulary, merges):
+        super().set_vocabulary_and_merges(vocabulary, merges)
 
-        self.start_token_id = self.token_to_id(start_token)
-        self.pad_token_id = self.token_to_id(pad_token)
-        self.end_token_id = self.token_to_id(end_token)
+        if vocabulary is not None:
+            # Check for necessary special tokens.
+            for token in [self.start_token, self.pad_token, self.end_token]:
+                if token not in self.vocabulary:
+                    raise ValueError(
+                        f"Cannot find token `'{token}'` in the provided "
+                        f"`vocabulary`. Please provide `'{token}'` in your "
+                        "`vocabulary` or use a pretrained `vocabulary` name."
+                    )
+
+            self.start_token_id = self.token_to_id(self.start_token)
+            self.pad_token_id = self.token_to_id(self.pad_token)
+            self.end_token_id = self.token_to_id(self.end_token)
+        else:
+            self.start_token_id = None
+            self.pad_token_id = None
+            self.end_token_id = None
 
     @classproperty
     def presets(cls):

--- a/keras_nlp/models/roberta/roberta_classifier_test.py
+++ b/keras_nlp/models/roberta/roberta_classifier_test.py
@@ -40,7 +40,7 @@ class RobertaClassifierTest(TestCase):
             num_heads=2,
             hidden_dim=2,
             intermediate_dim=4,
-            max_sequence_length=self.preprocessor.packer.sequence_length,
+            max_sequence_length=self.preprocessor.sequence_length,
         )
         self.init_kwargs = {
             "preprocessor": self.preprocessor,

--- a/keras_nlp/models/roberta/roberta_masked_lm_test.py
+++ b/keras_nlp/models/roberta/roberta_masked_lm_test.py
@@ -47,7 +47,7 @@ class RobertaMaskedLMTest(TestCase):
             num_heads=2,
             hidden_dim=2,
             intermediate_dim=4,
-            max_sequence_length=self.preprocessor.packer.sequence_length,
+            max_sequence_length=self.preprocessor.sequence_length,
         )
         self.init_kwargs = {
             "preprocessor": self.preprocessor,

--- a/keras_nlp/models/roberta/roberta_tokenizer.py
+++ b/keras_nlp/models/roberta/roberta_tokenizer.py
@@ -77,36 +77,54 @@ class RobertaTokenizer(BytePairTokenizer):
 
     def __init__(
         self,
-        vocabulary,
-        merges,
+        vocabulary=None,
+        merges=None,
         **kwargs,
     ):
-        # Special tokens.
-        start_token = "<s>"
-        pad_token = "<pad>"
-        end_token = "</s>"
-        mask_token = "<mask>"
+        self.start_token = "<s>"
+        self.pad_token = "<pad>"
+        self.end_token = "</s>"
+        self.mask_token = "<mask>"
 
         super().__init__(
             vocabulary=vocabulary,
             merges=merges,
-            unsplittable_tokens=[start_token, pad_token, end_token, mask_token],
+            unsplittable_tokens=[
+                self.start_token,
+                self.pad_token,
+                self.end_token,
+                self.mask_token,
+            ],
             **kwargs,
         )
 
-        # Check whether special tokens are present in the vocabulary.
-        for token in [start_token, pad_token, end_token, mask_token]:
-            if token not in self.get_vocabulary():
-                raise ValueError(
-                    f"Cannot find token `'{token}'` in the provided "
-                    f"`vocabulary`. Please provide `'{token}'` in your "
-                    "`vocabulary` or use a pretrained `vocabulary` name."
-                )
+    def set_vocabulary_and_merges(self, vocabulary, merges):
+        super().set_vocabulary_and_merges(vocabulary, merges)
 
-        self.start_token_id = self.token_to_id(start_token)
-        self.pad_token_id = self.token_to_id(pad_token)
-        self.end_token_id = self.token_to_id(end_token)
-        self.mask_token_id = self.token_to_id(mask_token)
+        if vocabulary is not None:
+            # Check for necessary special tokens.
+            for token in [
+                self.start_token,
+                self.pad_token,
+                self.end_token,
+                self.mask_token,
+            ]:
+                if token not in self.vocabulary:
+                    raise ValueError(
+                        f"Cannot find token `'{token}'` in the provided "
+                        f"`vocabulary`. Please provide `'{token}'` in your "
+                        "`vocabulary` or use a pretrained `vocabulary` name."
+                    )
+
+            self.start_token_id = self.token_to_id(self.start_token)
+            self.pad_token_id = self.token_to_id(self.pad_token)
+            self.end_token_id = self.token_to_id(self.end_token)
+            self.mask_token_id = self.token_to_id(self.mask_token)
+        else:
+            self.start_token_id = None
+            self.pad_token_id = None
+            self.end_token_id = None
+            self.mask_token_id = None
 
     @classproperty
     def presets(cls):

--- a/keras_nlp/models/whisper/whisper_preprocessor.py
+++ b/keras_nlp/models/whisper/whisper_preprocessor.py
@@ -164,48 +164,61 @@ class WhisperPreprocessor(Preprocessor):
         super().__init__(**kwargs)
         self.audio_feature_extractor = audio_feature_extractor
         self.tokenizer = tokenizer
+        self.decoder_sequence_length = decoder_sequence_length
+        self.language = language
+        self.task = task
+        self.no_timestamps = no_timestamps
+        self.decoder_packer = None
+
+    def build(self, input_shape):
+        # Defer packer creation to `build()` so that we can be sure tokenizer
+        # assets have loaded when restoring a saved model.
 
         # Create list of tokens to be prepended to decoder inputs.
         bos_tokens = [self.tokenizer.bos_token_id]
         if self.tokenizer.language_tokens is not None:
             if (
-                language is None
-                or language not in self.tokenizer.language_tokens
+                self.language is None
+                or self.language not in self.tokenizer.language_tokens
             ):
                 raise ValueError(
                     "You must pass a non-None value for `language` when using "
                     "a multilingual tokenizer. The value must be one of "
                     f'{",".join(self.tokenizer.language_tokens.keys())}. '
-                    f"Received: language={language}."
+                    f"Received: language={self.language}."
                 )
-            if task is None or task not in ["transcribe", "translate"]:
+            if self.task is None or self.task not in [
+                "transcribe",
+                "translate",
+            ]:
                 raise ValueError(
                     "You must pass a non-None value for `task` when using "
                     "a multilingual tokenizer. The value must be one of "
-                    f'`"transcribe"`, `"translate"`. Received: task={task}.'
+                    '`"transcribe"`, `"translate"`. '
+                    f"Received: task={self.task}."
                 )
 
-            bos_tokens += [self.tokenizer.language_tokens[language]]
+            bos_tokens += [self.tokenizer.language_tokens[self.language]]
 
-            if task == "transcribe":
+            if self.task == "transcribe":
                 bos_tokens += [self.tokenizer.special_tokens["<|transcribe|>"]]
-            elif task == "translate":
+            elif self.task == "translate":
                 bos_tokens += [self.tokenizer.special_tokens["<|translate|>"]]
         else:
-            if language is not None:
+            if self.language is not None:
                 logging.info(
                     "`tokenizer` is monolingual, and `language` has a "
                     "non-`None` value. Setting `language` to `None`."
                 )
-                language = None
-            if task is not None:
+                self.language = None
+            if self.task is not None:
                 logging.info(
                     "`tokenizer` is monolingual, and `task` has a "
                     "non-`None` value. Setting `task` to `None`."
                 )
-                task = None
+                self.task = None
 
-        if no_timestamps:
+        if self.no_timestamps:
             bos_tokens += [self.tokenizer.no_timestamps_token_id]
 
         # TODO: Use `MultiSegmentPacker` instead of `StartEndPacker` once we
@@ -215,43 +228,9 @@ class WhisperPreprocessor(Preprocessor):
             start_value=bos_tokens,
             end_value=self.tokenizer.eos_token_id,
             pad_value=self.tokenizer.pad_token_id,
-            sequence_length=decoder_sequence_length,
+            sequence_length=self.decoder_sequence_length,
             return_padding_mask=True,
         )
-
-        self.decoder_sequence_length = decoder_sequence_length
-        self.language = language
-        self.task = task
-        self.no_timestamps = no_timestamps
-
-    def get_config(self):
-        config = super().get_config()
-        config.update(
-            {
-                "audio_feature_extractor": keras.layers.serialize(
-                    self.audio_feature_extractor
-                ),
-                "decoder_sequence_length": self.decoder_sequence_length,
-                "language": self.language,
-                "task": self.task,
-                "no_timestamps": self.no_timestamps,
-            }
-        )
-        return config
-
-    @classmethod
-    def from_config(cls, config):
-        if "tokenizer" in config and isinstance(config["tokenizer"], dict):
-            config["tokenizer"] = keras.layers.deserialize(config["tokenizer"])
-
-        if "audio_feature_extractor" in config and isinstance(
-            config["audio_feature_extractor"], dict
-        ):
-            config["audio_feature_extractor"] = keras.layers.deserialize(
-                config["audio_feature_extractor"]
-            )
-
-        return cls(**config)
 
     def call(self, x, y=None, sample_weight=None, decoder_sequence_length=None):
         if not (
@@ -293,6 +272,35 @@ class WhisperPreprocessor(Preprocessor):
         }
 
         return pack_x_y_sample_weight(x, y, sample_weight)
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "audio_feature_extractor": keras.layers.serialize(
+                    self.audio_feature_extractor
+                ),
+                "decoder_sequence_length": self.decoder_sequence_length,
+                "language": self.language,
+                "task": self.task,
+                "no_timestamps": self.no_timestamps,
+            }
+        )
+        return config
+
+    @classmethod
+    def from_config(cls, config):
+        if "tokenizer" in config and isinstance(config["tokenizer"], dict):
+            config["tokenizer"] = keras.layers.deserialize(config["tokenizer"])
+
+        if "audio_feature_extractor" in config and isinstance(
+            config["audio_feature_extractor"], dict
+        ):
+            config["audio_feature_extractor"] = keras.layers.deserialize(
+                config["audio_feature_extractor"]
+            )
+
+        return cls(**config)
 
     @classproperty
     def audio_feature_extractor_cls(cls):

--- a/keras_nlp/tokenizers/byte_pair_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer.py
@@ -30,6 +30,8 @@ import tensorflow as tf
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.backend import keras
 from keras_nlp.tokenizers import tokenizer
+from keras_nlp.utils.preset_utils import check_preset_class
+from keras_nlp.utils.preset_utils import load_from_preset
 from keras_nlp.utils.python_utils import classproperty
 from keras_nlp.utils.python_utils import format_docstring
 from keras_nlp.utils.tensor_utils import assert_tf_text_installed
@@ -41,6 +43,10 @@ try:
     import tensorflow_text as tf_text
 except ImportError:
     tf_text = None
+
+VOCAB_FILENAME = "vocabulary.json"
+MERGES_FILENAME = "merges.txt"
+
 
 # As python and TF handles special spaces differently, we need to
 # manually handle special spaces during string split.
@@ -273,8 +279,8 @@ class BytePairTokenizer(tokenizer.Tokenizer):
 
     def __init__(
         self,
-        vocabulary,
-        merges,
+        vocabulary=None,
+        merges=None,
         sequence_length=None,
         add_prefix_space=False,
         unsplittable_tokens=None,
@@ -290,27 +296,6 @@ class BytePairTokenizer(tokenizer.Tokenizer):
             )
 
         super().__init__(dtype=dtype, **kwargs)
-
-        if isinstance(vocabulary, str):
-            with open(vocabulary, "r") as f:
-                self.vocabulary = json.load(f)
-        elif isinstance(vocabulary, dict):
-            self.vocabulary = vocabulary.copy()
-        else:
-            raise ValueError(
-                "Vocabulary must be an file path or dictionary mapping string "
-                "token to int ids. Received: "
-                f"`type(vocabulary)={type(vocabulary)}`."
-            )
-        if isinstance(merges, str):
-            self.merges = [bp.rstrip() for bp in tf.io.gfile.GFile(merges)]
-        elif isinstance(merges, Iterable):
-            self.merges = list(merges)
-        else:
-            raise ValueError(
-                "Merges must be a file path or a list of merge rules. "
-                f"Received: `type(merges)={type(merges)}`"
-            )
         self.sequence_length = sequence_length
         self.add_prefix_space = add_prefix_space
         self.unsplittable_tokens = unsplittable_tokens
@@ -325,11 +310,63 @@ class BytePairTokenizer(tokenizer.Tokenizer):
             unicode_list, byte_list, default=""
         )
 
+        self.set_vocabulary_and_merges(vocabulary, merges)
+
+    def save_assets(self, dir_path):
+        vocab_path = os.path.join(dir_path, VOCAB_FILENAME)
+        merges_path = os.path.join(dir_path, MERGES_FILENAME)
+        with open(vocab_path, "w") as file:
+            file.write(json.dumps(self.vocabulary))
+        with open(merges_path, "w") as file:
+            for merge in self.merges:
+                file.write(f"{merge}\n")
+
+    def load_assets(self, dir_path):
+        vocab_path = os.path.join(dir_path, VOCAB_FILENAME)
+        merges_path = os.path.join(dir_path, MERGES_FILENAME)
+        self.set_vocabulary_and_merges(vocab_path, merges_path)
+
+    def set_vocabulary_and_merges(self, vocabulary, merges):
+        """Set the vocabulary and merge rules from data or files."""
+        if vocabulary is None or merges is None:
+            # Clear vocab related state.
+            self.vocabulary = None
+            self.merges = None
+            self.cache = None
+            self.id_to_token_map = None
+            self.token_to_id_map = None
+            self.merge_ranks_lookup_default = None
+            self.merge_ranks = None
+            return
+
+        if isinstance(vocabulary, str):
+            with open(vocabulary, "r") as f:
+                self.vocabulary = json.load(f)
+        elif isinstance(vocabulary, dict):
+            self.vocabulary = vocabulary.copy()
+        else:
+            raise ValueError(
+                "Vocabulary must be an file path or dictionary mapping string "
+                "token to int ids. Received: "
+                f"`type(vocabulary)={type(vocabulary)}`."
+            )
+        if isinstance(merges, str):
+            self.merges = [bp.rstrip() for bp in open(merges)]
+        elif isinstance(merges, Iterable):
+            self.merges = list(merges)
+        else:
+            raise ValueError(
+                "Merges must be a file path or a list of merge rules. "
+                f"Received: `type(merges)={type(merges)}`"
+            )
+
         self.cache = BytePairTokenizerCache()
-        if unsplittable_tokens:
+        if self.unsplittable_tokens:
             # Put special tokens into cache, so it won't be further split and
             # merged.
-            self.cache.insert(unsplittable_tokens, unsplittable_tokens)
+            self.cache.insert(
+                self.unsplittable_tokens, self.unsplittable_tokens
+            )
 
         # Create mapping between string tokens to int ids, and vice versa.
         byte_pairs = [x[0] for x in self.vocabulary.items()]
@@ -356,10 +393,12 @@ class BytePairTokenizer(tokenizer.Tokenizer):
 
     def get_vocabulary(self) -> List[str]:
         """Get the tokenizer vocabulary as a list of strings tokens."""
+        self._check_vocabulary()
         return self.vocabulary.keys()
 
     def vocabulary_size(self) -> int:
         """Get the size of the tokenizer vocabulary."""
+        self._check_vocabulary()
         return len(self.vocabulary)
 
     def id_to_token(self, id: int) -> str:
@@ -367,6 +406,7 @@ class BytePairTokenizer(tokenizer.Tokenizer):
         # This will be slow, but keep memory usage down compared to building a
         # dict. Assuming the main use case is looking up a few special tokens
         # early in the vocab, this should be fine.
+        self._check_vocabulary()
 
         keys = self.get_vocabulary()
         for token in keys:
@@ -376,23 +416,8 @@ class BytePairTokenizer(tokenizer.Tokenizer):
 
     def token_to_id(self, token: str) -> int:
         """Convert a string token to an integer id."""
+        self._check_vocabulary()
         return self.vocabulary[token]
-
-    def get_config(self):
-        config = super().get_config()
-        config.update(
-            {
-                # Ideally vocabulary and merge list would be saved as plain text
-                # assets in the saved model. We have no good way to support
-                # this currently, so we save the vocabulary in the config.
-                "vocabulary": self.vocabulary,
-                "merges": self.merges,
-                "sequence_length": self.sequence_length,
-                "add_prefix_space": self.add_prefix_space,
-                "unsplittable_tokens": self.unsplittable_tokens,
-            }
-        )
-        return config
 
     @tf.function
     def _bpe_merge_one_step(self, words, mask):
@@ -499,7 +524,16 @@ class BytePairTokenizer(tokenizer.Tokenizer):
         )
         return merged_words
 
+    def _check_vocabulary(self):
+        if self.vocabulary is None:
+            raise ValueError(
+                "No vocabulary has been set for BytePairTokenizer. Make sure "
+                "to pass `vocabulary` and `merges` arguments when creating the "
+                "layer."
+            )
+
     def tokenize(self, inputs):
+        self._check_vocabulary()
         if not isinstance(inputs, (tf.Tensor, tf.RaggedTensor)):
             inputs = tf.convert_to_tensor(inputs)
 
@@ -560,6 +594,7 @@ class BytePairTokenizer(tokenizer.Tokenizer):
         return tokens
 
     def detokenize(self, inputs):
+        self._check_vocabulary()
         inputs, unbatched, _ = convert_to_ragged_batch(inputs)
         inputs = tf.cast(inputs, self.dtype)
         unicode_text = tf.strings.reduce_join(
@@ -592,9 +627,51 @@ class BytePairTokenizer(tokenizer.Tokenizer):
         )
         self.cache.insert(tokens, tokenized_words)
 
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "sequence_length": self.sequence_length,
+                "add_prefix_space": self.add_prefix_space,
+                "unsplittable_tokens": self.unsplittable_tokens,
+            }
+        )
+        return config
+
     @classproperty
     def presets(cls):
         return {}
+
+    @classmethod
+    def _legacy_from_preset(
+        cls,
+        preset,
+        **kwargs,
+    ):
+        metadata = cls.presets[preset]
+
+        vocabulary = keras.utils.get_file(
+            "vocab.txt",
+            metadata["vocabulary_url"],
+            cache_subdir=os.path.join("models", preset),
+            file_hash=metadata["vocabulary_hash"],
+        )
+        merges = keras.utils.get_file(
+            "merges.txt",
+            metadata["merges_url"],
+            cache_subdir=os.path.join("models", preset),
+            file_hash=metadata["merges_hash"],
+        )
+
+        config = metadata["preprocessor_config"]
+        config.update(
+            {
+                "vocabulary": vocabulary,
+                "merges": merges,
+            },
+        )
+
+        return cls.from_config({**config, **kwargs})
 
     @classmethod
     def from_preset(
@@ -619,41 +696,17 @@ class BytePairTokenizer(tokenizer.Tokenizer):
         tokenizer.detokenize([5, 6, 7, 8, 9])
         ```
         """
+        # TODO: delete me!
+        if preset in cls.presets:
+            return cls._legacy_from_preset(preset, **kwargs)
 
-        if not cls.presets:
-            raise NotImplementedError(
-                "No presets have been created for this class"
-            )
-
-        if preset not in cls.presets:
-            raise ValueError(
-                "`preset` must be one of "
-                f"""{", ".join(cls.presets)}. Received: {preset}."""
-            )
-        metadata = cls.presets[preset]
-
-        vocabulary = keras.utils.get_file(
-            "vocab.json",
-            metadata["vocabulary_url"],
-            cache_subdir=os.path.join("models", preset),
-            file_hash=metadata["vocabulary_hash"],
+        config_file = "tokenizer.json"
+        check_preset_class(preset, cls, config_file=config_file)
+        return load_from_preset(
+            preset,
+            config_file=config_file,
+            config_overrides=kwargs,
         )
-        merges = keras.utils.get_file(
-            "merges.txt",
-            metadata["merges_url"],
-            cache_subdir=os.path.join("models", preset),
-            file_hash=metadata["merges_hash"],
-        )
-
-        config = metadata["preprocessor_config"]
-        config.update(
-            {
-                "vocabulary": vocabulary,
-                "merges": merges,
-            },
-        )
-
-        return cls.from_config({**config, **kwargs})
 
     def __init_subclass__(cls, **kwargs):
         # Use __init_subclass__ to setup a correct docstring for from_preset.


### PR DESCRIPTION
As part of this work, we need to also switch all downstream preprocessing layers to create packers on build (instead of on call).

Two other cleanups while doing this:
- Switch us to a more idiomatic ordering for our layer methods. `build` -> `call` -> `get_config`.
- Expose the string special tokens on our tokenizers. So `bert.cls_token` and `bert.cls_token_id` will both be exposed.