### PR TITLE
Add a settable property for sequence_length

### DIFF
--- a/keras_nlp/models/albert/albert_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/albert/albert_masked_lm_preprocessor_test.py
@@ -43,7 +43,7 @@ class AlbertMaskedLMPreprocessorTest(TestCase):
         self.input_data = ["the quick brown fox"]
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=AlbertMaskedLMPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/albert/albert_preprocessor.py
+++ b/keras_nlp/models/albert/albert_preprocessor.py
@@ -158,9 +158,9 @@ class AlbertPreprocessor(Preprocessor):
     ):
         super().__init__(**kwargs)
         self.tokenizer = tokenizer
+        self.packer = None
         self.truncate = truncate
         self.sequence_length = sequence_length
-        self.packer = None
 
     def build(self, input_shape):
         # Defer packer creation to `build()` so that we can be sure tokenizer
@@ -194,6 +194,17 @@ class AlbertPreprocessor(Preprocessor):
             "padding_mask": token_ids != self.tokenizer.pad_token_id,
         }
         return pack_x_y_sample_weight(x, y, sample_weight)
+
+    @property
+    def sequence_length(self):
+        """The padded length of model input sequences."""
+        return self._sequence_length
+
+    @sequence_length.setter
+    def sequence_length(self, value):
+        self._sequence_length = value
+        if self.packer is not None:
+            self.packer.sequence_length = value
 
     @classproperty
     def tokenizer_cls(cls):

--- a/keras_nlp/models/albert/albert_preprocessor_test.py
+++ b/keras_nlp/models/albert/albert_preprocessor_test.py
@@ -40,7 +40,7 @@ class AlbertPreprocessorTest(TestCase):
         )
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=AlbertPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/bart/bart_preprocessor.py
+++ b/keras_nlp/models/bart/bart_preprocessor.py
@@ -140,10 +140,10 @@ class BartPreprocessor(Preprocessor):
     ):
         super().__init__(**kwargs)
         self.tokenizer = tokenizer
-        self.encoder_sequence_length = encoder_sequence_length
-        self.decoder_sequence_length = decoder_sequence_length
         self.encoder_packer = None
         self.decoder_packer = None
+        self.encoder_sequence_length = encoder_sequence_length
+        self.decoder_sequence_length = decoder_sequence_length
 
     def build(self, input_shape):
         # Defer packer creation to `build()` so that we can be sure tokenizer
@@ -174,7 +174,17 @@ class BartPreprocessor(Preprocessor):
         )
         self.built = True
 
-    def call(self, x, y=None, sample_weight=None):
+    def call(
+        self,
+        x,
+        y=None,
+        sample_weight=None,
+        *,
+        encoder_sequence_length=None,
+        decoder_sequence_length=None,
+        # `sequence_length` is an alias for `decoder_sequence_length`
+        sequence_length=None,
+    ):
         if not (
             isinstance(x, dict)
             and all(k in x for k in ("encoder_text", "decoder_text"))
@@ -183,6 +193,12 @@ class BartPreprocessor(Preprocessor):
                 '`x` must be a dictionary, containing the keys `"encoder_text"`'
                 f' and `"decoder_text"`. Received x={x}.'
             )
+
+        if encoder_sequence_length is None:
+            encoder_sequence_length = self.encoder_sequence_length
+        decoder_sequence_length = decoder_sequence_length or sequence_length
+        if decoder_sequence_length is None:
+            decoder_sequence_length = self.decoder_sequence_length
 
         encoder_text = x["encoder_text"]
         decoder_text = x["decoder_text"]
@@ -199,12 +215,14 @@ class BartPreprocessor(Preprocessor):
 
         encoder_inputs = self.tokenizer(encoder_text[0])
         encoder_token_ids, encoder_padding_mask = self.encoder_packer(
-            encoder_inputs
+            encoder_inputs,
+            sequence_length=encoder_sequence_length,
         )
 
         decoder_inputs = self.tokenizer(decoder_text[0])
         decoder_token_ids, decoder_padding_mask = self.decoder_packer(
-            decoder_inputs
+            decoder_inputs,
+            sequence_length=decoder_sequence_length,
         )
 
         x = {
@@ -225,6 +243,37 @@ class BartPreprocessor(Preprocessor):
             }
         )
         return config
+
+    @property
+    def encoder_sequence_length(self):
+        """The padded length of encoder input sequences."""
+        return self._encoder_sequence_length
+
+    @encoder_sequence_length.setter
+    def encoder_sequence_length(self, value):
+        self._encoder_sequence_length = value
+        if self.encoder_packer is not None:
+            self.encoder_packer.sequence_length = value
+
+    @property
+    def decoder_sequence_length(self):
+        """The padded length of decoder input sequences."""
+        return self._decoder_sequence_length
+
+    @decoder_sequence_length.setter
+    def decoder_sequence_length(self, value):
+        self._decoder_sequence_length = value
+        if self.decoder_packer is not None:
+            self.decoder_packer.sequence_length = value
+
+    @property
+    def sequence_length(self):
+        """Alias for `decoder_sequence_length`."""
+        return self.decoder_sequence_length
+
+    @sequence_length.setter
+    def sequence_length(self, value):
+        self.decoder_sequence_length = value
 
     @classproperty
     def tokenizer_cls(cls):

--- a/keras_nlp/models/bart/bart_preprocessor_test.py
+++ b/keras_nlp/models/bart/bart_preprocessor_test.py
@@ -46,7 +46,7 @@ class BartPreprocessorTest(TestCase):
         )
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=BartPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,
@@ -60,6 +60,7 @@ class BartPreprocessorTest(TestCase):
                 [1],  # Pass through labels.
                 [1.0],  # Pass through sample_weights.
             ),
+            token_id_key="decoder_token_ids",
         )
 
     def test_error_multi_segment_input(self):

--- a/keras_nlp/models/bart/bart_seq_2_seq_lm_preprocessor_test.py
+++ b/keras_nlp/models/bart/bart_seq_2_seq_lm_preprocessor_test.py
@@ -45,7 +45,7 @@ class BartSeq2SeqLMPreprocessorTest(TestCase):
         )
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=BartSeq2SeqLMPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,
@@ -59,6 +59,7 @@ class BartSeq2SeqLMPreprocessorTest(TestCase):
                 [[0, 4, 5, 4, 7, 2, 1, 1]],
                 [[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0]],
             ),
+            token_id_key="decoder_token_ids",
         )
 
     def test_generate_preprocess(self):

--- a/keras_nlp/models/bert/bert_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/bert/bert_masked_lm_preprocessor_test.py
@@ -39,7 +39,7 @@ class BertMaskedLMPreprocessorTest(TestCase):
         self.input_data = ["the quick brown fox"]
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=BertMaskedLMPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/bert/bert_preprocessor.py
+++ b/keras_nlp/models/bert/bert_preprocessor.py
@@ -139,9 +139,9 @@ class BertPreprocessor(Preprocessor):
     ):
         super().__init__(**kwargs)
         self.tokenizer = tokenizer
+        self.packer = None
         self.sequence_length = sequence_length
         self.truncate = truncate
-        self.packer = None
 
     def build(self, input_shape):
         # Defer packer creation to `build()` so that we can be sure tokenizer
@@ -175,6 +175,17 @@ class BertPreprocessor(Preprocessor):
             }
         )
         return config
+
+    @property
+    def sequence_length(self):
+        """The padded length of model input sequences."""
+        return self._sequence_length
+
+    @sequence_length.setter
+    def sequence_length(self, value):
+        self._sequence_length = value
+        if self.packer is not None:
+            self.packer.sequence_length = value
 
     @classproperty
     def tokenizer_cls(cls):

--- a/keras_nlp/models/bert/bert_preprocessor_test.py
+++ b/keras_nlp/models/bert/bert_preprocessor_test.py
@@ -36,7 +36,7 @@ class BertPreprocessorTest(TestCase):
         )
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=BertPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/bloom/bloom_causal_lm_preprocessor_test.py
+++ b/keras_nlp/models/bloom/bloom_causal_lm_preprocessor_test.py
@@ -40,7 +40,7 @@ class BloomCausalLMPreprocessorTest(TestCase):
         self.input_data = ["airplane at airport"]
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=BloomCausalLMPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/bloom/bloom_preprocessor.py
+++ b/keras_nlp/models/bloom/bloom_preprocessor.py
@@ -116,8 +116,8 @@ class BloomPreprocessor(Preprocessor):
         **kwargs,
     ):
         super().__init__(**kwargs)
-
         self.tokenizer = tokenizer
+        self.packer = None
         self.sequence_length = sequence_length
         self.add_start_token = add_start_token
         self.add_end_token = add_end_token
@@ -172,6 +172,17 @@ class BloomPreprocessor(Preprocessor):
             }
         )
         return config
+
+    @property
+    def sequence_length(self):
+        """The padded length of model input sequences."""
+        return self._sequence_length
+
+    @sequence_length.setter
+    def sequence_length(self, value):
+        self._sequence_length = value
+        if self.packer is not None:
+            self.packer.sequence_length = value
 
     @classproperty
     def presets(cls):

--- a/keras_nlp/models/bloom/bloom_preprocessor_test.py
+++ b/keras_nlp/models/bloom/bloom_preprocessor_test.py
@@ -38,7 +38,7 @@ class BloomPreprocessorTest(TestCase):
         self.input_data = ["airplane at airport"]
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=BloomPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/deberta_v3/deberta_v3_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_masked_lm_preprocessor_test.py
@@ -43,7 +43,7 @@ class DebertaV3MaskedLMPreprocessorTest(TestCase):
         self.input_data = ["the quick brown fox"]
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=DebertaV3MaskedLMPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/deberta_v3/deberta_v3_preprocessor.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_preprocessor.py
@@ -156,9 +156,9 @@ class DebertaV3Preprocessor(Preprocessor):
     ):
         super().__init__(**kwargs)
         self.tokenizer = tokenizer
+        self.packer = None
         self.truncate = truncate
         self.sequence_length = sequence_length
-        self.packer = None
 
     def build(self, input_shape):
         # Defer packer creation to `build()` so that we can be sure tokenizer
@@ -191,6 +191,17 @@ class DebertaV3Preprocessor(Preprocessor):
             "padding_mask": token_ids != self.tokenizer.pad_token_id,
         }
         return pack_x_y_sample_weight(x, y, sample_weight)
+
+    @property
+    def sequence_length(self):
+        """The padded length of model input sequences."""
+        return self._sequence_length
+
+    @sequence_length.setter
+    def sequence_length(self, value):
+        self._sequence_length = value
+        if self.packer is not None:
+            self.packer.sequence_length = value
 
     @classproperty
     def tokenizer_cls(cls):

--- a/keras_nlp/models/deberta_v3/deberta_v3_preprocessor_test.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_preprocessor_test.py
@@ -42,7 +42,7 @@ class DebertaV3PreprocessorTest(TestCase):
         )
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=DebertaV3Preprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/distil_bert/distil_bert_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/distil_bert/distil_bert_masked_lm_preprocessor_test.py
@@ -41,7 +41,7 @@ class DistilBertMaskedLMPreprocessorTest(TestCase):
         self.input_data = ["the quick brown fox"]
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=DistilBertMaskedLMPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/distil_bert/distil_bert_preprocessor.py
+++ b/keras_nlp/models/distil_bert/distil_bert_preprocessor.py
@@ -127,6 +127,7 @@ class DistilBertPreprocessor(Preprocessor):
     ):
         super().__init__(**kwargs)
         self.tokenizer = tokenizer
+        self.packer = None
         self.sequence_length = sequence_length
         self.truncate = truncate
 
@@ -161,6 +162,17 @@ class DistilBertPreprocessor(Preprocessor):
             }
         )
         return config
+
+    @property
+    def sequence_length(self):
+        """The padded length of model input sequences."""
+        return self._sequence_length
+
+    @sequence_length.setter
+    def sequence_length(self, value):
+        self._sequence_length = value
+        if self.packer is not None:
+            self.packer.sequence_length = value
 
     @classproperty
     def tokenizer_cls(cls):

--- a/keras_nlp/models/distil_bert/distil_bert_preprocessor_test.py
+++ b/keras_nlp/models/distil_bert/distil_bert_preprocessor_test.py
@@ -40,7 +40,7 @@ class DistilBertPreprocessorTest(TestCase):
         )
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=DistilBertPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/f_net/f_net_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/f_net/f_net_masked_lm_preprocessor_test.py
@@ -41,7 +41,7 @@ class FNetMaskedLMPreprocessorTest(TestCase):
         self.input_data = ["the quick brown fox"]
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=FNetMaskedLMPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/f_net/f_net_preprocessor.py
+++ b/keras_nlp/models/f_net/f_net_preprocessor.py
@@ -129,9 +129,9 @@ class FNetPreprocessor(Preprocessor):
     ):
         super().__init__(**kwargs)
         self.tokenizer = tokenizer
+        self.packer = None
         self.truncate = truncate
         self.sequence_length = sequence_length
-        self.packer = None
 
     def build(self, input_shape):
         # Defer packer creation to `build()` so that we can be sure tokenizer
@@ -164,6 +164,17 @@ class FNetPreprocessor(Preprocessor):
             "segment_ids": segment_ids,
         }
         return pack_x_y_sample_weight(x, y, sample_weight)
+
+    @property
+    def sequence_length(self):
+        """The padded length of model input sequences."""
+        return self._sequence_length
+
+    @sequence_length.setter
+    def sequence_length(self, value):
+        self._sequence_length = value
+        if self.packer is not None:
+            self.packer.sequence_length = value
 
     @classproperty
     def tokenizer_cls(cls):

--- a/keras_nlp/models/f_net/f_net_preprocessor_test.py
+++ b/keras_nlp/models/f_net/f_net_preprocessor_test.py
@@ -38,7 +38,7 @@ class FNetPreprocessorTest(TestCase):
         )
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=FNetPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/gpt2/gpt2_causal_lm_preprocessor_test.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm_preprocessor_test.py
@@ -40,7 +40,7 @@ class GPT2CausalLMPreprocessorTest(TestCase):
         self.input_data = ["airplane at airport"]
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=GPT2CausalLMPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/gpt2/gpt2_preprocessor.py
+++ b/keras_nlp/models/gpt2/gpt2_preprocessor.py
@@ -118,8 +118,8 @@ class GPT2Preprocessor(Preprocessor):
         **kwargs,
     ):
         super().__init__(**kwargs)
-
         self.tokenizer = tokenizer
+        self.packer = None
         self.sequence_length = sequence_length
         self.add_start_token = add_start_token
         self.add_end_token = add_end_token
@@ -174,6 +174,17 @@ class GPT2Preprocessor(Preprocessor):
             }
         )
         return config
+
+    @property
+    def sequence_length(self):
+        """The padded length of model input sequences."""
+        return self._sequence_length
+
+    @sequence_length.setter
+    def sequence_length(self, value):
+        self._sequence_length = value
+        if self.packer is not None:
+            self.packer.sequence_length = value
 
     @classproperty
     def presets(cls):

--- a/keras_nlp/models/gpt2/gpt2_preprocessor_test.py
+++ b/keras_nlp/models/gpt2/gpt2_preprocessor_test.py
@@ -38,7 +38,7 @@ class GPT2PreprocessorTest(TestCase):
         self.input_data = ["airplane at airport"]
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=GPT2Preprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/gpt_neo_x/gpt_neo_x_causal_lm_preprocessor_test.py
+++ b/keras_nlp/models/gpt_neo_x/gpt_neo_x_causal_lm_preprocessor_test.py
@@ -40,7 +40,7 @@ class GPTNeoXCausalLMPreprocessorTest(TestCase):
         self.input_data = ["airplane at airport"]
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=GPTNeoXCausalLMPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/gpt_neo_x/gpt_neo_x_preprocessor.py
+++ b/keras_nlp/models/gpt_neo_x/gpt_neo_x_preprocessor.py
@@ -74,12 +74,11 @@ class GPTNeoXPreprocessor(Preprocessor):
         **kwargs,
     ):
         super().__init__(**kwargs)
-
         self.tokenizer = tokenizer
+        self.packer = None
         self.sequence_length = sequence_length
         self.add_start_token = add_start_token
         self.add_end_token = add_end_token
-        self.packer = None
 
     def build(self, input_shape):
         # Defer packer creation to `build()` so that we can be sure tokenizer
@@ -131,6 +130,17 @@ class GPTNeoXPreprocessor(Preprocessor):
             }
         )
         return config
+
+    @property
+    def sequence_length(self):
+        """The padded length of model input sequences."""
+        return self._sequence_length
+
+    @sequence_length.setter
+    def sequence_length(self, value):
+        self._sequence_length = value
+        if self.packer is not None:
+            self.packer.sequence_length = value
 
     @classproperty
     def tokenizer_cls(cls):

--- a/keras_nlp/models/gpt_neo_x/gpt_neo_x_preprocessor_test.py
+++ b/keras_nlp/models/gpt_neo_x/gpt_neo_x_preprocessor_test.py
@@ -38,7 +38,7 @@ class GPTNeoXPreprocessorTest(TestCase):
         self.input_data = ["airplane at airport"]
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=GPTNeoXPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/mistral/mistral_causal_lm_preprocessor_test.py
+++ b/keras_nlp/models/mistral/mistral_causal_lm_preprocessor_test.py
@@ -36,7 +36,7 @@ class MistralCausalLMPreprocessorTest(TestCase):
         self.input_data = (["the quick brown fox"],)
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=MistralCausalLMPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/mistral/mistral_preprocessor.py
+++ b/keras_nlp/models/mistral/mistral_preprocessor.py
@@ -121,15 +121,15 @@ class MistralPreprocessor(Preprocessor):
     ):
         super().__init__(**kwargs)
         self.tokenizer = tokenizer
-        self.add_start_token = add_start_token
-        self.add_end_token = add_end_token
-        self.sequence_length = sequence_length
         self.packer = StartEndPacker(
             start_value=self.tokenizer.start_token_id,
             end_value=self.tokenizer.end_token_id,
             sequence_length=sequence_length,
             return_padding_mask=True,
         )
+        self.add_start_token = add_start_token
+        self.add_end_token = add_end_token
+        self.sequence_length = sequence_length
 
     def get_config(self):
         config = super().get_config()
@@ -169,6 +169,17 @@ class MistralPreprocessor(Preprocessor):
             "padding_mask": padding_mask,
         }
         return pack_x_y_sample_weight(x, y, sample_weight)
+
+    @property
+    def sequence_length(self):
+        """The padded length of model input sequences."""
+        return self._sequence_length
+
+    @sequence_length.setter
+    def sequence_length(self, value):
+        self._sequence_length = value
+        if self.packer is not None:
+            self.packer.sequence_length = value
 
     @classproperty
     def tokenizer_cls(cls):

--- a/keras_nlp/models/mistral/mistral_preprocessor_test.py
+++ b/keras_nlp/models/mistral/mistral_preprocessor_test.py
@@ -38,7 +38,7 @@ class MistralPreprocessorTest(TestCase):
         )
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=MistralPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/opt/opt_causal_lm_preprocessor_test.py
+++ b/keras_nlp/models/opt/opt_causal_lm_preprocessor_test.py
@@ -39,7 +39,7 @@ class OPTCausalLMPreprocessorTest(TestCase):
         self.input_data = ["airplane at airport"]
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=OPTCausalLMPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/opt/opt_preprocessor.py
+++ b/keras_nlp/models/opt/opt_preprocessor.py
@@ -120,10 +120,10 @@ class OPTPreprocessor(Preprocessor):
         super().__init__(**kwargs)
 
         self.tokenizer = tokenizer
+        self.packer = None
         self.sequence_length = sequence_length
         self.add_start_token = add_start_token
         self.add_end_token = add_end_token
-        self.packer = None
 
     def build(self, input_shape):
         # Defer packer creation to `build()` so that we can be sure tokenizer
@@ -175,6 +175,17 @@ class OPTPreprocessor(Preprocessor):
             "padding_mask": padding_mask,
         }
         return pack_x_y_sample_weight(x, y, sample_weight)
+
+    @property
+    def sequence_length(self):
+        """The padded length of model input sequences."""
+        return self._sequence_length
+
+    @sequence_length.setter
+    def sequence_length(self, value):
+        self._sequence_length = value
+        if self.packer is not None:
+            self.packer.sequence_length = value
 
     @classproperty
     def presets(cls):

--- a/keras_nlp/models/opt/opt_preprocessor_test.py
+++ b/keras_nlp/models/opt/opt_preprocessor_test.py
@@ -37,7 +37,7 @@ class OPTPreprocessorTest(TestCase):
         self.input_data = ["airplane at airport"]
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=OPTPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/roberta/roberta_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/roberta/roberta_masked_lm_preprocessor_test.py
@@ -44,7 +44,7 @@ class RobertaMaskedLMPreprocessorTest(TestCase):
         self.input_data = [" airplane airport"]
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=RobertaMaskedLMPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/roberta/roberta_preprocessor.py
+++ b/keras_nlp/models/roberta/roberta_preprocessor.py
@@ -143,9 +143,9 @@ class RobertaPreprocessor(Preprocessor):
         super().__init__(**kwargs)
 
         self.tokenizer = tokenizer
+        self.packer = None
         self.truncate = truncate
         self.sequence_length = sequence_length
-        self.packer = None
 
     def build(self, input_shape):
         # Defer packer creation to `build()` so that we can be sure tokenizer
@@ -179,6 +179,17 @@ class RobertaPreprocessor(Preprocessor):
             }
         )
         return config
+
+    @property
+    def sequence_length(self):
+        """The padded length of model input sequences."""
+        return self._sequence_length
+
+    @sequence_length.setter
+    def sequence_length(self, value):
+        self._sequence_length = value
+        if self.packer is not None:
+            self.packer.sequence_length = value
 
     @classproperty
     def tokenizer_cls(cls):

--- a/keras_nlp/models/roberta/roberta_preprocessor_test.py
+++ b/keras_nlp/models/roberta/roberta_preprocessor_test.py
@@ -41,7 +41,7 @@ class RobertaPreprocessorTest(TestCase):
         )
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=RobertaPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/whisper/whisper_preprocessor.py
+++ b/keras_nlp/models/whisper/whisper_preprocessor.py
@@ -169,11 +169,11 @@ class WhisperPreprocessor(Preprocessor):
             audio_feature_extractor = WhisperAudioFeatureExtractor()
         self.audio_feature_extractor = audio_feature_extractor
         self.tokenizer = tokenizer
+        self.decoder_packer = None
         self.decoder_sequence_length = decoder_sequence_length
         self.language = language
         self.task = task
         self.no_timestamps = no_timestamps
-        self.decoder_packer = None
 
     def build(self, input_shape):
         # Defer packer creation to `build()` so that we can be sure tokenizer
@@ -306,6 +306,26 @@ class WhisperPreprocessor(Preprocessor):
             )
 
         return cls(**config)
+
+    @property
+    def decoder_sequence_length(self):
+        """The padded length of decoder input sequences."""
+        return self._decoder_sequence_length
+
+    @decoder_sequence_length.setter
+    def decoder_sequence_length(self, value):
+        self._decoder_sequence_length = value
+        if self.decoder_packer is not None:
+            self.decoder_packer.sequence_length = value
+
+    @property
+    def sequence_length(self):
+        """Alias for `decoder_sequence_length`."""
+        return self.decoder_sequence_length
+
+    @sequence_length.setter
+    def sequence_length(self, value):
+        self.decoder_sequence_length = value
 
     @classproperty
     def audio_feature_extractor_cls(cls):

--- a/keras_nlp/models/whisper/whisper_preprocessor_test.py
+++ b/keras_nlp/models/whisper/whisper_preprocessor_test.py
@@ -66,10 +66,11 @@ class WhisperPreprocessorTest(TestCase):
         }
 
     def test_feature_extractor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=WhisperPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,
+            token_id_key="decoder_token_ids",
         )
 
     def test_sequence_length_override(self):

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_masked_lm_preprocessor_test.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_masked_lm_preprocessor_test.py
@@ -45,7 +45,7 @@ class XLMRobertaMaskedLMPreprocessorTest(TestCase):
         self.input_data = ["the quick brown fox"]
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=XLMRobertaMaskedLMPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_preprocessor.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_preprocessor.py
@@ -156,9 +156,9 @@ class XLMRobertaPreprocessor(Preprocessor):
         super().__init__(**kwargs)
 
         self.tokenizer = tokenizer
+        self.packer = None
         self.truncate = truncate
         self.sequence_length = sequence_length
-        self.packer = None
 
     def build(self, input_shape):
         # Defer packer creation to `build()` so that we can be sure tokenizer
@@ -192,6 +192,17 @@ class XLMRobertaPreprocessor(Preprocessor):
             "padding_mask": token_ids != self.tokenizer.pad_token_id,
         }
         return pack_x_y_sample_weight(x, y, sample_weight)
+
+    @property
+    def sequence_length(self):
+        """The padded length of model input sequences."""
+        return self._sequence_length
+
+    @sequence_length.setter
+    def sequence_length(self, value):
+        self._sequence_length = value
+        if self.packer is not None:
+            self.packer.sequence_length = value
 
     @classproperty
     def tokenizer_cls(cls):

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_preprocessor_test.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_preprocessor_test.py
@@ -44,7 +44,7 @@ class XLMRobertaPreprocessorTest(TestCase):
         )
 
     def test_preprocessor_basics(self):
-        self.run_preprocessing_layer_test(
+        self.run_preprocessor_test(
             cls=XLMRobertaPreprocessor,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,


### PR DESCRIPTION
For all preprocessors, we add a settable sequence length property. This removes a very annoying gotcha with preprocessing, where if you set the preprocessing length after build, it would not be reflected in the actual output length.