### PR TITLE
Align requirments with Keras

### DIFF
--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -1,6 +1,6 @@
 # Tensorflow cpu-only version.
-tf-nightly-cpu==2.16.0.dev20231109  # Pin a working nightly until rc0.
-tensorflow-text-nightly==2.16.0.dev20231109  # Pin a working nightly until rc0.
+tf-nightly-cpu==2.16.0.dev20231221  # Pin a working nightly until rc0.
+tensorflow-text-nightly==2.16.0.dev20231221  # Pin a working nightly until rc0.
 
 # Torch cpu-only version.
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -1,6 +1,6 @@
 # Tensorflow with cuda support.
-tf-nightly[and-cuda]==2.16.0.dev20231109  # Pin a working nightly until rc0.
-tensorflow-text-nightly==2.16.0.dev20231109  # Pin a working nightly until rc0.
+tf-nightly[and-cuda]==2.16.0.dev20231221  # Pin a working nightly until rc0.
+tensorflow-text-nightly==2.16.0.dev20231221  # Pin a working nightly until rc0.
 
 # Torch cpu-only version.
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -1,5 +1,4 @@
 # Tensorflow with cuda support.
---extra-index-url https://pypi.nvidia.com
 tf-nightly[and-cuda]==2.16.0.dev20231109  # Pin a working nightly until rc0.
 tensorflow-text-nightly==2.16.0.dev20231109  # Pin a working nightly until rc0.
 

--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -3,9 +3,9 @@ tf-nightly-cpu==2.16.0.dev20231109  # Pin a working nightly until rc0.
 tensorflow-text-nightly==2.16.0.dev20231109  # Pin a working nightly until rc0.
 
 # Torch with cuda support.
---extra-index-url https://download.pytorch.org/whl/cu118
-torch==2.1.0
-torchvision==0.16.0
+--extra-index-url https://download.pytorch.org/whl/cu121
+torch==2.1.2
+torchvision==0.16.2
 
 # Jax cpu-only version.
 jax[cpu]

--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -1,6 +1,6 @@
 # Tensorflow cpu-only version.
-tf-nightly-cpu==2.16.0.dev20231109  # Pin a working nightly until rc0.
-tensorflow-text-nightly==2.16.0.dev20231109  # Pin a working nightly until rc0.
+tf-nightly-cpu==2.16.0.dev20231221  # Pin a working nightly until rc0.
+tensorflow-text-nightly==2.16.0.dev20231221  # Pin a working nightly until rc0.
 
 # Torch with cuda support.
 --extra-index-url https://download.pytorch.org/whl/cu121

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Tensorflow.
-tf-nightly-cpu==2.16.0.dev20231109  # Pin a working nightly until rc0.
-tensorflow-text-nightly==2.16.0.dev20231109  # Pin a working nightly until rc0.
+tf-nightly-cpu==2.16.0.dev20231221  # Pin a working nightly until rc0.
+tensorflow-text-nightly==2.16.0.dev20231221  # Pin a working nightly until rc0.
 
 # Torch.
 --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
* Use Cuda 12.1 for Torch to align with TF and Jax. Also, aligns torch install with that of Colab that uses torch+cu121 packages.
* Remove extra-url for TensorFlow as its no longer required.