### PR TITLE
Fix a failing byte pair tokenizer test

### DIFF
--- a/keras_nlp/tokenizers/byte_pair_tokenizer_test.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer_test.py
@@ -164,6 +164,9 @@ class BytePairTokenizerTest(TestCase):
         cloned_tokenizer = BytePairTokenizer.from_config(
             self.tokenizer.get_config()
         )
+        cloned_tokenizer.set_vocabulary_and_merges(
+            self.tokenizer.vocabulary, self.tokenizer.merges
+        )
         self.assertAllEqual(
             self.tokenizer(input_data),
             cloned_tokenizer(input_data),


### PR DESCRIPTION
Now that vocab and merges are not config (they are assets state), we need to remember to copy them over when cloning a tokenizer.

This failure is only showing up on GPU testing because of https://github.com/keras-team/keras-nlp/issues/409