### PR TITLE
Pin to `tensorflow-hub 0.16.0` to fix CI error

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -17,3 +17,6 @@ namex
 rouge-score
 sentencepiece
 tensorflow-datasets
+# TODO #1419: CI fails with `tensorflow-hub==0.16.1` installed from
+# `tensorflow-text-nightly` dependency. Remove once GH issue 1419 is closed.
+tensorflow-hub==0.16.0


### PR DESCRIPTION
Temporarily Fixes #1419 