### PR TITLE
Fix task pre-processor in tasks

### DIFF
--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -174,6 +174,13 @@ class Task(PipelineModel):
         )
         ```
         """
+        if "backbone" in kwargs:
+            raise ValueError(
+                "You cannot pass a `backbone` argument to the `from_preset` "
+                f"method. Instead, call the {cls.__name__} default "
+                "constructor with a `backbone` argument. "
+                f"Received: backbone={kwargs['backbone']}."
+            )
         # We support short IDs for official presets, e.g. `"bert_base_en"`.
         # Map these to a Kaggle Models handle.
         if preset in cls.presets:
@@ -187,13 +194,6 @@ class Task(PipelineModel):
                 preset,
                 load_weights=load_weights,
             )
-            if "backbone" in kwargs:
-                raise ValueError(
-                    "You cannot pass a `backbone` argument to the "
-                    f"`from_preset` method. Instead, call the {cls.__name__} "
-                    "default constructor with `backbone` argument. "
-                    f"Received: backbone={backbone}."
-                )
             if "preprocessor" in kwargs:
                 preprocessor = kwargs.pop("preprocessor")
             else:

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -191,7 +191,16 @@ class Task(PipelineModel):
                 preset,
                 config_file="tokenizer.json",
             )
-            preprocessor = cls.preprocessor_cls(tokenizer=tokenizer)
+            if "backbone" in kwargs:
+                raise ValueError(
+                    "`backbone` weights are loaded from the "
+                    f"preset {preset}. Cannot provide `backbone` "
+                    "argument to the `from_preset` method."
+                )
+            if "preprocessor" in kwargs:
+                preprocessor = kwargs.pop("preprocessor")
+            else:
+                preprocessor = cls.preprocessor_cls(tokenizer=tokenizer)
             return cls(backbone=backbone, preprocessor=preprocessor, **kwargs)
 
         # Task case.

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -187,19 +187,20 @@ class Task(PipelineModel):
                 preset,
                 load_weights=load_weights,
             )
-            tokenizer = load_from_preset(
-                preset,
-                config_file="tokenizer.json",
-            )
             if "backbone" in kwargs:
                 raise ValueError(
-                    "`backbone` weights are loaded from the "
-                    f"preset {preset}. Cannot provide `backbone` "
-                    "argument to the `from_preset` method."
+                    "You cannot pass a `backbone` argument to the "
+                    f"`from_preset` method. Instead, call the {cls.__name__} "
+                    "default constructor with `backbone` argument. "
+                    f"Received: backbone={backbone}."
                 )
             if "preprocessor" in kwargs:
                 preprocessor = kwargs.pop("preprocessor")
             else:
+                tokenizer = load_from_preset(
+                    preset,
+                    config_file="tokenizer.json",
+                )
                 preprocessor = cls.preprocessor_cls(tokenizer=tokenizer)
             return cls(backbone=backbone, preprocessor=preprocessor, **kwargs)
 


### PR DESCRIPTION
When a user passes `preprocessor` to a `from_preset` constructor via kwargs, it fails with "got multiple values for keyword argument 'preprocessor'".  This is because `from_preset` adds `preprocessor` parameter regardless of whether has also provided it.  With this fix, we only add the `preprocessor` when the user has not provided the input.

Also, adds a validation to verify that user doesn't provide a `backbone` to the `from_preset` method since that's obtained from the preset directly.

```
# Repro steps
preprocessor = keras_nlp.models.DistilBertPreprocessor.from_preset(
    "distil_bert_base_en_uncased",
    sequence_length=SEQ_LENGTH,
)

# Pretrained classifier -  Errors out with duplicate `preprocessor` arg
classifier = keras_nlp.models.DistilBertClassifier.from_preset(
    "distil_bert_base_en_uncased",
    num_classes=2,
    activation=None,
    preprocessor=preprocessor,
)
```