### PR TITLE
Add `version` API to keras_nlp

### DIFF
--- a/keras_nlp/layers/preprocessing/masked_lm_mask_generator.py
+++ b/keras_nlp/layers/preprocessing/masked_lm_mask_generator.py
@@ -170,7 +170,11 @@ class MaskedLMMaskGenerator(PreprocessingLayer):
     def call(self, inputs):
         inputs, unbatched, rectangular = convert_to_ragged_batch(inputs)
 
-        (token_ids, mask_positions, mask_ids,) = tf_text.mask_language_model(
+        (
+            token_ids,
+            mask_positions,
+            mask_ids,
+        ) = tf_text.mask_language_model(
             inputs,
             item_selector=self._random_selector,
             mask_values_chooser=self._mask_values_chooser,

--- a/keras_nlp/layers/preprocessing/masked_lm_mask_generator.py
+++ b/keras_nlp/layers/preprocessing/masked_lm_mask_generator.py
@@ -170,11 +170,7 @@ class MaskedLMMaskGenerator(PreprocessingLayer):
     def call(self, inputs):
         inputs, unbatched, rectangular = convert_to_ragged_batch(inputs)
 
-        (
-            token_ids,
-            mask_positions,
-            mask_ids,
-        ) = tf_text.mask_language_model(
+        (token_ids, mask_positions, mask_ids,) = tf_text.mask_language_model(
             inputs,
             item_selector=self._random_selector,
             mask_values_chooser=self._mask_values_chooser,

--- a/keras_nlp/version.py
+++ b/keras_nlp/version.py
@@ -18,6 +18,6 @@ from keras_nlp.api_export import keras_nlp_export
 __version__ = "0.7.0"
 
 
-@keras_nlp_export("keras.version")
+@keras_nlp_export("keras_nlp.version")
 def version():
     return __version__

--- a/keras_nlp/version.py
+++ b/keras_nlp/version.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The KerasNLP Authors
+# Copyright 2023 The KerasNLP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,18 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# sentencepiece is segfaulting on tf-nightly if tensorflow is imported first.
-# This is a temporary fix to restore our nightly testing to green, while we look
-# for a longer term solution.
-try:
-    import sentencepiece
-except ImportError:
-    pass
+from keras_nlp.api_export import keras_nlp_export
 
-from keras_nlp import layers
-from keras_nlp import metrics
-from keras_nlp import models
-from keras_nlp import samplers
-from keras_nlp import tokenizers
-from keras_nlp import utils
-from keras_nlp.version import __version__
+# Unique source of truth for the version number.
+__version__ = "0.7.0"
+
+
+@keras_nlp_export("keras.version")
+def version():
+    return __version__

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ README = (HERE / "README.md").read_text()
 if os.path.exists("keras_nlp/version.py"):
     VERSION = get_version("keras_nlp/version.py")
 else:
-    VERSION = get_version("kera_nlps/__init__.py")
+    VERSION = get_version("keras_nlp/__init__.py")
 
 setup(
     name="keras-nlp",

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,10 @@ def get_version(rel_path):
 
 HERE = pathlib.Path(__file__).parent
 README = (HERE / "README.md").read_text()
+if os.path.exists("keras_nlp/version.py"):
+    VERSION = get_version("keras_nlp/version.py")
+else:
+    VERSION = get_version("kera_nlps/__init__.py")
 
 setup(
     name="keras-nlp",
@@ -45,7 +49,7 @@ setup(
     ),
     long_description=README,
     long_description_content_type="text/markdown",
-    version=get_version("keras_nlp/__init__.py"),
+    version=VERSION,
     url="https://github.com/keras-team/keras-nlp",
     author="Keras team",
     author_email="keras-nlp@google.com",

--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,7 @@ def get_version(rel_path):
 
 HERE = pathlib.Path(__file__).parent
 README = (HERE / "README.md").read_text()
-if os.path.exists("keras_nlp/version.py"):
-    VERSION = get_version("keras_nlp/version.py")
-else:
-    VERSION = get_version("keras_nlp/__init__.py")
+VERSION = get_version("keras_nlp/version.py")
 
 setup(
     name="keras-nlp",


### PR DESCRIPTION
Keras recently made the version string accessible via `keras.version()`. Porting this behavior to keras_nlp.