### PR TITLE
[WIP] Fix jax `generate()` memory issues

### DIFF
--- a/keras_nlp/models/generative_task.py
+++ b/keras_nlp/models/generative_task.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
+
 import tensorflow as tf
 import tree
 
@@ -80,18 +82,30 @@ class GenerativeTask(Task):
 
             @jax.jit
             def compiled_generate_function(inputs, end_token_id, state):
-                # The only state we update during generation is sampler state,
-                # all weights are fixed and will not change.
-                mapping = zip(self._sampler.variables, state)
+                (
+                    sampler_variables,
+                    trainable_variables,
+                    non_trainable_variables,
+                ) = state
+                mapping = itertools.chain(
+                    zip(self._sampler.variables, sampler_variables),
+                    zip(self.trainable_variables, trainable_variables),
+                    zip(self.non_trainable_variables, non_trainable_variables),
+                )
 
                 with keras.StatelessScope(state_mapping=mapping) as scope:
                     outputs = self.generate_step(inputs, end_token_id)
 
                 # Get updated sampler variables from the stateless scope.
-                state = []
+                sampler_variables = []
                 for v in self._sampler.variables:
                     new_v = scope.get_current_value(v)
-                    state.append(new_v if new_v is not None else v)
+                    sampler_variables.append(new_v if new_v is not None else v)
+                state = (
+                    sampler_variables,
+                    trainable_variables,
+                    non_trainable_variables,
+                )
                 return outputs, state
 
             def wrapped_generate_function(
@@ -99,15 +113,20 @@ class GenerativeTask(Task):
                 end_token_id=None,
             ):
                 # Create an explicit tuple of all variable state.
+                state = (
+                    self._sampler.variables,
+                    self.trainable_variables,
+                    self.non_trainable_variables,
+                )
                 inputs = tree.map_structure(ops.convert_to_tensor, inputs)
                 outputs, state = compiled_generate_function(
                     inputs,
                     end_token_id,
-                    self._sampler.variables,
+                    state,
                 )
                 # Only assign the sampler variables (random seeds), as other
                 # model variables should never be updated in generation.
-                for ref_v, v in zip(self._sampler.variables, state):
+                for ref_v, v in zip(self._sampler.variables, state[0]):
                     ref_v.assign(v)
                 return outputs
 

--- a/keras_nlp/models/gpt2/gpt2_causal_lm.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm.py
@@ -295,6 +295,7 @@ class GPT2CausalLM(GenerativeTask):
             )
 
         token_ids = self._sampler(
+            self,
             next=next,
             prompt=token_ids,
             cache=cache,

--- a/keras_nlp/models/opt/opt_causal_lm.py
+++ b/keras_nlp/models/opt/opt_causal_lm.py
@@ -291,6 +291,7 @@ class OPTCausalLM(GenerativeTask):
             )
 
         token_ids = self._sampler(
+            self,
             next=next,
             prompt=token_ids,
             cache=cache,

--- a/keras_nlp/samplers/sampler.py
+++ b/keras_nlp/samplers/sampler.py
@@ -113,6 +113,7 @@ class Sampler:
 
     def __call__(
         self,
+        model,
         next,
         prompt,
         cache=None,
@@ -157,6 +158,7 @@ class Sampler:
             return (prompt, cache, index + 1)
 
         prompt, _, _ = self.run_loop(
+            model,
             cond,
             body,
             loop_vars=(prompt, cache, index),
@@ -175,32 +177,61 @@ class Sampler:
         probs = keras.activations.softmax(logits / self.temperature)
         return ops.cast(probs, logits_dtype)
 
-    def run_loop(self, cond, body, loop_vars=None, maximum_iterations=None):
+    def run_loop(
+        self, model, cond, body, loop_vars=None, maximum_iterations=None
+    ):
         """Run ops.while_loops with a `StatelessScope` if necessary."""
         if config.backend() == "jax":
+            import itertools
 
-            def stateless_cond(variables, *loop_vars):
+            def stateless_cond(state, *loop_vars):
                 return cond(*loop_vars)
 
-            def stateless_body(variables, *loop_vars):
-                mapping = zip(self.variables, variables)
+            def stateless_body(state, *loop_vars):
+                (
+                    sampler_variables,
+                    trainable_variables,
+                    non_trainable_variables,
+                ) = state
+                mapping = itertools.chain(
+                    zip(self.variables, sampler_variables),
+                    zip(model.trainable_variables, trainable_variables),
+                    zip(model.non_trainable_variables, non_trainable_variables),
+                )
                 with keras.StatelessScope(state_mapping=mapping) as scope:
                     loop_vars = body(*loop_vars)
 
-                variables = []
+                sampler_variables = []
                 for v in self.variables:
                     new_v = scope.get_current_value(v)
-                    variables.append(new_v if new_v is not None else v)
-                return variables, *loop_vars
+                    sampler_variables.append(new_v if new_v is not None else v)
+                state = (
+                    sampler_variables,
+                    trainable_variables,
+                    non_trainable_variables,
+                )
+                return state, *loop_vars
 
             variables = [ops.convert_to_tensor(v) for v in self.variables]
-            variables, *loop_vars = ops.while_loop(
+            trainable_variables = [
+                ops.convert_to_tensor(v) for v in model.trainable_variables
+            ]
+            non_trainable_variables = [
+                ops.convert_to_tensor(v) for v in model.non_trainable_variables
+            ]
+            state = (
+                variables,
+                trainable_variables,
+                non_trainable_variables,
+            )
+            state, *loop_vars = ops.while_loop(
                 cond=stateless_cond,
                 body=stateless_body,
-                loop_vars=(variables, *loop_vars),
+                loop_vars=(state, *loop_vars),
                 maximum_iterations=maximum_iterations,
             )
-            [ref_v.assign(v) for ref_v, v in zip(self.variables, variables)]
+            for ref_v, v in zip(self.variables, state[0]):
+                ref_v.assign(v)
         else:
             loop_vars = ops.while_loop(
                 cond=cond,


### PR DESCRIPTION
This is not how we should ship this code! But this demonstrates a fix for memory issues on the jax backend during generation.

Basically, we need to pass all model weights all the time (both to the top-level compiled function, and the inner while loop), to avoid the weights being attached as *static* state to the compiled function, which was copy all weights to the CPU during compilation (many times over in this case!).