### PR TITLE
Add tests for Presets workflow, Add Metadata

### DIFF
--- a/keras_nlp/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/sentence_piece_tokenizer.py
@@ -132,7 +132,7 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
 
     def save_assets(self, dir_path):
         path = os.path.join(dir_path, VOCAB_FILENAME)
-        with open(path, "w") as file:
+        with open(path, "wb") as file:
             file.write(self.proto)
 
     def load_assets(self, dir_path):

--- a/keras_nlp/utils/preset_utils.py
+++ b/keras_nlp/utils/preset_utils.py
@@ -100,14 +100,18 @@ def save_to_preset(
     # Include references to weights and assets.
     config["assets"] = assets
     config["weights"] = weights_filename if save_weights else None
-    recursive_pop(config, "config_config")
+    recursive_pop(config, "compile_config")
     recursive_pop(config, "build_config")
     with open(config_path, "w") as config_file:
         config_file.write(json.dumps(config, indent=4))
 
+    from keras_nlp import __version__ as keras_nlp_version
+
     # Save any associated metadata.
     metadata = {
-        # TODO: save keras version and keras-nlp version.
+        "keras_version": keras.src.__version__,
+        "keras_nlp_version": keras_nlp_version,
+        "parameter_count": layer.count_params(),
         "date_saved": datetime.datetime.now().strftime("%Y-%m-%d@%H:%M:%S"),
     }
     metadata_path = os.path.join(preset, "metadata.json")

--- a/keras_nlp/utils/preset_utils_test.py
+++ b/keras_nlp/utils/preset_utils_test.py
@@ -1,0 +1,89 @@
+# Copyright 2023 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import json
+import os
+
+from keras_nlp.backend import keras
+from keras_nlp.model.bart import bart_presets
+from keras_nlp.models import AlbertMaskedLM
+from keras_nlp.models import BartSeq2SeqLM
+from keras_nlp.models import BertMaskedLM
+from keras_nlp.models.albert import albert_presets
+from keras_nlp.models.bert import bert_presets
+from keras_nlp.tests.test_case import TestCase
+from keras_nlp.utils import preset_utils
+
+
+class PresetUtilsTest(TestCase):
+    def test_albert_sentencepiece_preset_saving(self):
+        save_dir = self.get_temp_dir()
+        model = AlbertMaskedLM.from_preset("albert_base_en_uncased")
+        preset_utils.save_to_preset(model, save_dir)
+
+        # Check existence of files
+        self.assertTrue(
+            os.path.exists(
+                os.path.join(save_dir, "assets/tokenizer/vocabulary.txt")
+            )
+        )
+        self.assertTrue(os.path.exists(os.path.join(save_dir, "config.json")))
+        self.assertTrue(
+            os.path.exists(os.path.join(save_dir, "model.weights.h5"))
+        )
+        self.assertTrue(os.path.exists(os.path.join(save_dir, "metadata.json")))
+
+        preset_dict = albert_presets.backbone_presets["albert_base_en_uncased"]
+
+        # Check that saved vocab is equal to the original preset vocab
+        proto = open(
+            os.path.join(save_dir, "assets/tokenizer/vocabulary.txt"), "rb"
+        ).read()
+        expected_proto_file = keras.utils.get_file(
+            "vocab.spm",
+            preset_dict["spm_proto_url"],
+            cache_subdir=os.path.join("models", "albert_base_en_uncased"),
+            file_hash=preset_dict["spm_proto_hash"],
+        )
+        expected_proto = open(expected_proto_file, "rb").read()
+        self.assertEqual(proto, expected_proto)
+
+        # Check the model config (`config.json``)
+        config_json = open(os.path.join(save_dir, "config.json"), "r").read()
+        self.assertTrue(
+            "build_config" not in config_json
+        )  # Test on raw json to include nested keys
+        self.assertTrue(
+            "compile_config" not in config_json
+        )  # Test on raw json to include nested keys
+        config = json.loads(config_json)
+        self.assertAllEqual(
+            config["assets"], ["assets/tokenizer/vocabulary.txt"]
+        )
+        self.assertEqual(config["weights"], "model.weights.h5")
+
+        # Try deserializing the model using the config
+        restored_model = keras.saving.deserialize_keras_object(config)
+        restored_model.load_weights(os.path.join(save_dir, "model.weights.h5"))
+        restored_model.preprocessor.tokenizer.load_assets(
+            os.path.join(save_dir, "assets/tokenizer/")
+        )
+
+        # Check model outputs
+        train_data = (
+            ["the quick brown fox.", "the slow brown fox."],  # Features.
+        )
+        input_data = model.preprocessor(*train_data)[0]
+        self.assertAllEqual(model(input_data), restored_model(input_data))


### PR DESCRIPTION
This PR adds important tests for the entire presets workflow, with an example from each of:

- SentencePieceTokenizer (AlbertMaskedLM)
- BytePairTokenizer (BartSeq2SeqLM)
- WordPieceTokenize (BertMaskedLM)

This tests the result of each, including file structure, assets (vocab) verification, and deserialization tests.

Additionally, the metadata.json is added to the presets directory with relevant information on Keras versioning, parameter count, and date/time.