### PR TITLE
Fix t5 tokenizer expected output

### DIFF
--- a/keras_nlp/models/t5/t5_tokenizer_test.py
+++ b/keras_nlp/models/t5/t5_tokenizer_test.py
@@ -52,7 +52,7 @@ class T5TokenizerTest(TestCase):
                 cls=T5Tokenizer,
                 preset=preset,
                 input_data=["The quick brown fox."],
-                expected_output=[[1996, 4248, 2829, 4419, 1012]],
+                expected_output=[[37, 1704, 4216, 3, 20400, 5]],
             )
 
     @pytest.mark.extra_large


### PR DESCRIPTION
I am not exactly sure how this was ever working

We had copied the bert output, t5 has a different tokenizer.