### PR TITLE
Another fix for saving on Keras 2

### DIFF
--- a/keras_nlp/tokenizers/byte_pair_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer.py
@@ -315,7 +315,7 @@ class BytePairTokenizer(tokenizer.Tokenizer):
         vocab_path = os.path.join(dir_path, VOCAB_FILENAME)
         merges_path = os.path.join(dir_path, MERGES_FILENAME)
         with open(vocab_path, "w") as file:
-            file.write(json.dumps(self.vocabulary))
+            file.write(json.dumps(dict(self.vocabulary)))
         with open(merges_path, "w") as file:
             for merge in self.merges:
                 file.write(f"{merge}\n")


### PR DESCRIPTION
This we would also catch if we were running our large testing on 2.13 or 2.14. Tensorflow will turn all dictionary attributes on a layer into "trackable dicts." Python does not know how to save these, so we need to cast our byte pair vocabulary to a dict before writing the json.