### PR TITLE
Use set comparison for assets

### DIFF
--- a/keras_nlp/utils/preset_utils_test.py
+++ b/keras_nlp/utils/preset_utils_test.py
@@ -68,7 +68,7 @@ class PresetUtilsTest(TestCase):
             "compile_config" not in config_json
         )  # Test on raw json to include nested keys
         config = json.loads(config_json)
-        self.assertAllEqual(config["assets"], expected_assets)
+        self.assertEqual(set(config["assets"]), set(expected_assets))
         self.assertEqual(config["weights"], "model.weights.h5")
 
         # Try loading the model from preset directory


### PR DESCRIPTION
We were relying on the order of `os.listdir` previously, which is not fixed I believe.

https://github.com/keras-team/keras-nlp/pull/1333/checks?check_run_id=19158555913