### PR TITLE
Allow setting dtype per model

### DIFF
--- a/keras_nlp/layers/modeling/cached_multi_head_attention_test.py
+++ b/keras_nlp/layers/modeling/cached_multi_head_attention_test.py
@@ -39,7 +39,7 @@ class CachedMultiHeadAttentionTest(TestCase):
             expected_num_non_trainable_variables=1,
             # Keras 2 does not handle mixed precision correctly when not set
             # globally.
-            run_mixed_precision_check=config.keras_3(),
+            run_precision_checks=config.keras_3(),
         )
 
     def test_cache_call_is_correct(self):

--- a/keras_nlp/layers/modeling/masked_lm_head_test.py
+++ b/keras_nlp/layers/modeling/masked_lm_head_test.py
@@ -58,6 +58,7 @@ class MaskedLMHeadTest(TestCase):
             },
             expected_output_shape=(4, 5, 100),
             expected_num_trainable_weights=6,
+            run_precision_checks=False,
         )
 
     def test_value_error_when_neither_embedding_or_vocab_size_set(self):

--- a/keras_nlp/layers/modeling/sine_position_encoding_test.py
+++ b/keras_nlp/layers/modeling/sine_position_encoding_test.py
@@ -107,13 +107,3 @@ class SinePositionEncodingTest(TestCase):
                 sequential_output, (0, i, 0), parial_output
             )
         self.assertAllClose(full_output, sequential_output)
-
-    def test_float16_dtype(self):
-        pos_encoding = SinePositionEncoding(dtype="float16")
-        seq_length = 100
-        hidden_size = 32
-        inputs = keras.Input(shape=(seq_length, hidden_size))
-        outputs = pos_encoding(inputs)
-
-        # output dtype for this layer should be tf.float16.
-        self.assertEqual(outputs.dtype, "float16")

--- a/keras_nlp/layers/modeling/transformer_decoder_test.py
+++ b/keras_nlp/layers/modeling/transformer_decoder_test.py
@@ -49,7 +49,6 @@ class TransformerDecoderTest(TestCase):
         ("with_norm_first", True),
     )
     def test_layer_behaviors_with_cross_attention(self, normalize_first):
-        pass
         self.run_layer_test(
             cls=TransformerDecoder,
             init_kwargs={

--- a/keras_nlp/models/albert/albert_classifier.py
+++ b/keras_nlp/models/albert/albert_classifier.py
@@ -162,10 +162,12 @@ class AlbertClassifier(Task):
             num_classes,
             kernel_initializer=albert_kernel_initializer(),
             activation=activation,
+            dtype=backbone.dtype_policy,
             name="logits",
         )
         self.output_dropout = keras.layers.Dropout(
             dropout,
+            dtype=backbone.dtype_policy,
             name="output_dropout",
         )
 

--- a/keras_nlp/models/albert/albert_masked_lm.py
+++ b/keras_nlp/models/albert/albert_masked_lm.py
@@ -105,6 +105,7 @@ class AlbertMaskedLM(Task):
             token_embedding=backbone.token_embedding,
             intermediate_activation=gelu_approximate,
             kernel_initializer=albert_kernel_initializer(),
+            dtype=backbone.dtype_policy,
             name="mlm_head",
         )
 

--- a/keras_nlp/models/backbone.py
+++ b/keras_nlp/models/backbone.py
@@ -22,7 +22,7 @@ from keras_nlp.utils.python_utils import format_docstring
 
 @keras.saving.register_keras_serializable(package="keras_nlp")
 class Backbone(keras.Model):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, dtype=None, **kwargs):
         super().__init__(*args, **kwargs)
         self._functional_layer_ids = set(
             id(layer) for layer in self._flatten_layers()
@@ -74,8 +74,8 @@ class Backbone(keras.Model):
         self._token_embedding = value
 
     def get_config(self):
-        # Don't chain to super here. The default `get_config()` for functional
-        # models is nested and cannot be passed to our Backbone constructors.
+        # Don't chain to super here. `get_config()` for functional models is
+        # a nested layer config and cannot be passed to Backbone constructors.
         return {
             "name": self.name,
             "trainable": self.trainable,

--- a/keras_nlp/models/bart/bart_backbone.py
+++ b/keras_nlp/models/bart/bart_backbone.py
@@ -60,6 +60,10 @@ class BartBackbone(Backbone):
             can consume. If None, `max_sequence_length` uses the value from
             sequence length. This determines the variable shape for positional
             embeddings.
+        dtype: string or `keras.mixed_precision.DTypePolicy`. The dtype to use
+            for model computations and weights. Note that some computations,
+            such as softmax and layer normalization, will always be done at
+            float32 precision regardless of dtype.
 
     Examples:
     ```python
@@ -100,6 +104,7 @@ class BartBackbone(Backbone):
         intermediate_dim,
         dropout=0.1,
         max_sequence_length=1024,
+        dtype=None,
         **kwargs,
     ):
         # === Layers ===
@@ -107,24 +112,28 @@ class BartBackbone(Backbone):
             input_dim=vocabulary_size,
             output_dim=hidden_dim,
             embeddings_initializer=bart_kernel_initializer(),
+            dtype=dtype,
             name="token_embedding",
         )
         self.encoder_position_embedding = PositionEmbedding(
             initializer=bart_kernel_initializer(),
             sequence_length=max_sequence_length,
+            dtype=dtype,
             name="encoder_position_embedding",
         )
         self.encoder_embeddings_add = keras.layers.Add(
+            dtype=dtype,
             name="encoder_embeddings_add",
         )
         self.encoder_embeddings_layer_norm = keras.layers.LayerNormalization(
-            name="encoder_embeddings_layer_norm",
             axis=-1,
             epsilon=1e-5,
-            dtype="float32",
+            dtype=dtype,
+            name="encoder_embeddings_layer_norm",
         )
         self.encoder_embeddings_dropout = keras.layers.Dropout(
             dropout,
+            dtype=dtype,
             name="encoder_embeddings_dropout",
         )
         self.encoder_transformer_layers = []
@@ -136,25 +145,29 @@ class BartBackbone(Backbone):
                 dropout=dropout,
                 layer_norm_epsilon=1e-5,
                 kernel_initializer=bart_kernel_initializer(),
+                dtype=dtype,
                 name=f"transformer_encoder_layer_{i}",
             )
             self.encoder_transformer_layers.append(layer)
         self.decoder_position_embedding = PositionEmbedding(
             initializer=bart_kernel_initializer(),
             sequence_length=max_sequence_length,
+            dtype=dtype,
             name="decoder_position_embedding",
         )
         self.decoder_embeddings_add = keras.layers.Add(
+            dtype=dtype,
             name="decoder_embeddings_add",
         )
         self.decoder_embeddings_layer_norm = keras.layers.LayerNormalization(
-            name="decoder_embeddings_layer_norm",
             axis=-1,
             epsilon=1e-5,
-            dtype="float32",
+            dtype=dtype,
+            name="decoder_embeddings_layer_norm",
         )
         self.decoder_embeddings_dropout = keras.layers.Dropout(
             dropout,
+            dtype=dtype,
             name="decoder_embeddings_dropout",
         )
         self.decoder_transformer_layers = []
@@ -166,6 +179,7 @@ class BartBackbone(Backbone):
                 activation=keras.activations.gelu,
                 layer_norm_epsilon=1e-5,
                 kernel_initializer=bart_kernel_initializer(),
+                dtype=dtype,
                 name=f"transformer_decoder_layer_{i}",
             )
             self.decoder_transformer_layers.append(layer)

--- a/keras_nlp/models/bert/bert_backbone.py
+++ b/keras_nlp/models/bert/bert_backbone.py
@@ -61,6 +61,10 @@ class BertBackbone(Backbone):
             embeddings.
         num_segments: int. The number of types that the 'segment_ids' input can
             take.
+        dtype: string or `keras.mixed_precision.DTypePolicy`. The dtype to use
+            for model computations and weights. Note that some computations,
+            such as softmax and layer normalization, will always be done at
+            float32 precision regardless of dtype.
 
     Examples:
     ```python
@@ -97,6 +101,7 @@ class BertBackbone(Backbone):
         dropout=0.1,
         max_sequence_length=512,
         num_segments=2,
+        dtype=None,
         **kwargs,
     ):
         # === Layers ===
@@ -104,30 +109,35 @@ class BertBackbone(Backbone):
             input_dim=vocabulary_size,
             output_dim=hidden_dim,
             embeddings_initializer=bert_kernel_initializer(),
+            dtype=dtype,
             name="token_embedding",
         )
         self.position_embedding = PositionEmbedding(
             initializer=bert_kernel_initializer(),
             sequence_length=max_sequence_length,
+            dtype=dtype,
             name="position_embedding",
         )
         self.segment_embedding = keras.layers.Embedding(
             input_dim=num_segments,
             output_dim=hidden_dim,
             embeddings_initializer=bert_kernel_initializer(),
+            dtype=dtype,
             name="segment_embedding",
         )
         self.embeddings_add = keras.layers.Add(
+            dtype=dtype,
             name="embeddings_add",
         )
         self.embeddings_layer_norm = keras.layers.LayerNormalization(
-            name="embeddings_layer_norm",
             axis=-1,
             epsilon=1e-12,
-            dtype="float32",
+            dtype=dtype,
+            name="embeddings_layer_norm",
         )
         self.embeddings_dropout = keras.layers.Dropout(
             dropout,
+            dtype=dtype,
             name="embeddings_dropout",
         )
         self.transformer_layers = []
@@ -139,6 +149,7 @@ class BertBackbone(Backbone):
                 dropout=dropout,
                 layer_norm_epsilon=1e-12,
                 kernel_initializer=bert_kernel_initializer(),
+                dtype=dtype,
                 name=f"transformer_layer_{i}",
             )
             self.transformer_layers.append(layer)
@@ -146,6 +157,7 @@ class BertBackbone(Backbone):
             hidden_dim,
             kernel_initializer=bert_kernel_initializer(),
             activation="tanh",
+            dtype=dtype,
             name="pooled_dense",
         )
 

--- a/keras_nlp/models/bert/bert_classifier.py
+++ b/keras_nlp/models/bert/bert_classifier.py
@@ -145,12 +145,14 @@ class BertClassifier(Task):
         self.preprocessor = preprocessor
         self.output_dropout = keras.layers.Dropout(
             dropout,
+            dtype=backbone.dtype_policy,
             name="classifier_dropout",
         )
         self.output_dense = keras.layers.Dense(
             num_classes,
             kernel_initializer=bert_kernel_initializer(),
             activation=activation,
+            dtype=backbone.dtype_policy,
             name="logits",
         )
 

--- a/keras_nlp/models/bert/bert_masked_lm.py
+++ b/keras_nlp/models/bert/bert_masked_lm.py
@@ -109,6 +109,7 @@ class BertMaskedLM(Task):
             token_embedding=backbone.token_embedding,
             intermediate_activation="gelu",
             kernel_initializer=bert_kernel_initializer(),
+            dtype=backbone.dtype_policy,
             name="mlm_head",
         )
 

--- a/keras_nlp/models/bloom/bloom_attention.py
+++ b/keras_nlp/models/bloom/bloom_attention.py
@@ -75,7 +75,9 @@ class BloomAttention(keras.layers.Layer):
         )
         self._value_dense.build(inputs_shape)
 
-        self._alibi_layer = AlibiBias()
+        self._alibi_layer = AlibiBias(
+            dtype=self.dtype_policy,
+        )
 
         self._output_dense = keras.layers.Dense(
             hidden_dim,
@@ -87,10 +89,13 @@ class BloomAttention(keras.layers.Layer):
         self._output_dense.build(inputs_shape)
 
         self._dropout_layer = keras.layers.Dropout(
-            rate=self.dropout, dtype=self.dtype_policy, name="dropout"
+            rate=self.dropout,
+            dtype=self.dtype_policy,
+            name="dropout",
         )
         self._softmax = keras.layers.Softmax(
-            dtype=self.dtype_policy, name="softmax"
+            dtype="float32",
+            name="softmax",
         )
 
         self.built = True

--- a/keras_nlp/models/bloom/bloom_backbone.py
+++ b/keras_nlp/models/bloom/bloom_backbone.py
@@ -55,6 +55,10 @@ class BloomBackbone(Backbone):
             the transformer decoder.
         max_sequence_length: int. The maximum sequence length that this decoder
             can consume.
+        dtype: string or `keras.mixed_precision.DTypePolicy`. The dtype to use
+            for model computations and weights. Note that some computations,
+            such as softmax and layer normalization, will always be done at
+            float32 precision regardless of dtype.
 
     Examples:
     ```python
@@ -93,6 +97,7 @@ class BloomBackbone(Backbone):
         dropout=0.0,
         layer_norm_epsilon=1e-5,
         max_sequence_length=2048,
+        dtype=None,
         **kwargs,
     ):
         # === Layers ===
@@ -101,10 +106,12 @@ class BloomBackbone(Backbone):
             output_dim=hidden_dim,
             embeddings_initializer=_bloom_kernel_initializer(stddev=0.02),
             tie_weights=False,
+            dtype=dtype,
             name="token_embedding",
         )
         self.embeddings_layer_norm = keras.layers.LayerNormalization(
             epsilon=layer_norm_epsilon,
+            dtype=dtype,
             name="token_embedding_layernorm",
         )
         self.transformer_layers = []
@@ -114,11 +121,13 @@ class BloomBackbone(Backbone):
                 intermediate_dim=intermediate_dim,
                 dropout=dropout,
                 layer_norm_epsilon=layer_norm_epsilon,
+                dtype=dtype,
                 name=f"transformer_layer_{i}",
             )
             self.transformer_layers.append(layer)
         self.layer_norm = keras.layers.LayerNormalization(
             epsilon=layer_norm_epsilon,
+            dtype=dtype,
             name="final_layernorm",
         )
 

--- a/keras_nlp/models/deberta_v3/deberta_v3_backbone.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_backbone.py
@@ -67,6 +67,10 @@ class DebertaV3Backbone(Backbone):
             `max_sequence_length`.
         bucket_size: int. The size of the relative position buckets. Generally
             equal to `max_sequence_length // 2`.
+        dtype: string or `keras.mixed_precision.DTypePolicy`. The dtype to use
+            for model computations and weights. Note that some computations,
+            such as softmax and layer normalization, will always be done at
+            float32 precision regardless of dtype.
 
     Example:
     ```python
@@ -106,6 +110,7 @@ class DebertaV3Backbone(Backbone):
         dropout=0.1,
         max_sequence_length=512,
         bucket_size=256,
+        dtype=None,
         **kwargs,
     ):
         # === Layers ===
@@ -113,15 +118,17 @@ class DebertaV3Backbone(Backbone):
             input_dim=vocabulary_size,
             output_dim=hidden_dim,
             embeddings_initializer=deberta_kernel_initializer(),
+            dtype=dtype,
             name="token_embedding",
         )
         self.embeddings_layer_norm = keras.layers.LayerNormalization(
             epsilon=1e-7,
-            dtype="float32",
+            dtype=dtype,
             name="embeddings_layer_norm",
         )
         self.embeddings_dropout = keras.layers.Dropout(
             dropout,
+            dtype=dtype,
             name="embeddings_dropout",
         )
         self.relative_embeddings = RelativeEmbedding(
@@ -129,6 +136,7 @@ class DebertaV3Backbone(Backbone):
             bucket_size=bucket_size,
             layer_norm_epsilon=1e-7,
             kernel_initializer=deberta_kernel_initializer(),
+            dtype=dtype,
             name="rel_embedding",
         )
         self.transformer_layers = []
@@ -142,6 +150,7 @@ class DebertaV3Backbone(Backbone):
                 activation=keras.activations.gelu,
                 layer_norm_epsilon=1e-7,
                 kernel_initializer=deberta_kernel_initializer(),
+                dtype=dtype,
                 name=f"disentangled_attention_encoder_layer_{i}",
             )
             self.transformer_layers.append(layer)

--- a/keras_nlp/models/deberta_v3/deberta_v3_classifier.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_classifier.py
@@ -168,22 +168,26 @@ class DebertaV3Classifier(Task):
         self.preprocessor = preprocessor
         self.pooled_dropout = keras.layers.Dropout(
             dropout,
+            dtype=backbone.dtype_policy,
             name="pooled_dropout",
         )
         hidden_dim = hidden_dim or backbone.hidden_dim
         self.pooled_dense = keras.layers.Dense(
             hidden_dim,
             activation=keras.activations.gelu,
+            dtype=backbone.dtype_policy,
             name="pooled_dense",
         )
         self.output_dropout = keras.layers.Dropout(
             backbone.dropout,
+            dtype=backbone.dtype_policy,
             name="classifier_dropout",
         )
         self.output_dense = keras.layers.Dense(
             num_classes,
             kernel_initializer=deberta_kernel_initializer(),
             activation=activation,
+            dtype=backbone.dtype_policy,
             name="logits",
         )
 

--- a/keras_nlp/models/deberta_v3/deberta_v3_masked_lm.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_masked_lm.py
@@ -112,6 +112,7 @@ class DebertaV3MaskedLM(Task):
             token_embedding=backbone.token_embedding,
             intermediate_activation=keras.activations.gelu,
             kernel_initializer=deberta_kernel_initializer(),
+            dtype=backbone.dtype_policy,
             name="mlm_head",
         )
 

--- a/keras_nlp/models/deberta_v3/disentangled_attention_encoder.py
+++ b/keras_nlp/models/deberta_v3/disentangled_attention_encoder.py
@@ -99,22 +99,26 @@ class DisentangledAttentionEncoder(keras.layers.Layer):
             dropout=self.dropout,
             kernel_initializer=clone_initializer(self.kernel_initializer),
             bias_initializer=clone_initializer(self.bias_initializer),
+            dtype=self.dtype_policy,
             name="self_attention_layer",
         )
         self._self_attention_layer.build(inputs_shape)
         self._self_attention_layer_norm = keras.layers.LayerNormalization(
             epsilon=self.layer_norm_epsilon,
+            dtype=self.dtype_policy,
             name="self_attention_layer_norm",
         )
         self._self_attention_layer_norm.build(inputs_shape)
         self._self_attention_dropout = keras.layers.Dropout(
             rate=self.dropout,
+            dtype=self.dtype_policy,
             name="self_attention_dropout",
         )
 
         # Feedforward layers.
         self._feedforward_layer_norm = keras.layers.LayerNormalization(
             epsilon=self.layer_norm_epsilon,
+            dtype=self.dtype_policy,
             name="feedforward_layer_norm",
         )
         self._feedforward_layer_norm.build(inputs_shape)
@@ -123,6 +127,7 @@ class DisentangledAttentionEncoder(keras.layers.Layer):
             activation=self.activation,
             kernel_initializer=clone_initializer(self.kernel_initializer),
             bias_initializer=clone_initializer(self.bias_initializer),
+            dtype=self.dtype_policy,
             name="feedforward_intermediate_dense",
         )
         self._feedforward_intermediate_dense.build(inputs_shape)
@@ -130,6 +135,7 @@ class DisentangledAttentionEncoder(keras.layers.Layer):
             hidden_dim,
             kernel_initializer=clone_initializer(self.kernel_initializer),
             bias_initializer=clone_initializer(self.bias_initializer),
+            dtype=self.dtype_policy,
             name="feedforward_output_dense",
         )
         intermediate_shape = list(inputs_shape)
@@ -137,6 +143,7 @@ class DisentangledAttentionEncoder(keras.layers.Layer):
         self._feedforward_output_dense.build(tuple(intermediate_shape))
         self._feedforward_dropout = keras.layers.Dropout(
             rate=self.dropout,
+            dtype=self.dtype_policy,
             name="feedforward_dropout",
         )
         self.built = True

--- a/keras_nlp/models/deberta_v3/disentangled_self_attention.py
+++ b/keras_nlp/models/deberta_v3/disentangled_self_attention.py
@@ -86,6 +86,7 @@ class DisentangledSelfAttention(keras.layers.Layer):
             output_shape=(None, self.num_heads, self.attn_head_size),
             bias_axes="de",
             **self._get_common_kwargs_for_sublayer(use_bias=True),
+            dtype=self.dtype_policy,
             name="query",
         )
         self._query_dense.build(inputs_shape)
@@ -94,6 +95,7 @@ class DisentangledSelfAttention(keras.layers.Layer):
             output_shape=(None, self.num_heads, self.attn_head_size),
             bias_axes="de",
             **self._get_common_kwargs_for_sublayer(use_bias=True),
+            dtype=self.dtype_policy,
             name="key",
         )
         self._key_dense.build(inputs_shape)
@@ -102,17 +104,27 @@ class DisentangledSelfAttention(keras.layers.Layer):
             output_shape=(None, self.num_heads, self.attn_head_size),
             bias_axes="de",
             **self._get_common_kwargs_for_sublayer(use_bias=True),
+            dtype=self.dtype_policy,
             name="value",
         )
         self._value_dense.build(inputs_shape)
 
         # Relative attention.
-        self._position_dropout_layer = keras.layers.Dropout(self.dropout)
+        self._position_dropout_layer = keras.layers.Dropout(
+            self.dropout,
+            dtype=self.dtype_policy,
+        )
 
         self._attn_dropout_layer = keras.layers.Dropout(
-            self.dropout, name="attention_dropout"
+            self.dropout,
+            dtype=self.dtype_policy,
+            name="attention_dropout",
         )
-        self._softmax = keras.layers.Softmax(axis=-1, name="attention_softmax")
+        self._softmax = keras.layers.Softmax(
+            axis=-1,
+            dtype="float32",
+            name="attention_softmax",
+        )
 
         # Output.
         self._output_dense = keras.layers.EinsumDense(
@@ -120,6 +132,7 @@ class DisentangledSelfAttention(keras.layers.Layer):
             output_shape=(None, self.hidden_dim),
             bias_axes="d",
             **self._get_common_kwargs_for_sublayer(use_bias=True),
+            dtype=self.dtype_policy,
             name="attention_output",
         )
         self._output_dense.build(inputs_shape)

--- a/keras_nlp/models/deberta_v3/relative_embedding.py
+++ b/keras_nlp/models/deberta_v3/relative_embedding.py
@@ -57,7 +57,9 @@ class RelativeEmbedding(keras.layers.Layer):
             name="rel_embedding",
         )
         self.layer_norm = keras.layers.LayerNormalization(
-            epsilon=layer_norm_epsilon, name="rel_embeddings_layer_norm"
+            epsilon=layer_norm_epsilon,
+            dtype=self.dtype_policy,
+            name="rel_embeddings_layer_norm",
         )
 
     def call(self, inputs):

--- a/keras_nlp/models/distil_bert/distil_bert_backbone.py
+++ b/keras_nlp/models/distil_bert/distil_bert_backbone.py
@@ -62,6 +62,10 @@ class DistilBertBackbone(Backbone):
             can consume. If None, `max_sequence_length` uses the value from
             sequence length. This determines the variable shape for positional
             embeddings.
+        dtype: string or `keras.mixed_precision.DTypePolicy`. The dtype to use
+            for model computations and weights. Note that some computations,
+            such as softmax and layer normalization, will always be done at
+            float32 precision regardless of dtype.
 
     Examples:
     ```python
@@ -98,6 +102,7 @@ class DistilBertBackbone(Backbone):
         intermediate_dim,
         dropout=0.1,
         max_sequence_length=512,
+        dtype=None,
         **kwargs,
     ):
         # === Layers ===
@@ -106,6 +111,7 @@ class DistilBertBackbone(Backbone):
             sequence_length=max_sequence_length,
             embedding_dim=hidden_dim,
             embeddings_initializer=distilbert_kernel_initializer(),
+            dtype=dtype,
             name="token_and_position_embedding",
         )
         # Keep the token_embedding property for consistency across models.
@@ -113,11 +119,12 @@ class DistilBertBackbone(Backbone):
         self.embeddings_layer_norm = keras.layers.LayerNormalization(
             axis=-1,
             epsilon=1e-12,
-            dtype="float32",
+            dtype=dtype,
             name="embeddings_layer_norm",
         )
         self.embeddings_dropout = keras.layers.Dropout(
             dropout,
+            dtype=dtype,
             name="embeddings_dropout",
         )
         self.transformer_layers = []
@@ -129,6 +136,7 @@ class DistilBertBackbone(Backbone):
                 dropout=dropout,
                 layer_norm_epsilon=1e-12,
                 kernel_initializer=distilbert_kernel_initializer(),
+                dtype=dtype,
                 name=f"transformer_layer_{i}",
             )
             self.transformer_layers.append(layer)

--- a/keras_nlp/models/distil_bert/distil_bert_classifier.py
+++ b/keras_nlp/models/distil_bert/distil_bert_classifier.py
@@ -158,16 +158,19 @@ class DistilBertClassifier(Task):
             hidden_dim,
             activation="relu",
             kernel_initializer=distilbert_kernel_initializer(),
+            dtype=backbone.dtype_policy,
             name="pooled_dense",
         )
         self.output_dropout = keras.layers.Dropout(
             dropout,
+            dtype=backbone.dtype_policy,
             name="output_dropout",
         )
         self.output_dense = keras.layers.Dense(
             num_classes,
             kernel_initializer=distilbert_kernel_initializer(),
             activation=activation,
+            dtype=backbone.dtype_policy,
             name="logits",
         )
 

--- a/keras_nlp/models/distil_bert/distil_bert_masked_lm.py
+++ b/keras_nlp/models/distil_bert/distil_bert_masked_lm.py
@@ -112,6 +112,7 @@ class DistilBertMaskedLM(Task):
             token_embedding=backbone.token_embedding,
             intermediate_activation="gelu",
             kernel_initializer=distilbert_kernel_initializer(),
+            dtype=backbone.dtype_policy,
             name="mlm_head",
         )
 

--- a/keras_nlp/models/f_net/f_net_classifier.py
+++ b/keras_nlp/models/f_net/f_net_classifier.py
@@ -114,12 +114,14 @@ class FNetClassifier(Task):
         self.preprocessor = preprocessor
         self.output_dropout = keras.layers.Dropout(
             dropout,
+            dtype=backbone.dtype_policy,
             name="output_dropout",
         )
         self.output_dense = keras.layers.Dense(
             num_classes,
             kernel_initializer=f_net_kernel_initializer(),
             activation=activation,
+            dtype=backbone.dtype_policy,
             name="logits",
         )
 

--- a/keras_nlp/models/f_net/f_net_masked_lm.py
+++ b/keras_nlp/models/f_net/f_net_masked_lm.py
@@ -109,6 +109,7 @@ class FNetMaskedLM(Task):
             token_embedding=backbone.token_embedding,
             intermediate_activation="gelu",
             kernel_initializer=f_net_kernel_initializer(),
+            dtype=backbone.dtype_policy,
             name="mlm_head",
         )
 

--- a/keras_nlp/models/gpt_neo_x/gpt_neo_x_attention.py
+++ b/keras_nlp/models/gpt_neo_x/gpt_neo_x_attention.py
@@ -64,7 +64,8 @@ class GPTNeoXAttention(keras.layers.Layer):
         self.rotary_max_wavelength = rotary_max_wavelength
         self.rotary_dim = int(self.attn_head_size * rotary_percentage)
         self.rotary_embedding_layer = RotaryEmbedding(
-            max_wavelength=rotary_max_wavelength
+            max_wavelength=rotary_max_wavelength,
+            dtype=self.dtype_policy,
         )
         self.kernel_initializer = keras.initializers.get(kernel_initializer)
         self.bias_initializer = keras.initializers.get(bias_initializer)
@@ -76,15 +77,22 @@ class GPTNeoXAttention(keras.layers.Layer):
             output_shape=(None, self.num_heads, 3 * self.attn_head_size),
             bias_axes="de",
             **self._get_common_kwargs_for_sublayer(use_bias=True),
+            dtype=self.dtype_policy,
             name="query_key_value",
         )
         self._qkv_dense.build(input_shape)
 
         self._attn_dropout_layer = keras.layers.Dropout(
-            self.dropout, name="attention_dropout"
+            self.dropout,
+            dtype=self.dtype_policy,
+            name="attention_dropout",
         )
 
-        self._softmax = keras.layers.Softmax(axis=-1, name="attention_softmax")
+        self._softmax = keras.layers.Softmax(
+            axis=-1,
+            dtype="float32",
+            name="attention_softmax",
+        )
 
         # Output.
         self._output_dense = keras.layers.EinsumDense(
@@ -92,6 +100,7 @@ class GPTNeoXAttention(keras.layers.Layer):
             output_shape=(None, self.hidden_dim),
             bias_axes="d",
             **self._get_common_kwargs_for_sublayer(use_bias=True),
+            dtype=self.dtype_policy,
             name="attention_output",
         )
 

--- a/keras_nlp/models/gpt_neo_x/gpt_neo_x_decoder.py
+++ b/keras_nlp/models/gpt_neo_x/gpt_neo_x_decoder.py
@@ -99,18 +99,21 @@ class GPTNeoXDecoder(keras.layers.Layer):
             max_sequence_length=self.max_sequence_length,
             kernel_initializer=clone_initializer(self.kernel_initializer),
             bias_initializer=clone_initializer(self.bias_initializer),
+            dtype=self.dtype_policy,
             name="self_attention",
         )
         self._self_attention_layer.build(decoder_sequence_shape)
 
         self._self_attention_layer_norm = keras.layers.LayerNormalization(
             epsilon=self.layer_norm_epsilon,
+            dtype=self.dtype_policy,
             name="self_attention_layer_norm",
         )
         self._self_attention_layer_norm.build(decoder_sequence_shape)
 
         self._self_attention_dropout = keras.layers.Dropout(
             rate=self.dropout,
+            dtype=self.dtype_policy,
             name="self_attention_dropout",
         )
 
@@ -120,6 +123,7 @@ class GPTNeoXDecoder(keras.layers.Layer):
             activation=self.activation,
             kernel_initializer=clone_initializer(self.kernel_initializer),
             bias_initializer=clone_initializer(self.bias_initializer),
+            dtype=self.dtype_policy,
             name="feedforward_intermediate_dense",
         )
         self._feedforward_intermediate_dense.build(decoder_sequence_shape)
@@ -128,6 +132,7 @@ class GPTNeoXDecoder(keras.layers.Layer):
             hidden_dim,
             kernel_initializer=clone_initializer(self.kernel_initializer),
             bias_initializer=clone_initializer(self.bias_initializer),
+            dtype=self.dtype_policy,
             name="feedforward_output_dense",
         )
 
@@ -137,12 +142,14 @@ class GPTNeoXDecoder(keras.layers.Layer):
 
         self._feedforward_layer_norm = keras.layers.LayerNormalization(
             epsilon=self.layer_norm_epsilon,
+            dtype=self.dtype_policy,
             name="feedforward_layer_norm",
         )
         self._feedforward_layer_norm.build(decoder_sequence_shape)
 
         self._feedforward_dropout = keras.layers.Dropout(
             rate=self.dropout,
+            dtype=self.dtype_policy,
             name="feedforward_dropout",
         )
         self.built = True

--- a/keras_nlp/models/llama/llama_attention.py
+++ b/keras_nlp/models/llama/llama_attention.py
@@ -58,6 +58,7 @@ class LlamaAttention(keras.layers.Layer):
             equation="bqm,muh->bquh",
             output_shape=(None, self.num_query_heads, self.attn_head_size),
             kernel_initializer=clone_initializer(self.kernel_initializer),
+            dtype=self.dtype_policy,
             name="query",
         )
         self._query_dense.build(inputs_shape)
@@ -65,6 +66,7 @@ class LlamaAttention(keras.layers.Layer):
             equation="bkm,mvh->bkvh",
             output_shape=(None, self.num_key_value_heads, self.attn_head_size),
             kernel_initializer=clone_initializer(self.kernel_initializer),
+            dtype=self.dtype_policy,
             name="key",
         )
         self._key_dense.build(inputs_shape)
@@ -73,16 +75,22 @@ class LlamaAttention(keras.layers.Layer):
             equation="bkm,mvh->bkvh",
             output_shape=(None, self.num_key_value_heads, self.attn_head_size),
             kernel_initializer=clone_initializer(self.kernel_initializer),
+            dtype=self.dtype_policy,
             name="value",
         )
         self._value_dense.build(inputs_shape)
 
-        self._softmax = keras.layers.Softmax(axis=-1, name="attention_softmax")
+        self._softmax = keras.layers.Softmax(
+            axis=-1,
+            dtype="float32",
+            name="attention_softmax",
+        )
 
         self._output_dense = keras.layers.EinsumDense(
             equation="bqm,mh->bqh",
             output_shape=(None, self.hidden_dim),
             kernel_initializer=clone_initializer(self.kernel_initializer),
+            dtype=self.dtype_policy,
             name="attention_output",
         )
         self._output_dense.build(inputs_shape)
@@ -90,6 +98,7 @@ class LlamaAttention(keras.layers.Layer):
         self._rotary_embedding_layer = RotaryEmbedding(
             max_wavelength=self.rope_max_wavelength,
             scaling_factor=self.rope_scaling_factor,
+            dtype=self.dtype_policy,
         )
         self._rotary_embedding_layer.build(inputs_shape)
 

--- a/keras_nlp/models/llama/llama_attention.py
+++ b/keras_nlp/models/llama/llama_attention.py
@@ -182,10 +182,10 @@ class LlamaAttention(keras.layers.Layer):
         )
 
         attention_scores /= norm_factor
-
         attention_scores = self._masked_softmax(
             attention_scores, attention_mask
         )
+        attention_scores = ops.cast(attention_scores, self.compute_dtype)
         attention_output = ops.einsum(
             "acbe,aecd->abcd", attention_scores, value
         )

--- a/keras_nlp/models/llama/llama_decoder.py
+++ b/keras_nlp/models/llama/llama_decoder.py
@@ -64,11 +64,13 @@ class LlamaDecoder(keras.layers.Layer):
             max_sequence_length=self.max_sequence_length,
             rope_scaling_factor=self.rope_scaling_factor,
             kernel_initializer=clone_initializer(self.kernel_initializer),
+            dtype=self.dtype_policy,
         )
         self._self_attention_layer.build(decoder_sequence_shape)
 
         self._self_attention_layernorm = LlamaLayerNorm(
             epsilon=self.layer_norm_epsilon,
+            dtype=self.dtype_policy,
         )
         self._self_attention_layernorm.build(decoder_sequence_shape)
 
@@ -76,6 +78,7 @@ class LlamaDecoder(keras.layers.Layer):
         self._feedforward_intermediate_dense = keras.layers.Dense(
             self.intermediate_dim,
             kernel_initializer=clone_initializer(self.kernel_initializer),
+            dtype=self.dtype_policy,
         )
         self._feedforward_intermediate_dense.build(decoder_sequence_shape)
 
@@ -83,12 +86,14 @@ class LlamaDecoder(keras.layers.Layer):
             self.intermediate_dim,
             activation=self.activation,
             kernel_initializer=clone_initializer(self.kernel_initializer),
+            dtype=self.dtype_policy,
         )
         self._feedforward_gate_dense.build(decoder_sequence_shape)
 
         self._feedforward_output_dense = keras.layers.Dense(
             self.hidden_dim,
             kernel_initializer=clone_initializer(self.kernel_initializer),
+            dtype=self.dtype_policy,
         )
 
         intermediate_shape = list(decoder_sequence_shape)
@@ -97,6 +102,7 @@ class LlamaDecoder(keras.layers.Layer):
 
         self._feedforward_layernorm = LlamaLayerNorm(
             epsilon=self.layer_norm_epsilon,
+            dtype=self.dtype_policy,
         )
         self._feedforward_layernorm.build(decoder_sequence_shape)
 

--- a/keras_nlp/models/mistral/mistral_attention.py
+++ b/keras_nlp/models/mistral/mistral_attention.py
@@ -270,10 +270,10 @@ class CachedMistralAttention(keras.layers.Layer):
         norm_factor = ops.sqrt(ops.cast(self._head_dim, self.compute_dtype))
 
         attention_scores = attention_scores / norm_factor
-
         attention_scores = self._masked_softmax(
             attention_scores, attention_mask
         )
+        attention_scores = ops.cast(attention_scores, self.compute_dtype)
         attention_output = ops.einsum(
             self._combine_equation, attention_scores, value
         )

--- a/keras_nlp/models/mistral/mistral_attention.py
+++ b/keras_nlp/models/mistral/mistral_attention.py
@@ -69,7 +69,7 @@ class CachedMistralAttention(keras.layers.Layer):
             equation="bqm,muh->bquh",
             output_shape=(None, self._num_query_heads, self._head_dim),
             kernel_initializer=self._kernel_initializer,
-            dtype=self.compute_dtype,
+            dtype=self.dtype_policy,
             name="query",
         )
         self._query_dense.build(inputs_shape)
@@ -82,7 +82,7 @@ class CachedMistralAttention(keras.layers.Layer):
                 self._head_dim,
             ),
             kernel_initializer=self._kernel_initializer,
-            dtype=self.compute_dtype,
+            dtype=self.dtype_policy,
             name="key",
         )
         self._key_dense.build(inputs_shape)
@@ -95,22 +95,27 @@ class CachedMistralAttention(keras.layers.Layer):
                 self._head_dim,
             ),
             kernel_initializer=self._kernel_initializer,
-            dtype=self.compute_dtype,
+            dtype=self.dtype_policy,
             name="value",
         )
         self._value_dense.build(inputs_shape)
 
-        self._softmax = keras.layers.Softmax(axis=-1, name="attention_softmax")
+        self._softmax = keras.layers.Softmax(
+            axis=-1,
+            dtype="float32",
+            name="attention_softmax",
+        )
 
         self._dropout_layer = keras.layers.Dropout(
-            rate=self._dropout, dtype=self.compute_dtype
+            rate=self._dropout,
+            dtype=self.dtype_policy,
         )
 
         self._output_dense = keras.layers.EinsumDense(
             equation="bquh,uhm->bqm",
             output_shape=(None, self._hidden_dim),
             kernel_initializer=self._kernel_initializer,
-            dtype=self.compute_dtype,
+            dtype=self.dtype_policy,
             name="attention_output",
         )
         self._output_dense.build(
@@ -120,7 +125,7 @@ class CachedMistralAttention(keras.layers.Layer):
         self.rotary_embedding_layer = RotaryEmbedding(
             max_wavelength=self._rope_max_wavelength,
             scaling_factor=self._rope_scaling_factor,
-            dtype=self.compute_dtype,
+            dtype=self.dtype_policy,
         )
 
         self._dot_product_equation = "bquh,bkuh->buqk"

--- a/keras_nlp/models/mistral/mistral_backbone.py
+++ b/keras_nlp/models/mistral/mistral_backbone.py
@@ -64,7 +64,10 @@ class MistralBackbone(Backbone):
             layers in each transformer decoder. Only `sliding_window` number of tokens
             are saved in the cache and used to generate the next token.
             Defaults to `512`.
-        dtype (str, optional): The dtype policy for the mistral model.
+        dtype: string or `keras.mixed_precision.DTypePolicy`. The dtype to use
+            for model computations and weights. Note that some computations,
+            such as softmax and layer normalization, will always be done at
+            float32 precision regardless of dtype.
 
     Examples:
 
@@ -107,10 +110,10 @@ class MistralBackbone(Backbone):
         layer_norm_epsilon=1e-6,
         sliding_window=512,
         dropout=0,
+        dtype=None,
         **kwargs,
     ):
         # === Layers ===
-        dtype = kwargs.pop("dtype", keras.backend.floatx())
         self.token_embedding = ReversibleEmbedding(
             input_dim=vocabulary_size,
             output_dim=hidden_dim,

--- a/keras_nlp/models/mistral/mistral_layer_norm.py
+++ b/keras_nlp/models/mistral/mistral_layer_norm.py
@@ -32,7 +32,6 @@ class MistralLayerNormalization(keras.layers.Layer):
             trainable=True,
             shape=(self._dim,),
             initializer="ones",
-            dtype=self.compute_dtype,
         )
         self.built = True
 

--- a/keras_nlp/models/mistral/mistral_transformer_decoder.py
+++ b/keras_nlp/models/mistral/mistral_transformer_decoder.py
@@ -73,20 +73,20 @@ class MistralTransformerDecoder(keras.layers.Layer):
             sliding_window=self.sliding_window,
             kernel_initializer=clone_initializer(self.kernel_initializer),
             dropout=self.dropout,
-            dtype=self.compute_dtype,
+            dtype=self.dtype_policy,
             name="self_attention",
         )
         self._self_attention_layer.build(decoder_sequence_shape)
 
         self._self_attention_layernorm = MistralLayerNormalization(
             epsilon=self.layer_norm_epsilon,
+            dtype=self.dtype_policy,
             name="self_attention_layernorm",
-            dtype=self.compute_dtype,
         )
         self._self_attention_layernorm.build(decoder_sequence_shape)
         self._self_attention_dropout = keras.layers.Dropout(
             rate=self.dropout,
-            dtype=self.compute_dtype,
+            dtype=self.dtype_policy,
             name="self_attention_dropout",
         )
 
@@ -95,7 +95,7 @@ class MistralTransformerDecoder(keras.layers.Layer):
             self.intermediate_dim,
             kernel_initializer=clone_initializer(self.kernel_initializer),
             use_bias=False,
-            dtype=self.compute_dtype,
+            dtype=self.dtype_policy,
             name="feedforward_intermediate_dense",
         )
         self._feedforward_intermediate_dense.build(decoder_sequence_shape)
@@ -105,6 +105,7 @@ class MistralTransformerDecoder(keras.layers.Layer):
             activation=self.activation,
             kernel_initializer=clone_initializer(self.kernel_initializer),
             use_bias=False,
+            dtype=self.dtype_policy,
             name="feedforward_gate_dense",
         )
         self._feedforward_gate_dense.build(decoder_sequence_shape)
@@ -113,7 +114,7 @@ class MistralTransformerDecoder(keras.layers.Layer):
             self.hidden_dim,
             kernel_initializer=clone_initializer(self.kernel_initializer),
             use_bias=False,
-            dtype=self.compute_dtype,
+            dtype=self.dtype_policy,
             name="feedforward_output_dense",
         )
 
@@ -125,8 +126,8 @@ class MistralTransformerDecoder(keras.layers.Layer):
 
         self._feedforward_layernorm = MistralLayerNormalization(
             epsilon=self.layer_norm_epsilon,
+            dtype=self.dtype_policy,
             name="feedforward_layernorm",
-            dtype=self.compute_dtype,
         )
         self._feedforward_layernorm.build(decoder_sequence_shape)
 

--- a/keras_nlp/models/opt/opt_backbone.py
+++ b/keras_nlp/models/opt/opt_backbone.py
@@ -57,6 +57,10 @@ class OPTBackbone(Backbone):
             can consume. If `None`, `max_sequence_length` uses the value from
             sequence length. This determines the variable shape for positional
             embeddings.
+        dtype: string or `keras.mixed_precision.DTypePolicy`. The dtype to use
+            for model computations and weights. Note that some computations,
+            such as softmax and layer normalization, will always be done at
+            float32 precision regardless of dtype.
 
     Examples:
     ```python
@@ -91,6 +95,7 @@ class OPTBackbone(Backbone):
         intermediate_dim,
         dropout=0.1,
         max_sequence_length=2048,
+        dtype=None,
         **kwargs,
     ):
         # === Layers ===
@@ -99,6 +104,7 @@ class OPTBackbone(Backbone):
             sequence_length=max_sequence_length,
             embedding_dim=hidden_dim,
             embeddings_initializer=opt_kernel_initializer(),
+            dtype=dtype,
             name="embeddings",
         )
         self.token_embedding = self.embeddings.token_embedding
@@ -112,13 +118,14 @@ class OPTBackbone(Backbone):
                 layer_norm_epsilon=1e-5,
                 normalize_first=True,
                 kernel_initializer=opt_kernel_initializer(),
+                dtype=dtype,
                 name=f"transformer_layer_{i}",
             )
             self.transformer_layers.append(layer)
         self.layer_norm = keras.layers.LayerNormalization(
             axis=-1,
             epsilon=1e-5,
-            dtype="float32",
+            dtype=dtype,
             name="layer_norm",
         )
 

--- a/keras_nlp/models/roberta/roberta_backbone.py
+++ b/keras_nlp/models/roberta/roberta_backbone.py
@@ -61,6 +61,10 @@ class RobertaBackbone(Backbone):
             consume. The sequence length of the input must be less than
             `max_sequence_length` default value. This determines the variable
             shape for positional embeddings.
+        dtype: string or `keras.mixed_precision.DTypePolicy`. The dtype to use
+            for model computations and weights. Note that some computations,
+            such as softmax and layer normalization, will always be done at
+            float32 precision regardless of dtype.
 
     Examples:
     ```python
@@ -96,6 +100,7 @@ class RobertaBackbone(Backbone):
         intermediate_dim,
         dropout=0.1,
         max_sequence_length=512,
+        dtype=None,
         **kwargs,
     ):
         # === Layers ===
@@ -104,17 +109,19 @@ class RobertaBackbone(Backbone):
             sequence_length=max_sequence_length,
             embedding_dim=hidden_dim,
             embeddings_initializer=roberta_kernel_initializer(),
+            dtype=dtype,
             name="embeddings",
         )
         self.token_embedding = self.embeddings.token_embedding
         self.embeddings_layer_norm = keras.layers.LayerNormalization(
             axis=-1,
             epsilon=1e-5,  # Original paper uses this epsilon value
-            dtype="float32",
+            dtype=dtype,
             name="embeddings_layer_norm",
         )
         self.embeddings_dropout = keras.layers.Dropout(
             dropout,
+            dtype=dtype,
             name="embeddings_dropout",
         )
         self.transformer_layers = []
@@ -126,6 +133,7 @@ class RobertaBackbone(Backbone):
                 dropout=dropout,
                 layer_norm_epsilon=1e-5,
                 kernel_initializer=roberta_kernel_initializer(),
+                dtype=dtype,
                 name=f"transformer_layer_{i}",
             )
             self.transformer_layers.append(layer)

--- a/keras_nlp/models/roberta/roberta_classifier.py
+++ b/keras_nlp/models/roberta/roberta_classifier.py
@@ -149,22 +149,26 @@ class RobertaClassifier(Task):
         self.preprocessor = preprocessor
         self.pooled_dropout = keras.layers.Dropout(
             dropout,
+            dtype=backbone.dtype_policy,
             name="pooled_dropout",
         )
         hidden_dim = hidden_dim or backbone.hidden_dim
         self.pooled_dense = keras.layers.Dense(
             hidden_dim,
             activation="tanh",
+            dtype=backbone.dtype_policy,
             name="pooled_dense",
         )
         self.output_dropout = keras.layers.Dropout(
             dropout,
+            dtype=backbone.dtype_policy,
             name="output_dropout",
         )
         self.output_dense = keras.layers.Dense(
             num_classes,
             kernel_initializer=roberta_kernel_initializer(),
             activation=activation,
+            dtype=backbone.dtype_policy,
             name="logits",
         )
 

--- a/keras_nlp/models/roberta/roberta_masked_lm.py
+++ b/keras_nlp/models/roberta/roberta_masked_lm.py
@@ -111,6 +111,7 @@ class RobertaMaskedLM(Task):
             token_embedding=backbone.token_embedding,
             intermediate_activation="gelu",
             kernel_initializer=roberta_kernel_initializer(),
+            dtype=backbone.dtype_policy,
             name="mlm_head",
         )
 

--- a/keras_nlp/models/t5/t5_backbone.py
+++ b/keras_nlp/models/t5/t5_backbone.py
@@ -67,7 +67,11 @@ class T5Backbone(Backbone):
             layer normalization layers in the Transformer layers.
         tie_embedding_weights: boolean. If `True`, the weights of the token
             embedding and the weights projecting language model outputs from
-            `hidden_dim`
+            `hidden_dim`.
+        dtype: string or `keras.mixed_precision.DTypePolicy`. The dtype to use
+            for model computations and weights. Note that some computations,
+            such as softmax and layer normalization, will always be done at
+            float32 precision regardless of dtype.
     """
 
     def __init__(
@@ -83,6 +87,7 @@ class T5Backbone(Backbone):
         use_gated_activation=True,
         layer_norm_epsilon=1e-06,
         tie_embedding_weights=True,
+        dtype=None,
         **kwargs,
     ):
         # Token embedding layer. This layer is shared by encoder and decoder.
@@ -91,10 +96,12 @@ class T5Backbone(Backbone):
             output_dim=hidden_dim,
             tie_weights=tie_embedding_weights,
             embeddings_initializer=keras.initializers.TruncatedNormal(1.0),
+            dtype=dtype,
             name="token_embedding",
         )
         self.encoder_embedding_dropout = keras.layers.Dropout(
             dropout,
+            dtype=dtype,
             name="encoder_embedding_dropout",
         )
         self.encoder_transformer_layers = []
@@ -110,19 +117,23 @@ class T5Backbone(Backbone):
                 num_heads=num_heads,
                 use_gated_activation=use_gated_activation,
                 use_relative_attention_bias=bool(i == 0),
+                dtype=dtype,
                 name=f"transformer_encoder_layer_{i}",
             )
             self.encoder_transformer_layers.append(layer)
         self.encoder_layer_norm = T5LayerNorm(
             epsilon=layer_norm_epsilon,
+            dtype=dtype,
             name="encoder_output_layer_norm",
         )
         self.encoder_dropout = keras.layers.Dropout(
             dropout,
+            dtype=dtype,
             name="encoder_output_dropout",
         )
         self.decoder_embedding_dropout = keras.layers.Dropout(
             dropout,
+            dtype=dtype,
             name="decoder_embedding_dropout",
         )
         self.decoder_transformer_layers = []
@@ -138,15 +149,18 @@ class T5Backbone(Backbone):
                 num_heads=num_heads,
                 use_gated_activation=use_gated_activation,
                 use_relative_attention_bias=bool(i == 0),
+                dtype=dtype,
                 name=f"transformer_decoder_layer_{i}",
             )
             self.decoder_transformer_layers.append(layer)
         self.decoder_layer_norm = T5LayerNorm(
             epsilon=layer_norm_epsilon,
+            dtype=dtype,
             name="decoder_output_layer_norm",
         )
         self.decoder_dropout = keras.layers.Dropout(
             dropout,
+            dtype=dtype,
             name="decoder_output_dropout",
         )
 

--- a/keras_nlp/models/t5/t5_multi_head_attention.py
+++ b/keras_nlp/models/t5/t5_multi_head_attention.py
@@ -45,36 +45,43 @@ class T5MultiHeadAttention(keras.layers.Layer):
         self.query_projector = keras.layers.Dense(
             self.inner_dim,
             use_bias=False,
-            name="query_projector",
             kernel_initializer=keras.initializers.RandomNormal(
                 mean=0, stddev=(self.inner_dim * self.key_value_dim) ** -0.5
             ),
+            dtype=self.dtype_policy,
+            name="query_projector",
         )
         self.key_projector = keras.layers.Dense(
             self.inner_dim,
             use_bias=False,
-            name="key_projector",
             kernel_initializer=keras.initializers.RandomNormal(
                 mean=0, stddev=self.inner_dim**-0.5
             ),
+            dtype=self.dtype_policy,
+            name="key_projector",
         )
         self.value_projector = keras.layers.Dense(
             self.inner_dim,
             use_bias=False,
-            name="value_projector",
             kernel_initializer=keras.initializers.RandomNormal(
                 mean=0, stddev=self.inner_dim**-0.5
             ),
+            dtype=self.dtype_policy,
+            name="value_projector",
         )
         self.output_projector = keras.layers.Dense(
             self.hidden_dim,
             use_bias=False,
-            name="output_projector",
             kernel_initializer=keras.initializers.RandomNormal(
                 mean=0, stddev=self.inner_dim**-0.5
             ),
+            dtype=self.dtype_policy,
+            name="output_projector",
         )
-        self.dropout_layer = keras.layers.Dropout(dropout)
+        self.dropout_layer = keras.layers.Dropout(
+            dropout,
+            dtype=self.dtype_policy,
+        )
 
         if self.use_relative_attention_bias:
             self.relative_attention_bias = self.add_weight(
@@ -298,7 +305,7 @@ class T5MultiHeadAttention(keras.layers.Layer):
                 mask = (1.0 - ops.cast(mask, position_bias.dtype)) * -1e9
                 position_bias = position_bias + mask
 
-        scores += position_bias
+        scores += ops.cast(position_bias, scores.dtype)
         weights = ops.nn.softmax(
             scores, axis=-1
         )  # (batch_size, num_heads, query_length, key_length)

--- a/keras_nlp/models/t5/t5_transformer_layer.py
+++ b/keras_nlp/models/t5/t5_transformer_layer.py
@@ -47,10 +47,17 @@ class T5TransformerLayer(keras.layers.Layer):
             num_heads=num_heads,
             dropout=dropout,
             use_relative_attention_bias=use_relative_attention_bias,
+            dtype=self.dtype_policy,
             name="self_attention",
         )
-        self.self_attention_layer_norm = T5LayerNorm(layer_norm_epsilon)
-        self.self_attention_dropout = keras.layers.Dropout(dropout)
+        self.self_attention_layer_norm = T5LayerNorm(
+            layer_norm_epsilon,
+            dtype=self.dtype_policy,
+        )
+        self.self_attention_dropout = keras.layers.Dropout(
+            dropout,
+            dtype=self.dtype_policy,
+        )
 
         if self.is_decoder:
             self.cross_attention = T5MultiHeadAttention(
@@ -60,39 +67,55 @@ class T5TransformerLayer(keras.layers.Layer):
                 num_heads=num_heads,
                 dropout=dropout,
                 use_relative_attention_bias=False,
+                dtype=self.dtype_policy,
                 name="cross_attention",
             )
-            self.cross_attention_layer_norm = T5LayerNorm(layer_norm_epsilon)
-            self.cross_attention_dropout = keras.layers.Dropout(dropout)
+            self.cross_attention_layer_norm = T5LayerNorm(
+                layer_norm_epsilon,
+                dtype=self.dtype_policy,
+            )
+            self.cross_attention_dropout = keras.layers.Dropout(
+                dropout,
+                dtype=self.dtype_policy,
+            )
 
         self.input_projector = keras.layers.Dense(
             intermediate_dim,
             use_bias=False,
-            name="input_projector",
             activation=keras.activations.get(activation),
             kernel_initializer=keras.initializers.RandomNormal(
                 mean=0, stddev=hidden_dim**-0.5
             ),
+            dtype=self.dtype_policy,
+            name="input_projector",
         )
         if self.use_gated_activation:
             self.gate_projector = keras.layers.Dense(
                 intermediate_dim,
                 use_bias=False,
-                name="gate_projector",
                 kernel_initializer=keras.initializers.RandomNormal(
                     mean=0, stddev=hidden_dim**-0.5
                 ),
+                dtype=self.dtype_policy,
+                name="gate_projector",
             )
         self.output_projector = keras.layers.Dense(
             hidden_dim,
             use_bias=False,
-            name="output_projector",
             kernel_initializer=keras.initializers.RandomNormal(
                 mean=0, stddev=intermediate_dim**-0.5
             ),
+            dtype=self.dtype_policy,
+            name="output_projector",
         )
-        self.layer_norm = T5LayerNorm(epsilon=layer_norm_epsilon)
-        self.dropout_layer = keras.layers.Dropout(dropout)
+        self.layer_norm = T5LayerNorm(
+            epsilon=layer_norm_epsilon,
+            dtype=self.dtype_policy,
+        )
+        self.dropout_layer = keras.layers.Dropout(
+            dropout,
+            dtype=self.dtype_policy,
+        )
 
     def call(
         self,

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -220,9 +220,14 @@ class Task(PipelineModel):
 
         # Backbone case.
         if preset_cls == cls.backbone_cls:
+            # Forward dtype to the backbone.
+            config_overrides = {}
+            if "dtype" in kwargs:
+                config_overrides["dtype"] = kwargs.pop("dtype")
             backbone = load_from_preset(
                 preset,
                 load_weights=load_weights,
+                config_overrides=config_overrides,
             )
             if "preprocessor" in kwargs:
                 preprocessor = kwargs.pop("preprocessor")

--- a/keras_nlp/models/whisper/whisper_backbone.py
+++ b/keras_nlp/models/whisper/whisper_backbone.py
@@ -75,6 +75,10 @@ class WhisperBackbone(Backbone):
             positional embedding layer.
         max_decoder_sequence_length: int. The maximum sequence length that the
             text decoder can consume.
+        dtype: string or `keras.mixed_precision.DTypePolicy`. The dtype to use
+            for model computations and weights. Note that some computations,
+            such as softmax and layer normalization, will always be done at
+            float32 precision regardless of dtype.
 
     Examples:
 
@@ -112,6 +116,7 @@ class WhisperBackbone(Backbone):
         dropout=0.0,
         max_encoder_sequence_length=3000,
         max_decoder_sequence_length=448,
+        dtype=None,
         **kwargs,
     ):
         assert_tf_backend(self.__class__.__name__)
@@ -122,6 +127,7 @@ class WhisperBackbone(Backbone):
             kernel_size=3,
             strides=1,
             padding="same",
+            dtype=dtype,
             name="encoder_token_embedding_conv_layer_1",
         )
         self.encoder_conv_layer_2 = keras.layers.Conv1D(
@@ -129,22 +135,27 @@ class WhisperBackbone(Backbone):
             kernel_size=3,
             strides=2,
             padding="valid",
+            dtype=dtype,
             name="encoder_token_embedding_conv_layer_2",
         )
         self.encoder_padder = Padder(
+            dtype=dtype,
             name="encoder_padder",
         )
         self.encoder_position_embedding = PositionEmbedding(
             initializer=whisper_kernel_initializer(),
             sequence_length=max_encoder_sequence_length // 2,
+            dtype=dtype,
             name="encoder_position_embedding",
             trainable=False,
         )
         self.encoder_embeddings_add = keras.layers.Add(
+            dtype=dtype,
             name="encoder_embeddings_add",
         )
         self.encoder_embeddings_dropout = keras.layers.Dropout(
             dropout,
+            dtype=dtype,
             name="encoder_embeddings_dropout",
         )
         self.encoder_transformer_layers = []
@@ -157,25 +168,28 @@ class WhisperBackbone(Backbone):
                 dropout=dropout,
                 kernel_initializer=whisper_kernel_initializer(),
                 normalize_first=True,
+                dtype=dtype,
                 name=f"transformer_encoder_layer_{i}",
             )
             self.encoder_transformer_layers.append(layer)
         self.encoder_layer_norm = keras.layers.LayerNormalization(
-            name="encoder_layer_norm",
             axis=-1,
             epsilon=1e-5,
-            dtype="float32",
+            dtype=dtype,
+            name="encoder_layer_norm",
         )
         self.decoder_embeddings = TokenAndPositionEmbedding(
             vocabulary_size=vocabulary_size,
             sequence_length=max_decoder_sequence_length,
             embedding_dim=hidden_dim,
             embeddings_initializer=whisper_kernel_initializer(),
+            dtype=dtype,
             name="decoder_token_and_position_embedding",
         )
         self.token_embedding = self.decoder_embeddings.token_embedding
         self.decoder_embeddings_dropout = keras.layers.Dropout(
             dropout,
+            dtype=dtype,
             name="decoder_embeddings_dropout",
         )
         self.decoder_transformer_layers = []
@@ -188,14 +202,15 @@ class WhisperBackbone(Backbone):
                 layer_norm_epsilon=1e-5,
                 kernel_initializer=whisper_kernel_initializer(),
                 normalize_first=True,
+                dtype=dtype,
                 name=f"transformer_decoder_layer_{i}",
             )
             self.decoder_transformer_layers.append(layer)
         self.decoder_layer_norm = keras.layers.LayerNormalization(
-            name="decoder_layer_norm",
             axis=-1,
             epsilon=1e-5,
-            dtype="float32",
+            dtype=dtype,
+            name="decoder_layer_norm",
         )
 
         # === Functional Model ===

--- a/keras_nlp/models/whisper/whisper_backbone.py
+++ b/keras_nlp/models/whisper/whisper_backbone.py
@@ -237,7 +237,7 @@ class WhisperBackbone(Backbone):
         # For the second conv. layer, we cannot use `padding="same"` since
         # that corresponds to a padding size of 1.5 (since stride is 2). Hence,
         # we will manually pad the input.
-        embedded_features = Padder()(embedded_features)
+        embedded_features = self.encoder_padder(embedded_features)
         embedded_features = keras.activations.gelu(
             self.encoder_conv_layer_2(embedded_features),
             approximate=False,

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_backbone.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_backbone.py
@@ -52,6 +52,10 @@ class XLMRobertaBackbone(roberta_backbone.RobertaBackbone):
             consume. The sequence length of the input must be less than
             `max_sequence_length` default value. This determines the variable
             shape for positional embeddings.
+        dtype: string or `keras.mixed_precision.DTypePolicy`. The dtype to use
+            for model computations and weights. Note that some computations,
+            such as softmax and layer normalization, will always be done at
+            float32 precision regardless of dtype.
 
     Examples:
     ```python

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_classifier.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_classifier.py
@@ -162,22 +162,26 @@ class XLMRobertaClassifier(Task):
         self.preprocessor = preprocessor
         self.pooled_dropout = keras.layers.Dropout(
             dropout,
+            dtype=backbone.dtype_policy,
             name="pooled_dropout",
         )
         hidden_dim = hidden_dim or backbone.hidden_dim
         self.pooled_dense = keras.layers.Dense(
             hidden_dim,
             activation="tanh",
+            dtype=backbone.dtype_policy,
             name="pooled_dense",
         )
         self.output_dropout = keras.layers.Dropout(
             dropout,
+            dtype=backbone.dtype_policy,
             name="output_dropout",
         )
         self.output_dense = keras.layers.Dense(
             num_classes,
             kernel_initializer=roberta_kernel_initializer(),
             activation=activation,
+            dtype=backbone.dtype_policy,
             name="logits",
         )
 

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_masked_lm.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_masked_lm.py
@@ -114,6 +114,7 @@ class XLMRobertaMaskedLM(Task):
             token_embedding=backbone.token_embedding,
             intermediate_activation="gelu",
             kernel_initializer=roberta_kernel_initializer(),
+            dtype=backbone.dtype_policy,
             name="mlm_head",
         )
 

--- a/keras_nlp/models/xlnet/relative_attention.py
+++ b/keras_nlp/models/xlnet/relative_attention.py
@@ -154,6 +154,7 @@ class TwoStreamRelativeAttention(keras.layers.MultiHeadAttention):
                 output_rank - 1, [self._num_heads, self._key_dim]
             ),
             bias_axes=bias_axes if self._use_bias else None,
+            dtype=self.dtype_policy,
             name="query",
             **self._get_common_kwargs_for_sublayer(),
         )
@@ -168,6 +169,7 @@ class TwoStreamRelativeAttention(keras.layers.MultiHeadAttention):
                 output_rank - 1, [self._num_heads, self._key_dim]
             ),
             bias_axes=bias_axes if self._use_bias else None,
+            dtype=self.dtype_policy,
             name="key",
             **self._get_common_kwargs_for_sublayer(),
         )
@@ -182,6 +184,7 @@ class TwoStreamRelativeAttention(keras.layers.MultiHeadAttention):
                 output_rank - 1, [self._num_heads, self._value_dim]
             ),
             bias_axes=bias_axes if self._use_bias else None,
+            dtype=self.dtype_policy,
             name="value",
             **self._get_common_kwargs_for_sublayer(),
         )
@@ -197,6 +200,7 @@ class TwoStreamRelativeAttention(keras.layers.MultiHeadAttention):
                 output_rank - 1, [self._query_shape[-1]]
             ),
             bias_axes=None,
+            dtype=self.dtype_policy,
             name="attention_output",
             **self._get_common_kwargs_for_sublayer(),
         )
@@ -213,6 +217,7 @@ class TwoStreamRelativeAttention(keras.layers.MultiHeadAttention):
                 output_rank - 1, [self._num_heads, self._key_dim]
             ),
             bias_axes=None,
+            dtype=self.dtype_policy,
             name="encoding",
             **self._get_common_kwargs_for_sublayer(),
         )

--- a/keras_nlp/models/xlnet/xlnet_backbone.py
+++ b/keras_nlp/models/xlnet/xlnet_backbone.py
@@ -52,6 +52,10 @@ class XLNetBackbone(Backbone):
         bias_initializer: string or `keras.initializers` initializer,
             defaults to "zeros". The bias initializer for
             the dense and multiheaded relative attention layers.
+        dtype: string or `keras.mixed_precision.DTypePolicy`. The dtype to use
+            for model computations and weights. Note that some computations,
+            such as softmax and layer normalization, will always be done at
+            float32 precision regardless of dtype.
 
     Call arguments:
         token_ids: Indices of input sequence tokens in the vocabulary of shape
@@ -101,6 +105,7 @@ class XLNetBackbone(Backbone):
         activation="gelu",
         kernel_initializer_range=0.02,
         bias_initializer="zeros",
+        dtype=None,
         **kwargs,
     ):
         # === Layers ===
@@ -108,14 +113,17 @@ class XLNetBackbone(Backbone):
             vocabulary_size=vocabulary_size,
             hidden_dim=hidden_dim,
             dropout=dropout,
+            dtype=dtype,
             name="content_query_embedding",
         )
         self.attn_mask_layer = XLNetAttentionMaskLayer(
             hidden_dim=hidden_dim,
             kernel_initializer_range=kernel_initializer_range,
+            dtype=dtype,
             name="encoder_block_attn_mask_layer",
         )
         self.seg_mat_layer = XLNetSegmentMatrixLayer(
+            dtype=dtype,
             name="encoder_block_seg_mat_layer",
         )
         head_dim = hidden_dim // num_heads
@@ -131,11 +139,13 @@ class XLNetBackbone(Backbone):
                 layer_norm_epsilon=1e-12,
                 kernel_initializer_range=kernel_initializer_range,
                 bias_initializer=bias_initializer,
+                dtype=dtype,
                 name=f"xlnet_encoder_{i}",
             )
             self.transformer_layers.append(layer)
         self.dropout = keras.layers.Dropout(
             dropout,
+            dtype=dtype,
             name="dropout",
         )
 

--- a/keras_nlp/models/xlnet/xlnet_content_and_query_embedding.py
+++ b/keras_nlp/models/xlnet/xlnet_content_and_query_embedding.py
@@ -58,7 +58,8 @@ class ContentAndQueryEmbedding(keras.layers.Layer):
                     ops.shape(pos_emb)[0],
                     ops.shape(pos_emb)[1] * bsz,
                     ops.shape(pos_emb)[2],
-                ]
+                ],
+                dtype=self.compute_dtype,
             )
             * pos_emb
         )
@@ -67,12 +68,14 @@ class ContentAndQueryEmbedding(keras.layers.Layer):
 
     def relative_positional_encoding(self, qlen, klen, bsz=None, clamp_len=-1):
         """create relative positional encoding."""
-        freq_seq = ops.arange(0, self.hidden_dim, 2.0, dtype=self.compute_dtype)
+        freq_seq = ops.arange(0, self.hidden_dim, 2.0, dtype="float32")
+        freq_seq = ops.cast(freq_seq, self.compute_dtype)
         inv_freq = 1 / (10000 ** (freq_seq / self.hidden_dim))
 
         beg, end = klen, -qlen
 
-        fwd_pos_seq = ops.arange(beg, end, -1.0, dtype=self.compute_dtype)
+        fwd_pos_seq = ops.arange(beg, end, -1.0, dtype="float32")
+        fwd_pos_seq = ops.cast(fwd_pos_seq, self.compute_dtype)
         if clamp_len > 0:
             fwd_pos_seq = ops.clip(
                 fwd_pos_seq, x_min=-clamp_len, x_max=clamp_len

--- a/keras_nlp/models/xlnet/xlnet_content_and_query_embedding.py
+++ b/keras_nlp/models/xlnet/xlnet_content_and_query_embedding.py
@@ -85,11 +85,14 @@ class ContentAndQueryEmbedding(keras.layers.Layer):
         self.word_embed = keras.layers.Embedding(
             input_dim=self.vocabulary_size,
             output_dim=self.hidden_dim,
+            dtype=self.dtype_policy,
             name="word_embedding",
         )
         self.word_embed.build(input_shape)
-        self.dropout_layer = keras.layers.Dropout(self.dropout)
-
+        self.dropout_layer = keras.layers.Dropout(
+            self.dropout,
+            dtype=self.dtype_policy,
+        )
         super().build(input_shape)
 
     def call(

--- a/keras_nlp/models/xlnet/xlnet_encoder.py
+++ b/keras_nlp/models/xlnet/xlnet_encoder.py
@@ -94,25 +94,34 @@ class XLNetEncoder(keras.layers.Layer):
             key_dim=self.head_dim,
             kernel_initializer=self.kernel_initializer,
             bias_initializer=self.bias_initializer,
+            dtype=self.dtype_policy,
             name="rel_attn",
         )
 
         self.layer_norm = keras.layers.LayerNormalization(
-            epsilon=self.layer_norm_epsilon, name="layer_norm_rel_attn"
+            epsilon=self.layer_norm_epsilon,
+            dtype=self.dtype_policy,
+            name="layer_norm_rel_attn",
         )
         self.layer_norm.build(input_shape)
 
-        self.dropout_attn = keras.layers.Dropout(self.dropout)
+        self.dropout_attn = keras.layers.Dropout(
+            self.dropout,
+            dtype=self.dtype_policy,
+        )
 
         # Feed-Forward Part
         self.layer_norm_ff = keras.layers.LayerNormalization(
-            epsilon=self.layer_norm_epsilon, name="layer_norm_ff"
+            epsilon=self.layer_norm_epsilon,
+            dtype=self.dtype_policy,
+            name="layer_norm_ff",
         )
         self.layer_norm_ff.build(input_shape)
 
         self.feedforward_intermediate_dense = keras.layers.Dense(
             self.intermediate_dim,
             kernel_initializer=self.kernel_initializer,
+            dtype=self.dtype_policy,
             name="feedforward_intermediate_dense",
         )
         self.feedforward_intermediate_dense.build(input_shape)
@@ -120,6 +129,7 @@ class XLNetEncoder(keras.layers.Layer):
         self.feedforward_output_dense = keras.layers.Dense(
             self.hidden_dim,
             kernel_initializer=self.kernel_initializer,
+            dtype=self.dtype_policy,
             name="feedforward_output_dense",
         )
         self.feedforward_output_dense.build(
@@ -128,7 +138,10 @@ class XLNetEncoder(keras.layers.Layer):
             )
         )
 
-        self.dropout_ff = keras.layers.Dropout(self.dropout)
+        self.dropout_ff = keras.layers.Dropout(
+            self.dropout,
+            dtype=self.dtype_policy,
+        )
 
         self.activation_function_ff = keras.activations.get(self.activation)
 


### PR DESCRIPTION
This gives the following new syntax for setting dtype on a model.

```python
model = keras_nlp.models.BertBackbone.from_preset(
    "bert_base_en_uncased",
    dtype="bfloat16",
)

model = keras_nlp.models.BertBackbone(
    vocabulary_size=30552,
    num_layers=4,
    num_heads=4,
    hidden_dim=256,
    intermediate_dim=512,
    max_sequence_length=128,
    dtype="bfloat16",
)

classifier = keras_nlp.models.BertClassifier.from_preset(
    "bert_base_en_uncased",
    num_classes=4,
    dtype="bfloat16",
)
```