### PR TITLE
Add `FORCE_KERAS_3` environment variable

### DIFF
--- a/keras_nlp/backend/config.py
+++ b/keras_nlp/backend/config.py
@@ -36,6 +36,8 @@ def detect_if_tensorflow_uses_keras_3():
 
 
 _USE_KERAS_3 = detect_if_tensorflow_uses_keras_3()
+if os.environ.get("FORCE_KERAS_3"):
+    _USE_KERAS_3 = True
 
 if not _USE_KERAS_3:
     backend = os.environ.get("KERAS_BACKEND")

--- a/keras_nlp/backend/config.py
+++ b/keras_nlp/backend/config.py
@@ -36,7 +36,7 @@ def detect_if_tensorflow_uses_keras_3():
 
 
 _USE_KERAS_3 = detect_if_tensorflow_uses_keras_3()
-if os.environ.get("FORCE_KERAS_3"):
+if os.environ.get("KERAS_FORCE_V3"):
     _USE_KERAS_3 = True
 
 if not _USE_KERAS_3:


### PR DESCRIPTION
Allow users to force KerasNLP to use Keras3 by setting `FORCE_KERAS_3` environment variable to True. Useful when managing multiple tensorflow versions.