### PR TITLE
Support tokenization of special tokens for word_piece_tokenizer

### DIFF
--- a/keras_nlp/models/bert/bert_tokenizer.py
+++ b/keras_nlp/models/bert/bert_tokenizer.py
@@ -98,20 +98,6 @@ class BertTokenizer(WordPieceTokenizer):
         super().set_vocabulary(vocabulary)
 
         if vocabulary is not None:
-            # Check for necessary special tokens.
-            for token in [
-                self.cls_token,
-                self.pad_token,
-                self.sep_token,
-                self.mask_token,
-            ]:
-                if token not in self.vocabulary:
-                    raise ValueError(
-                        f"Cannot find token `'{token}'` in the provided "
-                        f"`vocabulary`. Please provide `'{token}'` in your "
-                        "`vocabulary` or use a pretrained `vocabulary` name."
-                    )
-
             self.cls_token_id = self.token_to_id(self.cls_token)
             self.sep_token_id = self.token_to_id(self.sep_token)
             self.pad_token_id = self.token_to_id(self.pad_token)

--- a/keras_nlp/models/bert/bert_tokenizer.py
+++ b/keras_nlp/models/bert/bert_tokenizer.py
@@ -49,6 +49,9 @@ class BertTokenizer(WordPieceTokenizer):
             plain text file containing a single word piece token per line.
         lowercase: If `True`, the input text will be first lowered before
             tokenization.
+        special_tokens_in_strings: bool. A bool to indicate if the tokenizer
+            should expect special tokens in input strings that should be
+            tokenized and mapped correctly to their ids. Defaults to False.
 
     Examples:
     ```python
@@ -76,6 +79,7 @@ class BertTokenizer(WordPieceTokenizer):
         self,
         vocabulary=None,
         lowercase=False,
+        special_tokens_in_strings=False,
         **kwargs,
     ):
         self.cls_token = "[CLS]"
@@ -91,6 +95,7 @@ class BertTokenizer(WordPieceTokenizer):
                 self.pad_token,
                 self.mask_token,
             ],
+            special_tokens_in_strings=special_tokens_in_strings,
             **kwargs,
         )
 

--- a/keras_nlp/models/bert/bert_tokenizer.py
+++ b/keras_nlp/models/bert/bert_tokenizer.py
@@ -82,7 +82,6 @@ class BertTokenizer(WordPieceTokenizer):
         self.sep_token = "[SEP]"
         self.pad_token = "[PAD]"
         self.mask_token = "[MASK]"
-        self.unk_token = "[UNK]"
         super().__init__(
             vocabulary=vocabulary,
             lowercase=lowercase,
@@ -91,7 +90,6 @@ class BertTokenizer(WordPieceTokenizer):
                 self.sep_token,
                 self.pad_token,
                 self.mask_token,
-                self.unk_token,
             ],
             **kwargs,
         )
@@ -106,7 +104,6 @@ class BertTokenizer(WordPieceTokenizer):
                 self.pad_token,
                 self.sep_token,
                 self.mask_token,
-                self.unk_token,
             ]:
                 if token not in self.vocabulary:
                     raise ValueError(

--- a/keras_nlp/models/bert/bert_tokenizer.py
+++ b/keras_nlp/models/bert/bert_tokenizer.py
@@ -119,8 +119,5 @@ class BertTokenizer(WordPieceTokenizer):
 
     def get_config(self):
         config = super().get_config()
-        # In the constructor, we pass the list of special tokens to the
-        # `special_tokens` arg of the superclass' constructor. Hence, we
-        # delete it from the config here.
-        del config["special_tokens"]
+        del config["special_tokens"] # Not configurable; set in __init__.
         return config

--- a/keras_nlp/models/bert/bert_tokenizer.py
+++ b/keras_nlp/models/bert/bert_tokenizer.py
@@ -82,10 +82,18 @@ class BertTokenizer(WordPieceTokenizer):
         self.sep_token = "[SEP]"
         self.pad_token = "[PAD]"
         self.mask_token = "[MASK]"
+        self.unk_token = "[UNK]"
         super().__init__(
             vocabulary=vocabulary,
             lowercase=lowercase,
-            **kwargs,
+            unsplittable_tokens=[
+                self.cls_token,
+                self.sep_token,
+                self.pad_token,
+                self.mask_token,
+                self.unk_token,
+            ],
+            ** kwargs,
         )
 
     def set_vocabulary(self, vocabulary):
@@ -93,7 +101,13 @@ class BertTokenizer(WordPieceTokenizer):
 
         if vocabulary is not None:
             # Check for necessary special tokens.
-            for token in [self.cls_token, self.pad_token, self.sep_token]:
+            for token in [
+                self.cls_token,
+                self.pad_token,
+                self.sep_token,
+                self.mask_token,
+                self.unk_token,
+            ]:
                 if token not in self.vocabulary:
                     raise ValueError(
                         f"Cannot find token `'{token}'` in the provided "
@@ -114,3 +128,11 @@ class BertTokenizer(WordPieceTokenizer):
     @classproperty
     def presets(cls):
         return copy.deepcopy({**backbone_presets, **classifier_presets})
+
+    def get_config(self):
+        config = super().get_config()
+        # In the constructor, we pass the list of special tokens to the
+        # `unsplittable_tokens` arg of the superclass' constructor. Hence, we
+        # delete it from the config here.
+        del config["unsplittable_tokens"]
+        return config

--- a/keras_nlp/models/bert/bert_tokenizer.py
+++ b/keras_nlp/models/bert/bert_tokenizer.py
@@ -119,5 +119,5 @@ class BertTokenizer(WordPieceTokenizer):
 
     def get_config(self):
         config = super().get_config()
-        del config["special_tokens"] # Not configurable; set in __init__.
+        del config["special_tokens"]  # Not configurable; set in __init__.
         return config

--- a/keras_nlp/models/bert/bert_tokenizer.py
+++ b/keras_nlp/models/bert/bert_tokenizer.py
@@ -85,7 +85,7 @@ class BertTokenizer(WordPieceTokenizer):
         super().__init__(
             vocabulary=vocabulary,
             lowercase=lowercase,
-            unsplittable_tokens=[
+            special_tokens=[
                 self.cls_token,
                 self.sep_token,
                 self.pad_token,
@@ -129,7 +129,7 @@ class BertTokenizer(WordPieceTokenizer):
     def get_config(self):
         config = super().get_config()
         # In the constructor, we pass the list of special tokens to the
-        # `unsplittable_tokens` arg of the superclass' constructor. Hence, we
+        # `special_tokens` arg of the superclass' constructor. Hence, we
         # delete it from the config here.
-        del config["unsplittable_tokens"]
+        del config["special_tokens"]
         return config

--- a/keras_nlp/models/bert/bert_tokenizer.py
+++ b/keras_nlp/models/bert/bert_tokenizer.py
@@ -93,7 +93,7 @@ class BertTokenizer(WordPieceTokenizer):
                 self.mask_token,
                 self.unk_token,
             ],
-            ** kwargs,
+            **kwargs,
         )
 
     def set_vocabulary(self, vocabulary):

--- a/keras_nlp/models/bert/bert_tokenizer_test.py
+++ b/keras_nlp/models/bert/bert_tokenizer_test.py
@@ -39,7 +39,7 @@ class BertTokenizerTest(TestCase):
         output = tokenizer(self.input_data)
         self.assertAllEqual(output, [[9, 10, 11, 12], [9, 12]])
 
-    def test_tokenizer_unsplittable_tokens(self):
+    def test_tokenizer_special_tokens(self):
         input_data = ["[CLS] THE [MASK] FOX [SEP] [PAD]"]
         tokenizer = BertTokenizer(**self.init_kwargs)
         output_data = tokenizer(input_data)

--- a/keras_nlp/models/bert/bert_tokenizer_test.py
+++ b/keras_nlp/models/bert/bert_tokenizer_test.py
@@ -41,7 +41,9 @@ class BertTokenizerTest(TestCase):
 
     def test_tokenizer_special_tokens(self):
         input_data = ["[CLS] THE [MASK] FOX [SEP] [PAD]"]
-        tokenizer = BertTokenizer(**self.init_kwargs)
+        tokenizer = BertTokenizer(
+            **self.init_kwargs, special_tokens_in_strings=True
+        )
         output_data = tokenizer(input_data)
         expected_output = [[2, 5, 4, 8, 3, 0]]
 

--- a/keras_nlp/models/bert/bert_tokenizer_test.py
+++ b/keras_nlp/models/bert/bert_tokenizer_test.py
@@ -39,6 +39,20 @@ class BertTokenizerTest(TestCase):
         output = tokenizer(self.input_data)
         self.assertAllEqual(output, [[9, 10, 11, 12], [9, 12]])
 
+    def test_tokenizer_unsplittable_tokens(self):
+        vocab = ["[PAD]", "[UNK]", "[CLS]", "[SEP]", "[MASK]"]
+        vocab += ["THE", "QUICK", "BROWN", "FOX"]
+        vocab += ["the", "quick", "brown", "fox"]
+        init_kwargs = {"vocabulary": self.vocab}
+        input_data = ["[CLS] THE [MASK] FOX [SEP] [PAD]"]
+        tokenizer = BertTokenizer(
+            **init_kwargs
+        )
+        output_data = tokenizer(input_data)
+        expected_output=[[2, 5, 4, 8, 3, 0]]
+
+        self.assertAllEqual(output_data, expected_output)
+
     def test_errors_missing_special_tokens(self):
         with self.assertRaises(ValueError):
             BertTokenizer(vocabulary=["a", "b", "c"])

--- a/keras_nlp/models/bert/bert_tokenizer_test.py
+++ b/keras_nlp/models/bert/bert_tokenizer_test.py
@@ -41,11 +41,9 @@ class BertTokenizerTest(TestCase):
 
     def test_tokenizer_unsplittable_tokens(self):
         input_data = ["[CLS] THE [MASK] FOX [SEP] [PAD]"]
-        tokenizer = BertTokenizer(
-            **self.init_kwargs
-        )
+        tokenizer = BertTokenizer(**self.init_kwargs)
         output_data = tokenizer(input_data)
-        expected_output=[[2, 5, 4, 8, 3, 0]]
+        expected_output = [[2, 5, 4, 8, 3, 0]]
 
         self.assertAllEqual(output_data, expected_output)
 

--- a/keras_nlp/models/bert/bert_tokenizer_test.py
+++ b/keras_nlp/models/bert/bert_tokenizer_test.py
@@ -40,13 +40,9 @@ class BertTokenizerTest(TestCase):
         self.assertAllEqual(output, [[9, 10, 11, 12], [9, 12]])
 
     def test_tokenizer_unsplittable_tokens(self):
-        vocab = ["[PAD]", "[UNK]", "[CLS]", "[SEP]", "[MASK]"]
-        vocab += ["THE", "QUICK", "BROWN", "FOX"]
-        vocab += ["the", "quick", "brown", "fox"]
-        init_kwargs = {"vocabulary": self.vocab}
         input_data = ["[CLS] THE [MASK] FOX [SEP] [PAD]"]
         tokenizer = BertTokenizer(
-            **init_kwargs
+            **self.init_kwargs
         )
         output_data = tokenizer(input_data)
         expected_output=[[2, 5, 4, 8, 3, 0]]

--- a/keras_nlp/models/distil_bert/distil_bert_tokenizer.py
+++ b/keras_nlp/models/distil_bert/distil_bert_tokenizer.py
@@ -80,7 +80,6 @@ class DistilBertTokenizer(WordPieceTokenizer):
         self.sep_token = "[SEP]"
         self.pad_token = "[PAD]"
         self.mask_token = "[MASK]"
-        self.unk_token = "[UNK]"
         super().__init__(
             vocabulary=vocabulary,
             lowercase=lowercase,
@@ -89,7 +88,6 @@ class DistilBertTokenizer(WordPieceTokenizer):
                 self.sep_token,
                 self.pad_token,
                 self.mask_token,
-                self.unk_token,
             ],
             **kwargs,
         )
@@ -104,7 +102,6 @@ class DistilBertTokenizer(WordPieceTokenizer):
                 self.pad_token,
                 self.sep_token,
                 self.mask_token,
-                self.unk_token,
             ]:
                 if token not in self.vocabulary:
                     raise ValueError(

--- a/keras_nlp/models/distil_bert/distil_bert_tokenizer.py
+++ b/keras_nlp/models/distil_bert/distil_bert_tokenizer.py
@@ -117,5 +117,5 @@ class DistilBertTokenizer(WordPieceTokenizer):
 
     def get_config(self):
         config = super().get_config()
-        del config["special_tokens"] # Not configurable; set in __init__.
+        del config["special_tokens"]  # Not configurable; set in __init__.
         return config

--- a/keras_nlp/models/distil_bert/distil_bert_tokenizer.py
+++ b/keras_nlp/models/distil_bert/distil_bert_tokenizer.py
@@ -46,6 +46,9 @@ class DistilBertTokenizer(WordPieceTokenizer):
             plain text file containing a single word piece token per line.
         lowercase: If `True`, the input text will be first lowered before
             tokenization.
+        special_tokens_in_strings: bool. A bool to indicate if the tokenizer
+            should expect special tokens in input strings that should be
+            tokenized and mapped correctly to their ids. Defaults to False.
 
     Examples:
 
@@ -74,6 +77,7 @@ class DistilBertTokenizer(WordPieceTokenizer):
         self,
         vocabulary,
         lowercase=False,
+        special_tokens_in_strings=False,
         **kwargs,
     ):
         self.cls_token = "[CLS]"
@@ -89,6 +93,7 @@ class DistilBertTokenizer(WordPieceTokenizer):
                 self.pad_token,
                 self.mask_token,
             ],
+            special_tokens_in_strings=special_tokens_in_strings,
             **kwargs,
         )
 

--- a/keras_nlp/models/distil_bert/distil_bert_tokenizer.py
+++ b/keras_nlp/models/distil_bert/distil_bert_tokenizer.py
@@ -91,7 +91,7 @@ class DistilBertTokenizer(WordPieceTokenizer):
                 self.mask_token,
                 self.unk_token,
             ],
-            ** kwargs,
+            **kwargs,
         )
 
     def set_vocabulary(self, vocabulary):

--- a/keras_nlp/models/distil_bert/distil_bert_tokenizer.py
+++ b/keras_nlp/models/distil_bert/distil_bert_tokenizer.py
@@ -83,7 +83,7 @@ class DistilBertTokenizer(WordPieceTokenizer):
         super().__init__(
             vocabulary=vocabulary,
             lowercase=lowercase,
-            unsplittable_tokens=[
+            special_tokens=[
                 self.cls_token,
                 self.sep_token,
                 self.pad_token,
@@ -127,7 +127,7 @@ class DistilBertTokenizer(WordPieceTokenizer):
     def get_config(self):
         config = super().get_config()
         # In the constructor, we pass the list of special tokens to the
-        # `unsplittable_tokens` arg of the superclass' constructor. Hence, we
+        # `special_tokens` arg of the superclass' constructor. Hence, we
         # delete it from the config here.
-        del config["unsplittable_tokens"]
+        del config["special_tokens"]
         return config

--- a/keras_nlp/models/distil_bert/distil_bert_tokenizer.py
+++ b/keras_nlp/models/distil_bert/distil_bert_tokenizer.py
@@ -80,10 +80,18 @@ class DistilBertTokenizer(WordPieceTokenizer):
         self.sep_token = "[SEP]"
         self.pad_token = "[PAD]"
         self.mask_token = "[MASK]"
+        self.unk_token = "[UNK]"
         super().__init__(
             vocabulary=vocabulary,
             lowercase=lowercase,
-            **kwargs,
+            unsplittable_tokens=[
+                self.cls_token,
+                self.sep_token,
+                self.pad_token,
+                self.mask_token,
+                self.unk_token,
+            ],
+            ** kwargs,
         )
 
     def set_vocabulary(self, vocabulary):
@@ -91,7 +99,13 @@ class DistilBertTokenizer(WordPieceTokenizer):
 
         if vocabulary is not None:
             # Check for necessary special tokens.
-            for token in [self.cls_token, self.pad_token, self.sep_token]:
+            for token in [
+                self.cls_token,
+                self.pad_token,
+                self.sep_token,
+                self.mask_token,
+                self.unk_token,
+            ]:
                 if token not in self.vocabulary:
                     raise ValueError(
                         f"Cannot find token `'{token}'` in the provided "
@@ -112,3 +126,11 @@ class DistilBertTokenizer(WordPieceTokenizer):
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
+
+    def get_config(self):
+        config = super().get_config()
+        # In the constructor, we pass the list of special tokens to the
+        # `unsplittable_tokens` arg of the superclass' constructor. Hence, we
+        # delete it from the config here.
+        del config["unsplittable_tokens"]
+        return config

--- a/keras_nlp/models/distil_bert/distil_bert_tokenizer.py
+++ b/keras_nlp/models/distil_bert/distil_bert_tokenizer.py
@@ -96,20 +96,6 @@ class DistilBertTokenizer(WordPieceTokenizer):
         super().set_vocabulary(vocabulary)
 
         if vocabulary is not None:
-            # Check for necessary special tokens.
-            for token in [
-                self.cls_token,
-                self.pad_token,
-                self.sep_token,
-                self.mask_token,
-            ]:
-                if token not in self.vocabulary:
-                    raise ValueError(
-                        f"Cannot find token `'{token}'` in the provided "
-                        f"`vocabulary`. Please provide `'{token}'` in your "
-                        "`vocabulary` or use a pretrained `vocabulary` name."
-                    )
-
             self.cls_token_id = self.token_to_id(self.cls_token)
             self.sep_token_id = self.token_to_id(self.sep_token)
             self.pad_token_id = self.token_to_id(self.pad_token)

--- a/keras_nlp/models/distil_bert/distil_bert_tokenizer.py
+++ b/keras_nlp/models/distil_bert/distil_bert_tokenizer.py
@@ -117,8 +117,5 @@ class DistilBertTokenizer(WordPieceTokenizer):
 
     def get_config(self):
         config = super().get_config()
-        # In the constructor, we pass the list of special tokens to the
-        # `special_tokens` arg of the superclass' constructor. Hence, we
-        # delete it from the config here.
-        del config["special_tokens"]
+        del config["special_tokens"] # Not configurable; set in __init__.
         return config

--- a/keras_nlp/models/distil_bert/distil_bert_tokenizer_test.py
+++ b/keras_nlp/models/distil_bert/distil_bert_tokenizer_test.py
@@ -43,11 +43,9 @@ class DistilBertTokenizerTest(TestCase):
 
     def test_tokenizer_unsplittable_tokens(self):
         input_data = ["[CLS] THE [MASK] FOX [SEP] [PAD]"]
-        tokenizer = DistilBertTokenizer(
-            **self.init_kwargs
-        )
+        tokenizer = DistilBertTokenizer(**self.init_kwargs)
         output_data = tokenizer(input_data)
-        expected_output=[[2, 5, 4, 8, 3, 0]]
+        expected_output = [[2, 5, 4, 8, 3, 0]]
 
         self.assertAllEqual(output_data, expected_output)
 

--- a/keras_nlp/models/distil_bert/distil_bert_tokenizer_test.py
+++ b/keras_nlp/models/distil_bert/distil_bert_tokenizer_test.py
@@ -41,7 +41,7 @@ class DistilBertTokenizerTest(TestCase):
         output = tokenizer(self.input_data)
         self.assertAllEqual(output, [[9, 10, 11, 12], [9, 12]])
 
-    def test_tokenizer_unsplittable_tokens(self):
+    def test_tokenizer_special_tokens(self):
         input_data = ["[CLS] THE [MASK] FOX [SEP] [PAD]"]
         tokenizer = DistilBertTokenizer(**self.init_kwargs)
         output_data = tokenizer(input_data)

--- a/keras_nlp/models/distil_bert/distil_bert_tokenizer_test.py
+++ b/keras_nlp/models/distil_bert/distil_bert_tokenizer_test.py
@@ -43,7 +43,9 @@ class DistilBertTokenizerTest(TestCase):
 
     def test_tokenizer_special_tokens(self):
         input_data = ["[CLS] THE [MASK] FOX [SEP] [PAD]"]
-        tokenizer = DistilBertTokenizer(**self.init_kwargs)
+        tokenizer = DistilBertTokenizer(
+            **self.init_kwargs, special_tokens_in_strings=True
+        )
         output_data = tokenizer(input_data)
         expected_output = [[2, 5, 4, 8, 3, 0]]
 

--- a/keras_nlp/models/distil_bert/distil_bert_tokenizer_test.py
+++ b/keras_nlp/models/distil_bert/distil_bert_tokenizer_test.py
@@ -41,6 +41,16 @@ class DistilBertTokenizerTest(TestCase):
         output = tokenizer(self.input_data)
         self.assertAllEqual(output, [[9, 10, 11, 12], [9, 12]])
 
+    def test_tokenizer_unsplittable_tokens(self):
+        input_data = ["[CLS] THE [MASK] FOX [SEP] [PAD]"]
+        tokenizer = DistilBertTokenizer(
+            **self.init_kwargs
+        )
+        output_data = tokenizer(input_data)
+        expected_output=[[2, 5, 4, 8, 3, 0]]
+
+        self.assertAllEqual(output_data, expected_output)
+
     def test_errors_missing_special_tokens(self):
         with self.assertRaises(ValueError):
             DistilBertTokenizer(vocabulary=["a", "b", "c"])

--- a/keras_nlp/models/electra/electra_tokenizer.py
+++ b/keras_nlp/models/electra/electra_tokenizer.py
@@ -83,20 +83,6 @@ class ElectraTokenizer(WordPieceTokenizer):
         super().set_vocabulary(vocabulary)
 
         if vocabulary is not None:
-            # Check for necessary special tokens.
-            for token in [
-                self.cls_token,
-                self.pad_token,
-                self.sep_token,
-                self.mask_token,
-            ]:
-                if token not in self.vocabulary:
-                    raise ValueError(
-                        f"Cannot find token `'{token}'` in the provided "
-                        f"`vocabulary`. Please provide `'{token}'` in your "
-                        "`vocabulary` or use a pretrained `vocabulary` name."
-                    )
-
             self.cls_token_id = self.token_to_id(self.cls_token)
             self.sep_token_id = self.token_to_id(self.sep_token)
             self.pad_token_id = self.token_to_id(self.pad_token)

--- a/keras_nlp/models/electra/electra_tokenizer.py
+++ b/keras_nlp/models/electra/electra_tokenizer.py
@@ -36,6 +36,9 @@ class ElectraTokenizer(WordPieceTokenizer):
             plain text file containing a single word piece token per line.
         lowercase: If `True`, the input text will be first lowered before
             tokenization.
+        special_tokens_in_strings: bool. A bool to indicate if the tokenizer
+            should expect special tokens in input strings that should be
+            tokenized and mapped correctly to their ids. Defaults to False.
 
     Examples:
     ```python
@@ -61,6 +64,7 @@ class ElectraTokenizer(WordPieceTokenizer):
         self,
         vocabulary,
         lowercase=False,
+        special_tokens_in_strings=False,
         **kwargs,
     ):
         self.cls_token = "[CLS]"
@@ -76,6 +80,7 @@ class ElectraTokenizer(WordPieceTokenizer):
                 self.pad_token,
                 self.mask_token,
             ],
+            special_tokens_in_strings=special_tokens_in_strings,
             **kwargs,
         )
 

--- a/keras_nlp/models/electra/electra_tokenizer.py
+++ b/keras_nlp/models/electra/electra_tokenizer.py
@@ -70,7 +70,7 @@ class ElectraTokenizer(WordPieceTokenizer):
         super().__init__(
             vocabulary=vocabulary,
             lowercase=lowercase,
-            unsplittable_tokens=[
+            special_tokens=[
                 self.cls_token,
                 self.sep_token,
                 self.pad_token,
@@ -110,7 +110,7 @@ class ElectraTokenizer(WordPieceTokenizer):
     def get_config(self):
         config = super().get_config()
         # In the constructor, we pass the list of special tokens to the
-        # `unsplittable_tokens` arg of the superclass' constructor. Hence, we
+        # `special_tokens` arg of the superclass' constructor. Hence, we
         # delete it from the config here.
-        del config["unsplittable_tokens"]
+        del config["special_tokens"]
         return config

--- a/keras_nlp/models/electra/electra_tokenizer.py
+++ b/keras_nlp/models/electra/electra_tokenizer.py
@@ -67,7 +67,6 @@ class ElectraTokenizer(WordPieceTokenizer):
         self.sep_token = "[SEP]"
         self.pad_token = "[PAD]"
         self.mask_token = "[MASK]"
-        self.unk_token = "[UNK]"
         super().__init__(
             vocabulary=vocabulary,
             lowercase=lowercase,
@@ -76,7 +75,6 @@ class ElectraTokenizer(WordPieceTokenizer):
                 self.sep_token,
                 self.pad_token,
                 self.mask_token,
-                self.unk_token,
             ],
             **kwargs,
         )
@@ -91,7 +89,6 @@ class ElectraTokenizer(WordPieceTokenizer):
                 self.pad_token,
                 self.sep_token,
                 self.mask_token,
-                self.unk_token,
             ]:
                 if token not in self.vocabulary:
                     raise ValueError(

--- a/keras_nlp/models/electra/electra_tokenizer.py
+++ b/keras_nlp/models/electra/electra_tokenizer.py
@@ -57,19 +57,42 @@ class ElectraTokenizer(WordPieceTokenizer):
     ```
     """
 
-    def __init__(self, vocabulary, lowercase=False, **kwargs):
+    def __init__(
+        self,
+        vocabulary,
+        lowercase=False,
+        **kwargs,
+    ):
         self.cls_token = "[CLS]"
         self.sep_token = "[SEP]"
         self.pad_token = "[PAD]"
         self.mask_token = "[MASK]"
-        super().__init__(vocabulary=vocabulary, lowercase=lowercase, **kwargs)
+        self.unk_token = "[UNK]"
+        super().__init__(
+            vocabulary=vocabulary,
+            lowercase=lowercase,
+            unsplittable_tokens=[
+                self.cls_token,
+                self.sep_token,
+                self.pad_token,
+                self.mask_token,
+                self.unk_token,
+            ],
+            ** kwargs,
+        )
 
     def set_vocabulary(self, vocabulary):
         super().set_vocabulary(vocabulary)
 
         if vocabulary is not None:
             # Check for necessary special tokens.
-            for token in [self.cls_token, self.pad_token, self.sep_token]:
+            for token in [
+                self.cls_token,
+                self.pad_token,
+                self.sep_token,
+                self.mask_token,
+                self.unk_token,
+            ]:
                 if token not in self.vocabulary:
                     raise ValueError(
                         f"Cannot find token `'{token}'` in the provided "
@@ -86,3 +109,11 @@ class ElectraTokenizer(WordPieceTokenizer):
             self.sep_token_id = None
             self.pad_token_id = None
             self.mask_token_id = None
+
+    def get_config(self):
+        config = super().get_config()
+        # In the constructor, we pass the list of special tokens to the
+        # `unsplittable_tokens` arg of the superclass' constructor. Hence, we
+        # delete it from the config here.
+        del config["unsplittable_tokens"]
+        return config

--- a/keras_nlp/models/electra/electra_tokenizer.py
+++ b/keras_nlp/models/electra/electra_tokenizer.py
@@ -100,5 +100,5 @@ class ElectraTokenizer(WordPieceTokenizer):
 
     def get_config(self):
         config = super().get_config()
-        del config["special_tokens"] # Not configurable; set in __init__.
+        del config["special_tokens"]  # Not configurable; set in __init__.
         return config

--- a/keras_nlp/models/electra/electra_tokenizer.py
+++ b/keras_nlp/models/electra/electra_tokenizer.py
@@ -100,8 +100,5 @@ class ElectraTokenizer(WordPieceTokenizer):
 
     def get_config(self):
         config = super().get_config()
-        # In the constructor, we pass the list of special tokens to the
-        # `special_tokens` arg of the superclass' constructor. Hence, we
-        # delete it from the config here.
-        del config["special_tokens"]
+        del config["special_tokens"] # Not configurable; set in __init__.
         return config

--- a/keras_nlp/models/electra/electra_tokenizer.py
+++ b/keras_nlp/models/electra/electra_tokenizer.py
@@ -78,7 +78,7 @@ class ElectraTokenizer(WordPieceTokenizer):
                 self.mask_token,
                 self.unk_token,
             ],
-            ** kwargs,
+            **kwargs,
         )
 
     def set_vocabulary(self, vocabulary):

--- a/keras_nlp/models/electra/electra_tokenizer_test.py
+++ b/keras_nlp/models/electra/electra_tokenizer_test.py
@@ -39,7 +39,9 @@ class ElectraTokenizerTest(TestCase):
 
     def test_tokenizer_special_tokens(self):
         input_data = ["[CLS] THE [MASK] FOX [SEP] [PAD]"]
-        tokenizer = ElectraTokenizer(**self.init_kwargs)
+        tokenizer = ElectraTokenizer(
+            **self.init_kwargs, special_tokens_in_strings=True
+        )
         output_data = tokenizer(input_data)
         expected_output = [[2, 5, 4, 8, 3, 0]]
 

--- a/keras_nlp/models/electra/electra_tokenizer_test.py
+++ b/keras_nlp/models/electra/electra_tokenizer_test.py
@@ -37,7 +37,7 @@ class ElectraTokenizerTest(TestCase):
         output = tokenizer(self.input_data)
         self.assertAllEqual(output, [[9, 10, 11, 12], [9, 12]])
 
-    def test_tokenizer_unsplittable_tokens(self):
+    def test_tokenizer_special_tokens(self):
         input_data = ["[CLS] THE [MASK] FOX [SEP] [PAD]"]
         tokenizer = ElectraTokenizer(**self.init_kwargs)
         output_data = tokenizer(input_data)

--- a/keras_nlp/models/electra/electra_tokenizer_test.py
+++ b/keras_nlp/models/electra/electra_tokenizer_test.py
@@ -37,6 +37,14 @@ class ElectraTokenizerTest(TestCase):
         output = tokenizer(self.input_data)
         self.assertAllEqual(output, [[9, 10, 11, 12], [9, 12]])
 
+    def test_tokenizer_unsplittable_tokens(self):
+        input_data = ["[CLS] THE [MASK] FOX [SEP] [PAD]"]
+        tokenizer = ElectraTokenizer(**self.init_kwargs)
+        output_data = tokenizer(input_data)
+        expected_output = [[2, 5, 4, 8, 3, 0]]
+
+        self.assertAllEqual(output_data, expected_output)
+
     def test_errors_missing_special_tokens(self):
         with self.assertRaises(ValueError):
             ElectraTokenizer(vocabulary=["a", "b", "c"])

--- a/keras_nlp/tokenizers/word_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer.py
@@ -423,6 +423,15 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
                 "the `oov_token` argument when creating the tokenizer."
             )
 
+        # Check for special tokens in the vocabulary
+        for token in self.special_tokens:
+            if token not in self.vocabulary:
+                raise ValueError(
+                    f"Cannot find token `'{token}'` in the provided "
+                    f"`vocabulary`. Please provide `'{token}'` in your "
+                    "`vocabulary` or use a pretrained `vocabulary` name."
+                )
+
         self._fast_word_piece = tf_text.FastWordpieceTokenizer(
             vocab=self.vocabulary,
             token_out_type=self.compute_dtype,

--- a/keras_nlp/tokenizers/word_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer.py
@@ -262,12 +262,12 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
         oov_token: str. The string value to substitute for
             an unknown token. It must be included in the vocab.
             Defaults to `"[UNK]"`.
-        special_tokens: list. A list of strings that will
-            never be split during the word-level splitting applied before the
-            word-peice encoding. This can be used to ensure special tokens map
-            to unique indices in the vocabulary, even if these special tokens
-            contain splittable characters such as punctuation. Special tokens
-            must still be included in `vocabulary`. Defaults to `None`.
+        special_tokens: list. A list of strings that will never be split during 
+            the word-level splitting applied before the word-peice encoding. 
+            This can be used to ensure special tokens map to unique indices in 
+            the vocabulary, even if these special tokens contain splittable 
+            characters such as punctuation. Special tokens must still be 
+            included in `vocabulary`. Defaults to `None`.
 
     References:
      - [Schuster and Nakajima, 2012](https://research.google/pubs/pub37842/)

--- a/keras_nlp/tokenizers/word_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer.py
@@ -262,11 +262,11 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
         oov_token: str. The string value to substitute for
             an unknown token. It must be included in the vocab.
             Defaults to `"[UNK]"`.
-        special_tokens: list. A list of strings that will never be split during 
-            the word-level splitting applied before the word-peice encoding. 
-            This can be used to ensure special tokens map to unique indices in 
-            the vocabulary, even if these special tokens contain splittable 
-            characters such as punctuation. Special tokens must still be 
+        special_tokens: list. A list of strings that will never be split during
+            the word-level splitting applied before the word-peice encoding.
+            This can be used to ensure special tokens map to unique indices in
+            the vocabulary, even if these special tokens contain splittable
+            characters such as punctuation. Special tokens must still be
             included in `vocabulary`. Defaults to `None`.
 
     References:

--- a/keras_nlp/tokenizers/word_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer.py
@@ -170,12 +170,12 @@ def pretokenize(
             split_pattern = WHITESPACE_AND_PUNCTUATION_REGEX
             keep_split_pattern = PUNCTUATION_REGEX
         if special_tokens_pattern is not None:
-            # the idea here is to pass the special tokens regex to the split 
+            # the idea here is to pass the special tokens regex to the split
             # function as delimiter regex pattern, so the input will be splitted
-            # by them, but also the function will treat each on of them as one 
-            # entity that shouldn't be splitted even if they have other 
-            # delimiter regex pattern inside them. then pass the special tokens 
-            # regex also as keep delimiter regex pattern, so they will 
+            # by them, but also the function will treat each on of them as one
+            # entity that shouldn't be splitted even if they have other
+            # delimiter regex pattern inside them. then pass the special tokens
+            # regex also as keep delimiter regex pattern, so they will
             # not be removed.
             split_pattern = r"|".join(
                 [

--- a/keras_nlp/tokenizers/word_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer.py
@@ -376,12 +376,12 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
             if self.unsplittable_tokens is not None:
                 # Get the regex of unsplittable tokens.
                 # the idea here is to pass the unsplittable tokens regex to the
-                # split function as delimiter regex pattern, so the input will be
-                # splitted by them, but also the function will treat each on of them
-                # as one entity that shouldn't be splitted even if they have other
-                # delimiter regex pattern inside them. then pass the unsplittable
-                # tokens regex also as keep delimiter regex pattern, so they will
-                # not be removed.
+                # split function as delimiter regex pattern, so the input will
+                # be splitted by them, but also the function will treat each on
+                # of them as one entity that shouldn't be splitted even if they
+                # have other delimiter regex pattern inside them. then pass the
+                # unsplittable tokens regex also as keep delimiter regex
+                # pattern, so they will not be removed.
                 self.unsplittable_tokens_regex = get_unsplittable_tokens_regex(
                     self.unsplittable_tokens
                 )

--- a/keras_nlp/tokenizers/word_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer.py
@@ -134,9 +134,9 @@ def pretokenize(
             characters (https://en.wikipedia.org/wiki/CJK_Unified_Ideographs_(Unicode_block)).
             Note that this is applicable only when `split` is `True`. Defaults
             to `True`.
-        unsplittable_tokens_pattern: str. A regex pattern that contain the 
-            unsplittable tokens that will never be split during the word-level 
-            splitting applied before the word-peice encoding. This can be used 
+        unsplittable_tokens_pattern: str. A regex pattern that contain the
+            unsplittable tokens that will never be split during the word-level
+            splitting applied before the word-peice encoding. This can be used
             to ensure special tokens map to unique indices in the vocabulary,
             even if these special tokens contain splittable characters such as
             punctuation.

--- a/keras_nlp/tokenizers/word_piece_tokenizer_test.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer_test.py
@@ -81,13 +81,13 @@ class WordPieceTokenizerTest(TestCase):
     def test_special_tokens(self):
         input_data = ["quick brown whale @MASK@"]
         vocab_data = ["@UNK@", "qu", "@@ick", "br", "@@own", "fox", "@MASK@"]
-        unsplittable_tokens = ["@UNK@", "@MASK@"]
+        special_tokens = ["@UNK@", "@MASK@"]
         tokenizer = WordPieceTokenizer(
             vocabulary=vocab_data,
             oov_token="@UNK@",
             suffix_indicator="@@",
             dtype="string",
-            unsplittable_tokens=unsplittable_tokens,
+            special_tokens=special_tokens,
         )
         call_output = tokenizer(input_data)
         self.assertAllEqual(
@@ -222,12 +222,12 @@ class WordPieceTokenizerTest(TestCase):
 
     def test_tokenize_special_tokens(self):
         input_data = ["[UNK] [MASK] [SEP] [PAD] [CLS] the quick brown fox."]
-        unsplittable_tokens = ["[UNK]", "[MASK]", "[SEP]", "[PAD]", "[CLS]"]
+        special_tokens = ["[UNK]", "[MASK]", "[SEP]", "[PAD]", "[CLS]"]
         vocab_data = ["the", "qu", "##ick", "br", "##own", "fox", "."]
-        vocab_data = [*unsplittable_tokens, *vocab_data]
+        vocab_data = [*special_tokens, *vocab_data]
 
         tokenizer = WordPieceTokenizer(
-            vocabulary=vocab_data, unsplittable_tokens=unsplittable_tokens
+            vocabulary=vocab_data, special_tokens=special_tokens
         )
         output = tokenizer(input_data)
         self.assertAllEqual(output, [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]])
@@ -242,23 +242,23 @@ class WordPieceTokenizerTest(TestCase):
         ]
         vocab_data = ["[UNK]", "[MASK]", "t o k e n"]
         tokenizer = WordPieceTokenizer(
-            vocabulary=vocab_data, split=False, unsplittable_tokens=["[MASK]"]
+            vocabulary=vocab_data, split=False, special_tokens=["[MASK]"]
         )
         output = tokenizer(input_data)
         self.assertAllEqual(output, [0, 0, 1, 2])
 
     def test_config_with_special_tokens(self):
         input_data = ["[UNK] [MASK] [SEP] [PAD] [CLS] the quick brown fox."]
-        unsplittable_tokens = ["[UNK]", "[MASK]", "[SEP]", "[PAD]", "[CLS]"]
+        special_tokens = ["[UNK]", "[MASK]", "[SEP]", "[PAD]", "[CLS]"]
         vocab_data = ["the", "qu", "##ick", "br", "##own", "fox", "."]
-        vocab_data = [*unsplittable_tokens, *vocab_data]
+        vocab_data = [*special_tokens, *vocab_data]
         original_tokenizer = WordPieceTokenizer(
             vocabulary=vocab_data,
             lowercase=False,
             oov_token="[UNK]",
             suffix_indicator="##",
             dtype="string",
-            unsplittable_tokens=unsplittable_tokens,
+            special_tokens=special_tokens,
         )
         cloned_tokenizer = WordPieceTokenizer.from_config(
             original_tokenizer.get_config()

--- a/keras_nlp/tokenizers/word_piece_tokenizer_test.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer_test.py
@@ -79,18 +79,20 @@ class WordPieceTokenizerTest(TestCase):
             tokenizer.id_to_token(-1)
 
     def test_special_tokens(self):
-        input_data = ["quick brown whale"]
-        vocab_data = ["@UNK@", "qu", "@@ick", "br", "@@own", "fox"]
+        input_data = ["quick brown whale @MASK@"]
+        vocab_data = ["@UNK@", "qu", "@@ick", "br", "@@own", "fox", "@MASK@"]
+        unsplittable_tokens = ["@UNK@", "@MASK@"]
         tokenizer = WordPieceTokenizer(
             vocabulary=vocab_data,
             oov_token="@UNK@",
             suffix_indicator="@@",
             dtype="string",
+            unsplittable_tokens=unsplittable_tokens,
         )
         call_output = tokenizer(input_data)
         self.assertAllEqual(
             call_output,
-            [["qu", "@@ick", "br", "@@own", "@UNK@"]],
+            [["qu", "@@ick", "br", "@@own", "@UNK@", "@MASK@"]],
         )
 
     def test_cjk_tokens(self):
@@ -217,3 +219,44 @@ class WordPieceTokenizerTest(TestCase):
 
         with self.assertRaises(ValueError):
             WordPieceTokenizer(vocabulary=vocab_data, oov_token=None)
+
+    def test_tokenize_special_tokens(self):
+        input_data = ["[UNK] [MASK] [SEP] [PAD] [CLS] the quick brown fox."]
+        unsplittable_tokens = ["[UNK]", "[MASK]", "[SEP]", "[PAD]", "[CLS]"]
+        vocab_data = ["the", "qu", "##ick", "br", "##own", "fox", "."]
+        vocab_data = [*unsplittable_tokens, *vocab_data]
+
+        tokenizer = WordPieceTokenizer(
+            vocabulary=vocab_data, unsplittable_tokens=unsplittable_tokens
+        )
+        output = tokenizer(input_data)
+        self.assertAllEqual(output, [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]])
+
+    def test_no_splitting_special_tokens(self):
+        input_data = ["[MASK]", "m i s s i n g", "t o k e n"]
+        vocab_data = ["[UNK]", "[MASK]", "t o k e n"]
+        tokenizer = WordPieceTokenizer(vocabulary=vocab_data, split=False)
+        output = tokenizer(input_data)
+        self.assertAllEqual(output, [1, 0, 2])
+
+    def test_config_with_special_tokens(self):
+        input_data = ["[UNK] [MASK] [SEP] [PAD] [CLS] the quick brown fox."]
+        unsplittable_tokens = ["[UNK]", "[MASK]", "[SEP]", "[PAD]", "[CLS]"]
+        vocab_data = ["the", "qu", "##ick", "br", "##own", "fox", "."]
+        vocab_data = [*unsplittable_tokens, *vocab_data]
+        original_tokenizer = WordPieceTokenizer(
+            vocabulary=vocab_data,
+            lowercase=False,
+            oov_token="[UNK]",
+            suffix_indicator="##",
+            dtype="string",
+            unsplittable_tokens=unsplittable_tokens,
+        )
+        cloned_tokenizer = WordPieceTokenizer.from_config(
+            original_tokenizer.get_config()
+        )
+        cloned_tokenizer.set_vocabulary(original_tokenizer.get_vocabulary())
+        self.assertAllEqual(
+            original_tokenizer(input_data),
+            cloned_tokenizer(input_data),
+        )

--- a/keras_nlp/tokenizers/word_piece_tokenizer_test.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer_test.py
@@ -234,12 +234,15 @@ class WordPieceTokenizerTest(TestCase):
 
     def test_no_splitting_with_special_tokens(self):
         # When `split` is `False`, no special tokens tokenization will be done.
-        input_data = ["[MASK] t o k e n", "m i s s i n g", "[MASK]", "t o k e n"]
+        input_data = [
+            "[MASK] t o k e n",
+            "m i s s i n g",
+            "[MASK]",
+            "t o k e n",
+        ]
         vocab_data = ["[UNK]", "[MASK]", "t o k e n"]
         tokenizer = WordPieceTokenizer(
-            vocabulary=vocab_data,
-            split=False,
-            unsplittable_tokens=["[MASK]"]
+            vocabulary=vocab_data, split=False, unsplittable_tokens=["[MASK]"]
         )
         output = tokenizer(input_data)
         self.assertAllEqual(output, [0, 0, 1, 2])

--- a/keras_nlp/tokenizers/word_piece_tokenizer_test.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer_test.py
@@ -232,12 +232,17 @@ class WordPieceTokenizerTest(TestCase):
         output = tokenizer(input_data)
         self.assertAllEqual(output, [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]])
 
-    def test_no_splitting_special_tokens(self):
-        input_data = ["[MASK]", "m i s s i n g", "t o k e n"]
+    def test_no_splitting_with_special_tokens(self):
+        # When `split` is `False`, no special tokens tokenization will be done.
+        input_data = ["[MASK] t o k e n", "m i s s i n g", "[MASK]", "t o k e n"]
         vocab_data = ["[UNK]", "[MASK]", "t o k e n"]
-        tokenizer = WordPieceTokenizer(vocabulary=vocab_data, split=False)
+        tokenizer = WordPieceTokenizer(
+            vocabulary=vocab_data,
+            split=False,
+            unsplittable_tokens=["[MASK]"]
+        )
         output = tokenizer(input_data)
-        self.assertAllEqual(output, [1, 0, 2])
+        self.assertAllEqual(output, [0, 0, 1, 2])
 
     def test_config_with_special_tokens(self):
         input_data = ["[UNK] [MASK] [SEP] [PAD] [CLS] the quick brown fox."]

--- a/keras_nlp/tokenizers/word_piece_tokenizer_test.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer_test.py
@@ -78,7 +78,7 @@ class WordPieceTokenizerTest(TestCase):
         with self.assertRaises(ValueError):
             tokenizer.id_to_token(-1)
 
-    def test_special_tokens(self):
+    def test_special_tokens_string_dtype(self):
         input_data = ["quick brown whale @MASK@"]
         vocab_data = ["@UNK@", "qu", "@@ick", "br", "@@own", "fox", "@MASK@"]
         special_tokens = ["@UNK@", "@MASK@"]
@@ -88,12 +88,27 @@ class WordPieceTokenizerTest(TestCase):
             suffix_indicator="@@",
             dtype="string",
             special_tokens=special_tokens,
+            special_tokens_in_strings=True,
         )
         call_output = tokenizer(input_data)
         self.assertAllEqual(
             call_output,
             [["qu", "@@ick", "br", "@@own", "@UNK@", "@MASK@"]],
         )
+
+    def test_special_tokens_int_dtype(self):
+        input_data = ["[UNK] [MASK] [SEP] [PAD] [CLS] the quick brown fox."]
+        special_tokens = ["[UNK]", "[MASK]", "[SEP]", "[PAD]", "[CLS]"]
+        vocab_data = ["the", "qu", "##ick", "br", "##own", "fox", "."]
+        vocab_data = [*special_tokens, *vocab_data]
+
+        tokenizer = WordPieceTokenizer(
+            vocabulary=vocab_data,
+            special_tokens=special_tokens,
+            special_tokens_in_strings=True,
+        )
+        output = tokenizer(input_data)
+        self.assertAllEqual(output, [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]])
 
     def test_cjk_tokens(self):
         input_data = ["ah半推zz"]
@@ -219,18 +234,6 @@ class WordPieceTokenizerTest(TestCase):
 
         with self.assertRaises(ValueError):
             WordPieceTokenizer(vocabulary=vocab_data, oov_token=None)
-
-    def test_tokenize_special_tokens(self):
-        input_data = ["[UNK] [MASK] [SEP] [PAD] [CLS] the quick brown fox."]
-        special_tokens = ["[UNK]", "[MASK]", "[SEP]", "[PAD]", "[CLS]"]
-        vocab_data = ["the", "qu", "##ick", "br", "##own", "fox", "."]
-        vocab_data = [*special_tokens, *vocab_data]
-
-        tokenizer = WordPieceTokenizer(
-            vocabulary=vocab_data, special_tokens=special_tokens
-        )
-        output = tokenizer(input_data)
-        self.assertAllEqual(output, [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]])
 
     def test_no_splitting_with_special_tokens(self):
         # When `split` is `False`, no special tokens tokenization will be done.


### PR DESCRIPTION
this PR enables the user to tokenize special tokens from text input as was suggested in keras-team/keras-nlp#1395.
The behaviour is the same as `ByteBairTokenizer` I think. also the models' tokenizers that use `WordPieceTokenizer` have the same behaviour as the models' tokenizers that use `BytePairTokenizer`.