### PR TITLE
Use the proper title for example

### DIFF
--- a/keras_nlp/models/deberta_v3/deberta_v3_backbone.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_backbone.py
@@ -68,7 +68,7 @@ class DebertaV3Backbone(Backbone):
         bucket_size: int. The size of the relative position buckets. Generally
             equal to `max_sequence_length // 2`.
 
-    Example usage:
+    Example:
     ```python
     input_data = {
         "token_ids": np.ones(shape=(1, 12), dtype="int32"),

--- a/keras_nlp/models/gpt2/gpt2_backbone.py
+++ b/keras_nlp/models/gpt2/gpt2_backbone.py
@@ -62,7 +62,7 @@ class GPT2Backbone(Backbone):
             sequence length. This determines the variable shape for positional
             embeddings.
 
-    Example usage:
+    Example:
     ```python
     input_data = {
         "token_ids": np.ones(shape=(1, 12), dtype="int32"),


### PR DESCRIPTION
Otherwise it won't be rendered correctly by the [`TFKerasDocumentationGenerator`](https://github.com/keras-team/keras-io/blob/fc340b9989cdf17fba44e66efa22758afad39b87/scripts/docstrings.py#L27-L28)

Same idea as https://github.com/keras-team/keras-cv/pull/2109