### PR TITLE
Fix Keras 3 version check

### DIFF
--- a/keras_nlp/backend/config.py
+++ b/keras_nlp/backend/config.py
@@ -63,9 +63,9 @@ if "KERAS_BACKEND" in os.environ and os.environ["KERAS_BACKEND"]:
     _MULTI_BACKEND = True
 
 
-def detect_if_tensorflow_uses_keras_3():
+def detect_if_keras_3_installed():
     # We follow the version of keras that tensorflow is configured to use.
-    from tensorflow import keras
+    import keras
 
     # Note that only recent versions of keras have a `version()` function.
     if hasattr(keras, "version") and keras.version().startswith("3."):
@@ -75,7 +75,7 @@ def detect_if_tensorflow_uses_keras_3():
     return False
 
 
-_USE_KERAS_3 = detect_if_tensorflow_uses_keras_3()
+_USE_KERAS_3 = detect_if_keras_3_installed()
 if _USE_KERAS_3:
     _MULTI_BACKEND = True
 

--- a/keras_nlp/backend/config.py
+++ b/keras_nlp/backend/config.py
@@ -63,9 +63,20 @@ if "KERAS_BACKEND" in os.environ and os.environ["KERAS_BACKEND"]:
     _MULTI_BACKEND = True
 
 
-def detect_if_keras_3_installed():
+def detect_if_tensorflow_uses_keras_3():
     # We follow the version of keras that tensorflow is configured to use.
     import keras
+
+    # Return False if env variable is set and `tf_keras` is installed.
+    use_legacy_keras = os.environ.get("TF_USE_LEGACY_KERAS", "")
+    if use_legacy_keras == "1" or use_legacy_keras.lower() == "true":
+        try:
+            import tf_keras  # noqa: F401
+
+            return False
+        except ImportError:
+            # `tf_keras` is not installed
+            pass
 
     # Note that only recent versions of keras have a `version()` function.
     if hasattr(keras, "version") and keras.version().startswith("3."):
@@ -75,7 +86,7 @@ def detect_if_keras_3_installed():
     return False
 
 
-_USE_KERAS_3 = detect_if_keras_3_installed()
+_USE_KERAS_3 = detect_if_tensorflow_uses_keras_3()
 if _USE_KERAS_3:
     _MULTI_BACKEND = True
 

--- a/keras_nlp/backend/config.py
+++ b/keras_nlp/backend/config.py
@@ -66,20 +66,25 @@ if "KERAS_BACKEND" in os.environ and os.environ["KERAS_BACKEND"]:
 def detect_if_tensorflow_uses_keras_3():
     # We follow the version of keras that tensorflow is configured to use.
     import keras
+    import tensorflow as tf
+    from packaging import version
 
     # Return False if env variable is set and `tf_keras` is installed.
-    use_legacy_keras = os.environ.get("TF_USE_LEGACY_KERAS", "")
-    if use_legacy_keras == "1" or use_legacy_keras.lower() == "true":
-        try:
-            import tf_keras  # noqa: F401
-
-            return False
-        except ImportError:
-            # `tf_keras` is not installed
-            pass
-
+    if os.environ.get("TF_USE_LEGACY_KERAS", None) in ("true", "True", "1"):
+        raise ValueError(
+            "`keras-nlp` is not compatible with usage of `tf-keras` "
+            "via environment variable `TF_USE_LEGACY_KERAS`. "
+            "Please unset this environment variable to use `keras-nlp`."
+        )
     # Note that only recent versions of keras have a `version()` function.
     if hasattr(keras, "version") and keras.version().startswith("3."):
+        if version.parse(tf.__version__) < version.parse("2.15.0"):
+            raise ValueError(
+                f"Your `tensorflow` version {tf.__version__} is not compatible "
+                f"with `keras` version {keras.version()}. Keras 3 requires "
+                "TensorFlow 2.15 or later. See keras.io/getting_started for "
+                "more information on installing Keras."
+            )
         return True
 
     # No `keras.version()` means we are on an old version of keras.

--- a/keras_nlp/backend/config.py
+++ b/keras_nlp/backend/config.py
@@ -65,27 +65,19 @@ if "KERAS_BACKEND" in os.environ and os.environ["KERAS_BACKEND"]:
 
 def detect_if_tensorflow_uses_keras_3():
     # We follow the version of keras that tensorflow is configured to use.
-    import keras
-    import tensorflow as tf
-    from packaging import version
+    try:
+        from tensorflow import keras
 
-    # Return False if env variable is set and `tf_keras` is installed.
-    if os.environ.get("TF_USE_LEGACY_KERAS", None) in ("true", "True", "1"):
+        # Note that only recent versions of keras have a `version()` function.
+        if hasattr(keras, "version") and keras.version().startswith("3."):
+            return True
+    except:
         raise ValueError(
-            "`keras-nlp` is not compatible with usage of `tf-keras` "
-            "via environment variable `TF_USE_LEGACY_KERAS`. "
-            "Please unset this environment variable to use `keras-nlp`."
+            "Unable to import `keras` with `tensorflow`.  Please check your "
+            "Keras and Tensorflow version are compatible; Keras 3 requires "
+            "TensorFlow 2.15 or later. See keras.io/getting_started for more "
+            "information on installing Keras."
         )
-    # Note that only recent versions of keras have a `version()` function.
-    if hasattr(keras, "version") and keras.version().startswith("3."):
-        if version.parse(tf.__version__) < version.parse("2.15.0"):
-            raise ValueError(
-                f"Your `tensorflow` version {tf.__version__} is not compatible "
-                f"with `keras` version {keras.version()}. Keras 3 requires "
-                "TensorFlow 2.15 or later. See keras.io/getting_started for "
-                "more information on installing Keras."
-            )
-        return True
 
     # No `keras.version()` means we are on an old version of keras.
     return False


### PR DESCRIPTION
`keras-nlp` has a function to check if TensorFlow uses Keras 3 via - 
https://github.com/keras-team/keras-nlp/blob/master/keras_nlp/backend/config.py#L66

This works when using `tf-nightly` or `TensorFlow 2.15`, but breaks on `TensorFlow 2.14` which is the default in Colab.  To fix it, use `import keras` instead of `from tensorflow import keras` when doing this check.

Colab to repro the issue:
https://colab.research.google.com/drive/17AwBX5S29d-hjUDPLN8roHSNzrjXricG?usp=sharing