### PR TITLE
Add BloomCausalLM

### DIFF
--- a/keras_nlp/layers/modeling/alibi_bias.py
+++ b/keras_nlp/layers/modeling/alibi_bias.py
@@ -94,7 +94,9 @@ class AlibiBias(keras.layers.Layer):
         )
         slopes = ops.expand_dims(slopes, 1)
 
-        seq_range = ops.expand_dims(ops.arange(1 - key_length, 1), 0)
+        seq_range = ops.expand_dims(
+            ops.arange(1 - key_length, 1, dtype="int32"), 0
+        )
         seq_range = ops.cast(seq_range, dtype=self.compute_dtype)
 
         alibi_bias = ops.multiply(slopes, seq_range)

--- a/keras_nlp/layers/modeling/alibi_bias_test.py
+++ b/keras_nlp/layers/modeling/alibi_bias_test.py
@@ -99,7 +99,6 @@ class AlibiBiasTest(TestCase):
         input_tensor = ops.zeros(input_shape)
         layer = AlibiBias()
         output_tensor = layer(input_tensor)
-        print(output_tensor)
         self.assertAllClose(
             output_tensor,
             ops.convert_to_tensor(
@@ -127,7 +126,6 @@ class AlibiBiasTest(TestCase):
         input_tensor = ops.zeros(input_shape)
         layer = AlibiBias()
         output_tensor = layer(input_tensor)
-        print(output_tensor)
         self.assertAllClose(
             output_tensor,
             ops.convert_to_tensor(
@@ -162,7 +160,6 @@ class AlibiBiasTest(TestCase):
         input_tensor = ops.zeros(input_shape)
         layer = AlibiBias(alibi_bias_max=alibi_bias_max)
         output_tensor = layer(input_tensor)
-        print(output_tensor)
         self.assertAllClose(
             output_tensor,
             ops.convert_to_tensor(
@@ -187,7 +184,6 @@ class AlibiBiasTest(TestCase):
         input_tensor = ops.zeros(input_shape)
         layer = AlibiBias(alibi_bias_max=alibi_bias_max)
         output_tensor = layer(input_tensor)
-        print(output_tensor)
         self.assertAllClose(
             output_tensor,
             ops.convert_to_tensor(

--- a/keras_nlp/models/__init__.py
+++ b/keras_nlp/models/__init__.py
@@ -36,6 +36,11 @@ from keras_nlp.models.bert.bert_masked_lm_preprocessor import (
 from keras_nlp.models.bert.bert_preprocessor import BertPreprocessor
 from keras_nlp.models.bert.bert_tokenizer import BertTokenizer
 from keras_nlp.models.bloom.bloom_backbone import BloomBackbone
+from keras_nlp.models.bloom.bloom_causal_lm import BloomCausalLm
+from keras_nlp.models.bloom.bloom_causal_lm_preprocessor import (
+    BloomCausalLMPreprocessor,
+)
+from keras_nlp.models.bloom.bloom_preprocessor import BloomPreprocessor
 from keras_nlp.models.bloom.bloom_tokenizer import BloomTokenizer
 from keras_nlp.models.deberta_v3.deberta_v3_backbone import DebertaV3Backbone
 from keras_nlp.models.deberta_v3.deberta_v3_classifier import (

--- a/keras_nlp/models/__init__.py
+++ b/keras_nlp/models/__init__.py
@@ -36,7 +36,7 @@ from keras_nlp.models.bert.bert_masked_lm_preprocessor import (
 from keras_nlp.models.bert.bert_preprocessor import BertPreprocessor
 from keras_nlp.models.bert.bert_tokenizer import BertTokenizer
 from keras_nlp.models.bloom.bloom_backbone import BloomBackbone
-from keras_nlp.models.bloom.bloom_causal_lm import BloomCausalLm
+from keras_nlp.models.bloom.bloom_causal_lm import BloomCausalLM
 from keras_nlp.models.bloom.bloom_causal_lm_preprocessor import (
     BloomCausalLMPreprocessor,
 )

--- a/keras_nlp/models/backbone.py
+++ b/keras_nlp/models/backbone.py
@@ -27,10 +27,6 @@ class Backbone(keras.Model):
         self._functional_layer_ids = set(
             id(layer) for layer in self._flatten_layers()
         )
-        if config.keras_3():
-            self.dtype_policy = keras.src.dtype_policies.get(dtype)
-        else:
-            self._set_dtype_policy(dtype)
         self._initialized = True
         if dtype is not None:
             # Keras 2 and Keras 3 handle setting policy differently.

--- a/keras_nlp/models/backbone.py
+++ b/keras_nlp/models/backbone.py
@@ -27,6 +27,10 @@ class Backbone(keras.Model):
         self._functional_layer_ids = set(
             id(layer) for layer in self._flatten_layers()
         )
+        if config.keras_3():
+            self.dtype_policy = keras.src.dtype_policies.get(dtype)
+        else:
+            self._set_dtype_policy(dtype)
         self._initialized = True
         if dtype is not None:
             # Keras 2 and Keras 3 handle setting policy differently.

--- a/keras_nlp/models/bloom/bloom_backbone.py
+++ b/keras_nlp/models/bloom/bloom_backbone.py
@@ -53,8 +53,6 @@ class BloomBackbone(Backbone):
         dropout: float. Dropout probability for the Transformer decoder.
         layer_norm_epsilon: float. Epsilon for the layer normalization layers in
             the transformer decoder.
-        max_sequence_length: int. The maximum sequence length that this decoder
-            can consume.
         dtype: string or `keras.mixed_precision.DTypePolicy`. The dtype to use
             for model computations and weights. Note that some computations,
             such as softmax and layer normalization, will always be done at
@@ -80,7 +78,6 @@ class BloomBackbone(Backbone):
         intermediate_dim=32*4,
         dropout=0.0,
         layer_norm_epsilon=1e-5,
-        max_sequence_length=128,
     )
     model(input_data)
     ```
@@ -96,7 +93,6 @@ class BloomBackbone(Backbone):
         intermediate_dim,
         dropout=0.0,
         layer_norm_epsilon=1e-5,
-        max_sequence_length=2048,
         dtype=None,
         **kwargs,
     ):
@@ -160,7 +156,6 @@ class BloomBackbone(Backbone):
         self.intermediate_dim = intermediate_dim
         self.dropout = dropout
         self.layer_norm_epsilon = layer_norm_epsilon
-        self.max_sequence_length = max_sequence_length
 
     def get_config(self):
         config = super().get_config()
@@ -173,7 +168,6 @@ class BloomBackbone(Backbone):
                 "intermediate_dim": self.intermediate_dim,
                 "dropout": self.dropout,
                 "layer_norm_epsilon": self.layer_norm_epsilon,
-                "max_sequence_length": self.max_sequence_length,
             }
         )
         return config

--- a/keras_nlp/models/bloom/bloom_backbone.py
+++ b/keras_nlp/models/bloom/bloom_backbone.py
@@ -105,7 +105,6 @@ class BloomBackbone(Backbone):
             input_dim=vocabulary_size,
             output_dim=hidden_dim,
             embeddings_initializer=_bloom_kernel_initializer(stddev=0.02),
-            tie_weights=False,
             dtype=dtype,
             name="token_embedding",
         )

--- a/keras_nlp/models/bloom/bloom_backbone.py
+++ b/keras_nlp/models/bloom/bloom_backbone.py
@@ -139,6 +139,7 @@ class BloomBackbone(Backbone):
             x = transformer_layer(x, decoder_padding_mask=padding_mask_input)
         sequence_output = self.layer_norm(x)
         super().__init__(
+            dtype=dtype,
             inputs={
                 "token_ids": token_id_input,
                 "padding_mask": padding_mask_input,

--- a/keras_nlp/models/bloom/bloom_backbone.py
+++ b/keras_nlp/models/bloom/bloom_backbone.py
@@ -139,7 +139,6 @@ class BloomBackbone(Backbone):
             x = transformer_layer(x, decoder_padding_mask=padding_mask_input)
         sequence_output = self.layer_norm(x)
         super().__init__(
-            dtype=dtype,
             inputs={
                 "token_ids": token_id_input,
                 "padding_mask": padding_mask_input,

--- a/keras_nlp/models/bloom/bloom_backbone_test.py
+++ b/keras_nlp/models/bloom/bloom_backbone_test.py
@@ -27,7 +27,6 @@ class BloomBackboneTest(TestCase):
             "num_heads": 4,
             "hidden_dim": 8,
             "intermediate_dim": 32,
-            "max_sequence_length": 10,
         }
         self.input_data = {
             "token_ids": ops.ones((2, 5), dtype="int32"),

--- a/keras_nlp/models/bloom/bloom_causal_lm.py
+++ b/keras_nlp/models/bloom/bloom_causal_lm.py
@@ -237,7 +237,9 @@ class BloomCausalLM(GenerativeTask):
         num_heads = self.backbone.num_heads
         head_dim = self.backbone.hidden_dim // num_heads
         shape = [batch_size, num_layers, 2, max_length, num_heads, head_dim]
-        attention_layer_dtype = self.backbone.transformer_layers[0].dtype
+        attention_layer_dtype = self.backbone.transformer_layers[
+            0
+        ].compute_dtype
         cache = ops.zeros(shape, dtype=attention_layer_dtype)
         # Seed the cache.
         _, hidden_states, cache = self.call_with_cache(token_ids, cache, 0)

--- a/keras_nlp/models/bloom/bloom_causal_lm.py
+++ b/keras_nlp/models/bloom/bloom_causal_lm.py
@@ -1,0 +1,310 @@
+# Copyright 2024 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+
+from keras_nlp.api_export import keras_nlp_export
+from keras_nlp.backend import keras
+from keras_nlp.backend import ops
+from keras_nlp.models.bloom.bloom_backbone import BloomBackbone
+from keras_nlp.models.bloom.bloom_causal_lm_preprocessor import (
+    BloomCausalLMPreprocessor,
+)
+from keras_nlp.models.bloom.bloom_presets import backbone_presets
+from keras_nlp.models.generative_task import GenerativeTask
+from keras_nlp.utils.python_utils import classproperty
+
+
+@keras_nlp_export("keras_nlp.models.BloomCausalLm")
+class BloomCausalLm(GenerativeTask):
+    """An end-to-end Gemma model for causal language modeling.
+
+    A causal language model (LM) predicts the next token based on previous
+    tokens. This task setup can be used to train the model unsupervised on
+    plain text input, or to autoregressively generate plain text similar to
+    the data used for training. This task can be used for pre-training or
+    fine-tuning a Gemma model, simply by calling `fit()`.
+
+    This model has a `generate()` method, which generates text based on a
+    prompt. The generation strategy used is controlled by an additional
+    `sampler` argument on `compile()`. You can recompile the model with
+    different `keras_nlp.samplers` objects to control the generation. By
+    default, `"greedy"` sampling will be used.
+
+    This model can optionally be configured with a `preprocessor` layer, in
+    which case it will automatically apply preprocessing to string inputs during
+    `fit()`, `predict()`, `evaluate()` and `generate()`. This is done by default
+    when creating the model with `from_preset()`.
+
+    Args:
+        backbone: A `keras_nlp.models.GemmaBackbone` instance.
+        preprocessor: A `keras_nlp.models.GemmaCausalLMPreprocessor` or `None`.
+            If `None`, this model will not apply preprocessing, and inputs
+            should be preprocessed before calling the model.
+
+    Examples:
+
+    Use `generate()` to do text generation.
+    ```python
+    gemma_lm = keras_nlp.models.GemmaCausalLM.from_preset("gemma_2b_en")
+    gemma_lm.generate("I want to say", max_length=30)
+
+    # Generate with batched prompts.
+    gemma_lm.generate(["This is a", "Where are you"], max_length=30)
+    ```
+
+    Compile the `generate()` function with a custom sampler.
+    ```python
+    gemma_lm = keras_nlp.models.GemmaCausalLM.from_preset("gemma_2b_en")
+    gemma_lm.compile(sampler="top_k")
+    gemma_lm.generate("I want to say", max_length=30)
+
+    gemma_lm.compile(sampler=keras_nlp.samplers.BeamSampler(num_beams=2))
+    gemma_lm.generate("I want to say", max_length=30)
+    ```
+
+    Use `generate()` without preprocessing.
+    ```python
+    prompt = {
+        # Token ids for "<bos> Keras is".
+        "token_ids": np.array([[2, 214064, 603, 0, 0, 0, 0]] * 2),
+        # Use `"padding_mask"` to indicate values that should not be overridden.
+        "padding_mask": np.array([[1, 1, 1, 0, 0, 0, 0]] * 2),
+    }
+
+    gemma_lm = keras_nlp.models.GemmaCausalLM.from_preset(
+        "gemma_2b_en",
+        preprocessor=None,
+    )
+    gemma_lm.generate(prompt)
+    ```
+
+    Call `fit()` on a single batch.
+    ```python
+    features = ["The quick brown fox jumped.", "I forgot my homework."]
+    gemma_lm = keras_nlp.models.GemmaCausalLM.from_preset("gemma_2b_en")
+    gemma_lm.fit(x=features, batch_size=2)
+    ```
+
+    Call `fit()` without preprocessing.
+    ```python
+    x = {
+        # Token ids for "<bos> Keras is deep learning library<eos>"
+        "token_ids": np.array([[2, 214064, 603, 5271, 6044, 9581, 1, 0]] * 2),
+        "padding_mask": np.array([[1, 1, 1, 1, 1, 1, 1, 0]] * 2),
+    }
+    y = np.array([[214064, 603, 5271, 6044, 9581, 3, 0, 0]] * 2)
+    sw = np.array([[1, 1, 1, 1, 1, 1, 0, 0]] * 2)
+
+    gemma_lm = keras_nlp.models.GemmaCausalLM.from_preset(
+        "gemma_2b_en",
+        preprocessor=None,
+    )
+    gemma_lm.fit(x=x, y=y, sample_weight=sw, batch_size=2)
+    ```
+
+    Custom backbone and vocabulary.
+    ```python
+    tokenizer = keras_nlp.models.GemmaTokenizer(
+        proto="proto.spm",
+    )
+    preprocessor = keras_nlp.models.GemmaCausalLMPreprocessor(
+        tokenizer=tokenizer,
+        sequence_length=128,
+    )
+    backbone = keras_nlp.models.GemmaBackbone(
+        vocabulary_size=30552,
+        num_layers=4,
+        num_heads=4,
+        hidden_dim=256,
+        intermediate_dim=512,
+        max_sequence_length=128,
+    )
+    gemma_lm = keras_nlp.models.GemmaCausalLM(
+        backbone=backbone,
+        preprocessor=preprocessor,
+    )
+    gemma_lm.fit(x=features, batch_size=2)
+    ```
+    """
+
+    def __init__(
+        self,
+        backbone,
+        preprocessor=None,
+        **kwargs,
+    ):
+        # === Layers ===
+        self.backbone = backbone
+        self.preprocessor = preprocessor
+
+        # === Functional Model ===
+        inputs = backbone.input
+        hidden_states = backbone(inputs)
+        outputs = backbone.token_embedding(hidden_states, reverse=True)
+        super().__init__(
+            inputs=inputs,
+            outputs=outputs,
+            **kwargs,
+        )
+
+        # === Default compilation ===
+        self.compile(
+            loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+            optimizer=keras.optimizers.Adam(2e-5),
+            metrics=[keras.metrics.SparseCategoricalAccuracy()],
+            sampler="greedy",
+            jit_compile=True,
+        )
+
+    @classproperty
+    def presets(cls):
+        return copy.deepcopy(backbone_presets)
+
+    @classproperty
+    def backbone_cls(cls):
+        return BloomBackbone
+
+    @classproperty
+    def preprocessor_cls(cls):
+        return BloomCausalLMPreprocessor
+
+    def call_with_cache(
+        self,
+        token_ids,
+        cache,
+        cache_update_index,
+    ):
+        """Forward pass of `GemmaCausalLM` with cache.
+
+        `call_with_cache` adds an additional forward pass for the model for
+        autoregressive inference. Unlike calling the model directly, this method
+        allows caching previous key/value Tensors in multi-head attention layer,
+        and avoids recomputing the outputs of seen tokens.
+
+        Args:
+            token_ids: a dense int Tensor with shape `(batch_size, max_length)`.
+            cache: a dense float Tensor, the cache of key and value.
+            cache_update_index: int, or int Tensor. The index of current inputs in the
+                whole sequence.
+
+        Returns:
+            A (logits, hidden_states, cache) tuple. Where `logits` is the
+            language model logits for the input token_ids, `hidden_states` is
+            the final hidden representation of the input tokens, and `cache` is
+            the decoding cache.
+        """
+        x = self.backbone.token_embedding(token_ids)
+        x = self.backbone.embeddings_layer_norm(x)
+        # Each decoder layer has a cache; we update them separately.
+        caches = []
+        for i, transformer_layer in enumerate(self.backbone.transformer_layers):
+            current_cache = cache[:, i, ...]
+            x, next_cache = transformer_layer(
+                x,
+                cache=current_cache,
+                cache_update_index=cache_update_index,
+            )
+            caches.append(next_cache)
+        cache = ops.stack(caches, axis=1)
+        hidden_states = x = self.backbone.layer_norm(x)
+        logits = self.backbone.token_embedding(x, reverse=True)
+        return logits, hidden_states, cache
+
+    def _build_cache(self, token_ids):
+        """Build an empty cache for use with `call_with_cache()`."""
+        batch_size = ops.shape(token_ids)[0]
+        max_length = ops.shape(token_ids)[1]
+        num_layers = self.backbone.num_layers
+        num_heads = self.backbone.num_heads
+        head_dim = self.backbone.hidden_dim // num_heads
+        shape = [batch_size, num_layers, 2, max_length, num_heads, head_dim]
+        cache = ops.zeros(shape, dtype=self.compute_dtype)
+        # Seed the cache.
+        _, hidden_states, cache = self.call_with_cache(token_ids, cache, 0)
+        return hidden_states, cache
+
+    def generate_step(
+        self,
+        inputs,
+        end_token_id=None,
+    ):
+        """A compilable generation function for a single batch of inputs.
+
+        This function represents the inner, XLA-compilable, generation function
+        for a single batch of inputs. Inputs should have the same structure as
+        model inputs, a dictionary with keys `"token_ids"` and `"padding_mask"`.
+
+        Args:
+            inputs: A dictionary with two keys `"token_ids"` and
+                `"padding_mask"` and batched tensor values.
+            end_token_id: The id of the end token to stop on. If all
+                sequences have produced a new `end_token_id`, generation
+                will stop.
+        """
+        token_ids, padding_mask = inputs["token_ids"], inputs["padding_mask"]
+        # Create and seed cache with a single forward pass.
+        hidden_states, cache = self._build_cache(token_ids)
+        # Compute the lengths of all user inputted tokens ids.
+        row_lengths = ops.sum(ops.cast(padding_mask, "int32"), axis=-1)
+        # Start at the first index that has no user inputted id.
+        index = ops.min(row_lengths)
+
+        def next(prompt, cache, index):
+            # The cache index is the index of our previous token.
+            cache_update_index = index - 1
+            batch_size = ops.shape(prompt)[0]
+            prompt = ops.slice(prompt, [0, cache_update_index], [batch_size, 1])
+            logits, hidden_states, cache = self.call_with_cache(
+                prompt,
+                cache,
+                cache_update_index,
+            )
+            return (
+                ops.squeeze(logits, axis=1),
+                ops.squeeze(hidden_states, axis=1),
+                cache,
+            )
+        token_ids = self._sampler(
+            next=next,
+            prompt=token_ids,
+            cache=cache,
+            index=index,
+            mask=padding_mask,
+            end_token_id=end_token_id,
+            hidden_states=hidden_states,
+            model=self,
+        )
+
+        # Compute an output padding mask with the token ids we updated.
+        if end_token_id is not None:
+            # Build a mask of `end_token_id` locations not in the original
+            # prompt (not in locations where `padding_mask` is True).
+            end_locations = ops.logical_and(
+                ops.equal(token_ids, end_token_id),
+                ops.logical_not(padding_mask),
+            )
+            end_locations = ops.cast(end_locations, "int32")
+            # Use cumsum to get ones in all locations after end_locations.
+            cumsum = ops.cast(ops.cumsum(end_locations, axis=-1), "int32")
+            overflow = cumsum - end_locations
+            # Our padding mask is the inverse of these overflow locations.
+            padding_mask = ops.logical_not(ops.cast(overflow, "bool"))
+        else:
+            # Without early stopping, all locations will have been updated.
+            padding_mask = ops.ones_like(token_ids, dtype="bool")
+        return {
+            "token_ids": token_ids,
+            "padding_mask": padding_mask,
+        }

--- a/keras_nlp/models/bloom/bloom_causal_lm.py
+++ b/keras_nlp/models/bloom/bloom_causal_lm.py
@@ -237,10 +237,7 @@ class BloomCausalLM(GenerativeTask):
         num_heads = self.backbone.num_heads
         head_dim = self.backbone.hidden_dim // num_heads
         shape = [batch_size, num_layers, 2, max_length, num_heads, head_dim]
-        attention_layer_dtype = self.backbone.transformer_layers[
-            0
-        ].compute_dtype
-        cache = ops.zeros(shape, dtype=attention_layer_dtype)
+        cache = ops.zeros(shape, dtype=self.compute_dtype)
         # Seed the cache.
         _, hidden_states, cache = self.call_with_cache(token_ids, cache, 0)
         return hidden_states, cache

--- a/keras_nlp/models/bloom/bloom_causal_lm.py
+++ b/keras_nlp/models/bloom/bloom_causal_lm.py
@@ -237,9 +237,7 @@ class BloomCausalLM(GenerativeTask):
         num_heads = self.backbone.num_heads
         head_dim = self.backbone.hidden_dim // num_heads
         shape = [batch_size, num_layers, 2, max_length, num_heads, head_dim]
-        attention_layer_dtype = self.backbone.transformer_layers[
-            0
-        ].compute_dtype
+        attention_layer_dtype = self.compute_dtype
         cache = ops.zeros(shape, dtype=attention_layer_dtype)
         # Seed the cache.
         _, hidden_states, cache = self.call_with_cache(token_ids, cache, 0)

--- a/keras_nlp/models/bloom/bloom_causal_lm.py
+++ b/keras_nlp/models/bloom/bloom_causal_lm.py
@@ -237,7 +237,10 @@ class BloomCausalLM(GenerativeTask):
         num_heads = self.backbone.num_heads
         head_dim = self.backbone.hidden_dim // num_heads
         shape = [batch_size, num_layers, 2, max_length, num_heads, head_dim]
-        cache = ops.zeros(shape, dtype=self.compute_dtype)
+        attention_layer_dtype = self.backbone.transformer_layers[
+            0
+        ].compute_dtype
+        cache = ops.zeros(shape, dtype=attention_layer_dtype)
         # Seed the cache.
         _, hidden_states, cache = self.call_with_cache(token_ids, cache, 0)
         return hidden_states, cache

--- a/keras_nlp/models/bloom/bloom_causal_lm.py
+++ b/keras_nlp/models/bloom/bloom_causal_lm.py
@@ -237,8 +237,7 @@ class BloomCausalLM(GenerativeTask):
         num_heads = self.backbone.num_heads
         head_dim = self.backbone.hidden_dim // num_heads
         shape = [batch_size, num_layers, 2, max_length, num_heads, head_dim]
-        attention_layer_dtype = self.compute_dtype
-        cache = ops.zeros(shape, dtype=attention_layer_dtype)
+        cache = ops.zeros(shape, dtype=self.compute_dtype)
         # Seed the cache.
         _, hidden_states, cache = self.call_with_cache(token_ids, cache, 0)
         return hidden_states, cache

--- a/keras_nlp/models/bloom/bloom_causal_lm.py
+++ b/keras_nlp/models/bloom/bloom_causal_lm.py
@@ -237,7 +237,8 @@ class BloomCausalLM(GenerativeTask):
         num_heads = self.backbone.num_heads
         head_dim = self.backbone.hidden_dim // num_heads
         shape = [batch_size, num_layers, 2, max_length, num_heads, head_dim]
-        cache = ops.zeros(shape, dtype=self.compute_dtype)
+        attention_layer_dtype = self.backbone.transformer_layers[0].dtype
+        cache = ops.zeros(shape, dtype=attention_layer_dtype)
         # Seed the cache.
         _, hidden_states, cache = self.call_with_cache(token_ids, cache, 0)
         return hidden_states, cache

--- a/keras_nlp/models/bloom/bloom_causal_lm.py
+++ b/keras_nlp/models/bloom/bloom_causal_lm.py
@@ -16,7 +16,6 @@ import copy
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.backend import keras
-from keras_nlp.backend import config
 from keras_nlp.backend import ops
 from keras_nlp.models.bloom.bloom_backbone import BloomBackbone
 from keras_nlp.models.bloom.bloom_causal_lm_preprocessor import (
@@ -176,12 +175,6 @@ class BloomCausalLM(GenerativeTask):
             jit_compile=True,
         )
 
-        # === dtype policy ===
-        if config.keras_3():
-            self.dtype_policy = self.backbone.dtype_policy 
-        else:
-            self._set_dtype_policy(self.backbone._dtype_policy)
-            
     @classproperty
     def presets(cls):
         return copy.deepcopy(backbone_presets)
@@ -244,10 +237,10 @@ class BloomCausalLM(GenerativeTask):
         num_heads = self.backbone.num_heads
         head_dim = self.backbone.hidden_dim // num_heads
         shape = [batch_size, num_layers, 2, max_length, num_heads, head_dim]
-        # attention_layer_dtype = self.backbone.transformer_layers[
-        #     0
-        # ].compute_dtype
-        cache = ops.zeros(shape, dtype=self.compute_dtype)
+        attention_layer_dtype = self.backbone.transformer_layers[
+            0
+        ].compute_dtype
+        cache = ops.zeros(shape, dtype=attention_layer_dtype)
         # Seed the cache.
         _, hidden_states, cache = self.call_with_cache(token_ids, cache, 0)
         return hidden_states, cache

--- a/keras_nlp/models/bloom/bloom_causal_lm.py
+++ b/keras_nlp/models/bloom/bloom_causal_lm.py
@@ -84,7 +84,7 @@ class BloomCausalLM(GenerativeTask):
     }
 
     bloom_lm = keras_nlp.models.BloomCausalLM.from_preset(
-        "/home/mohamed/Mohamed/projects/bloom_560m_multi",
+        "bloom_560m_multi",
         preprocessor=None,
     )
     bloom_lm.generate(prompt)
@@ -135,8 +135,8 @@ class BloomCausalLM(GenerativeTask):
         vocabulary_size=tokenizer.vocabulary_size(),
         num_layers=4,
         num_heads=4,
-        hidden_dim=256,
-        intermediate_dim=512,
+        hidden_dim=32,
+        intermediate_dim=128,
         max_sequence_length=128,
     )
     bloom_lm = keras_nlp.models.BloomCausalLM(

--- a/keras_nlp/models/bloom/bloom_causal_lm.py
+++ b/keras_nlp/models/bloom/bloom_causal_lm.py
@@ -137,7 +137,6 @@ class BloomCausalLM(GenerativeTask):
         num_heads=4,
         hidden_dim=32,
         intermediate_dim=128,
-        max_sequence_length=128,
     )
     bloom_lm = keras_nlp.models.BloomCausalLM(
         backbone=backbone,

--- a/keras_nlp/models/bloom/bloom_causal_lm_preprocessor.py
+++ b/keras_nlp/models/bloom/bloom_causal_lm_preprocessor.py
@@ -175,8 +175,8 @@ class BloomCausalLMPreprocessor(BloomPreprocessor):
         # end markers). In the future we could make this configurable.
         padding_mask = (
             padding_mask
-            & (token_ids != self.tokenizer.eos_token_id)
-            & (token_ids != self.tokenizer.bos_token_id)
+            & (token_ids != self.tokenizer.start_token_id)
+            & (token_ids != self.tokenizer.end_token_id)
         )
         token_ids = tf.ragged.boolean_mask(token_ids, padding_mask)
         return self.tokenizer.detokenize(token_ids)

--- a/keras_nlp/models/bloom/bloom_causal_lm_preprocessor.py
+++ b/keras_nlp/models/bloom/bloom_causal_lm_preprocessor.py
@@ -148,7 +148,7 @@ class BloomCausalLMPreprocessor(BloomPreprocessor):
         x = convert_inputs_to_list_of_tensor_segments(x)[0]
         x = self.tokenizer(x)
         token_ids, padding_mask = self.packer(
-            x, sequence_length=sequence_length, add_end_value=False
+            x, sequence_length=sequence_length, add_start_value=False ,add_end_value=False
         )
         return {
             "token_ids": token_ids,

--- a/keras_nlp/models/bloom/bloom_causal_lm_preprocessor.py
+++ b/keras_nlp/models/bloom/bloom_causal_lm_preprocessor.py
@@ -148,7 +148,7 @@ class BloomCausalLMPreprocessor(BloomPreprocessor):
         x = convert_inputs_to_list_of_tensor_segments(x)[0]
         x = self.tokenizer(x)
         token_ids, padding_mask = self.packer(
-            x, sequence_length=sequence_length, add_start_value=False ,add_end_value=False
+            x, sequence_length=sequence_length, add_end_value=False
         )
         return {
             "token_ids": token_ids,

--- a/keras_nlp/models/bloom/bloom_causal_lm_test.py
+++ b/keras_nlp/models/bloom/bloom_causal_lm_test.py
@@ -28,18 +28,6 @@ from keras_nlp.models.bloom.bloom_tokenizer import BloomTokenizer
 from keras_nlp.tests.test_case import TestCase
 
 
-@contextlib.contextmanager
-def _set_keras_default_dtype(dtype):
-    original_floatx = keras.config.floatx()
-    keras.config.set_floatx(dtype)
-    try:
-        yield
-    finally:
-        # Restore floatx to the original value to prevent impact on other
-        # tests even if there is an exception.
-        keras.config.set_floatx(original_floatx)
-
-
 class BloomCausalLMTest(TestCase):
     def setUp(self):
         self.vocab = ["<unk>", "<s>", "</s>", "<pad>"]
@@ -104,7 +92,20 @@ class BloomCausalLMTest(TestCase):
             prompt_ids["padding_mask"][:, :4],
         )
 
+    @pytest.mark.keras_3_only
     def test_generate_with_bfloat16(self):
+
+        @contextlib.contextmanager
+        def _set_keras_default_dtype(dtype):
+            original_floatx = keras.config.floatx()
+            keras.config.set_floatx(dtype)
+            try:
+                yield
+            finally:
+                # Restore floatx to the original value to prevent impact on other
+                # tests even if there is an exception.
+                keras.config.set_floatx(original_floatx)
+
         with _set_keras_default_dtype("float16"):
             causal_lm = BloomCausalLM(**self.init_kwargs)
             # String input.

--- a/keras_nlp/models/bloom/bloom_causal_lm_test.py
+++ b/keras_nlp/models/bloom/bloom_causal_lm_test.py
@@ -1,0 +1,174 @@
+# Copyright 2024 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+from unittest.mock import patch
+
+import keras
+import pytest
+
+from keras_nlp.backend import ops
+from keras_nlp.models.bloom.bloom_backbone import BloomBackbone
+from keras_nlp.models.bloom.bloom_causal_lm import BloomCausalLM
+from keras_nlp.models.bloom.bloom_causal_lm_preprocessor import (
+    BloomCausalLMPreprocessor,
+)
+from keras_nlp.models.bloom.bloom_tokenizer import BloomTokenizer
+from keras_nlp.tests.test_case import TestCase
+
+
+@contextlib.contextmanager
+def _set_keras_default_dtype(dtype):
+    original_floatx = keras.config.floatx()
+    keras.config.set_floatx(dtype)
+    try:
+        yield
+    finally:
+        # Restore floatx to the original value to prevent impact on other
+        # tests even if there is an exception.
+        keras.config.set_floatx(original_floatx)
+
+
+class BloomCausalLMTest(TestCase):
+    def setUp(self):
+        self.vocab = ["<unk>", "<s>", "</s>", "<pad>"]
+        self.vocab += ["!", "air", "Ġair", "plane", "Ġat", "port"]
+        self.vocab = dict([(token, i) for i, token in enumerate(self.vocab)])
+        self.merges = ["Ġ a", "Ġ t", "Ġ i", "Ġ b", "a i", "p l", "n e"]
+        self.merges += ["Ġa t", "p o", "r t", "Ġt h", "ai r", "pl a", "po rt"]
+        self.merges += ["Ġai r", "Ġa i", "pla ne"]
+        self.tokenizer = BloomTokenizer(
+            vocabulary=self.vocab, merges=self.merges
+        )
+        self.preprocessor = BloomCausalLMPreprocessor(
+            self.tokenizer,
+            sequence_length=8,
+        )
+        self.backbone = BloomBackbone(
+            vocabulary_size=self.preprocessor.tokenizer.vocabulary_size(),
+            num_layers=2,
+            num_heads=2,
+            hidden_dim=4,
+            intermediate_dim=16,
+            max_sequence_length=8,
+        )
+        self.init_kwargs = {
+            "preprocessor": self.preprocessor,
+            "backbone": self.backbone,
+        }
+        self.train_data = (
+            [
+                " airplane at airport",
+                " airplane airport",
+            ],
+        )
+        self.input_data = self.preprocessor(*self.train_data)[0]
+
+    def test_causal_lm_basics(self):
+        vocabulary_size = self.tokenizer.vocabulary_size()
+        self.run_task_test(
+            cls=BloomCausalLM,
+            init_kwargs=self.init_kwargs,
+            train_data=self.train_data,
+            expected_output_shape=(2, 8, vocabulary_size),
+        )
+
+    def test_generate(self):
+        causal_lm = BloomCausalLM(**self.init_kwargs)
+        # String input.
+        prompt = "airplane at airport"
+        output = causal_lm.generate(prompt)
+        self.assertTrue(prompt in output)
+        # Int tensor input.
+        prompt_ids = self.preprocessor.generate_preprocess([prompt])
+        causal_lm.preprocessor = None
+        outputs = causal_lm.generate(prompt_ids)
+        # Assert prompt is in output in token id space.
+        self.assertAllEqual(
+            outputs["token_ids"][:, :4],
+            prompt_ids["token_ids"][:, :4],
+        )
+        self.assertAllEqual(
+            outputs["padding_mask"][:, :4],
+            prompt_ids["padding_mask"][:, :4],
+        )
+
+    def test_generate_with_bfloat16(self):
+        with _set_keras_default_dtype("float16"):
+            causal_lm = BloomCausalLM(**self.init_kwargs)
+            # String input.
+            prompt = "airplane at airport"
+            output = causal_lm.generate(prompt)
+            self.assertTrue(prompt in output)
+            # Int tensor input.
+            prompt_ids = self.preprocessor.generate_preprocess([prompt])
+            causal_lm.preprocessor = None
+            outputs = causal_lm.generate(prompt_ids)
+            # Assert prompt is in output in token id space.
+            self.assertAllEqual(
+                outputs["token_ids"][:, :4],
+                prompt_ids["token_ids"][:, :4],
+            )
+            self.assertAllEqual(
+                outputs["padding_mask"][:, :4],
+                prompt_ids["padding_mask"][:, :4],
+            )
+
+    def test_early_stopping(self):
+        causal_lm = BloomCausalLM(**self.init_kwargs)
+        call_with_cache = causal_lm.call_with_cache
+
+        def wrapper(*args, **kwargs):
+            """Modify output logits to always favor end_token_id"""
+            logits, hidden_states, cache = call_with_cache(*args, **kwargs)
+            index = self.preprocessor.tokenizer.end_token_id
+            update = ops.ones_like(logits)[:, :, index] * 1.0e9
+            update = ops.expand_dims(update, axis=-1)
+            logits = ops.slice_update(logits, (0, 0, index), update)
+            return logits, hidden_states, cache
+
+        with patch.object(causal_lm, "call_with_cache", wraps=wrapper):
+            prompt = ["airplane at", "airplane"]
+            output = causal_lm.generate(prompt)
+            # We should immediately abort and output the prompt.
+            self.assertEqual(prompt, output)
+
+    def test_generate_compilation(self):
+        causal_lm = BloomCausalLM(**self.init_kwargs)
+        # Assert we do not recompile with successive calls.
+        causal_lm.generate("airplane at airport")
+        first_fn = causal_lm.generate_function
+        causal_lm.generate("airplane at airport")
+        second_fn = causal_lm.generate_function
+        self.assertEqual(first_fn, second_fn)
+        # Assert we do recompile after compile is called.
+        causal_lm.compile(sampler="greedy")
+        self.assertIsNone(causal_lm.generate_function)
+
+    @pytest.mark.large
+    def test_saved_model(self):
+        self.run_model_saving_test(
+            cls=BloomCausalLM,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+        )
+
+    @pytest.mark.extra_large
+    def test_all_presets(self):
+        for preset in BloomCausalLM.presets:
+            self.run_preset_test(
+                cls=BloomCausalLM,
+                preset=preset,
+                input_data=self.input_data,
+            )

--- a/keras_nlp/models/bloom/bloom_decoder.py
+++ b/keras_nlp/models/bloom/bloom_decoder.py
@@ -110,8 +110,8 @@ class BloomDecoder(keras.layers.Layer):
         decoder_sequence,
         decoder_padding_mask=None,
         decoder_attention_mask=None,
-        attention_cache=None,
-        attention_cache_update_index=None,
+        cache=None,
+        cache_update_index=None,
         use_causal_mask=True,
     ):
         self_attention_mask = self._compute_attention_mask(
@@ -119,8 +119,8 @@ class BloomDecoder(keras.layers.Layer):
             decoder_padding_mask=decoder_padding_mask,
             decoder_attention_mask=decoder_attention_mask,
             use_causal_mask=use_causal_mask,
-            attention_cache=attention_cache,
-            attention_cache_update_index=attention_cache_update_index,
+            cache=cache,
+            cache_update_index=cache_update_index,
         )
 
         residual = decoder_sequence
@@ -129,14 +129,14 @@ class BloomDecoder(keras.layers.Layer):
         attention_output = self._self_attention_layer(
             hidden_states=x,
             attention_mask=self_attention_mask,
-            cache=attention_cache,
-            cache_update_index=attention_cache_update_index,
+            cache=cache,
+            cache_update_index=cache_update_index,
         )
 
-        if attention_cache is None:
+        if cache is None:
             x = attention_output
         else:
-            x, attention_cache = attention_output
+            x, cache = attention_output
 
         x = x + residual
         residual = x
@@ -147,8 +147,8 @@ class BloomDecoder(keras.layers.Layer):
         x = self._dropout_layer(x)
         x = x + residual
 
-        if attention_cache is not None:
-            return x, attention_cache
+        if cache is not None:
+            return x, cache
         else:
             return x
 
@@ -158,8 +158,8 @@ class BloomDecoder(keras.layers.Layer):
         decoder_padding_mask,
         decoder_attention_mask,
         use_causal_mask,
-        attention_cache,
-        attention_cache_update_index,
+        cache,
+        cache_update_index,
     ):
         decoder_mask = merge_padding_and_attention_mask(
             decoder_sequence, decoder_padding_mask, decoder_attention_mask
@@ -167,8 +167,8 @@ class BloomDecoder(keras.layers.Layer):
         if use_causal_mask:
             batch_size = ops.shape(decoder_sequence)[0]
             input_length = output_length = ops.shape(decoder_sequence)[1]
-            if attention_cache is not None:
-                input_length = ops.shape(attention_cache)[2]
+            if cache is not None:
+                input_length = ops.shape(cache)[2]
 
             causal_mask = compute_causal_mask(
                 batch_size,
@@ -176,8 +176,8 @@ class BloomDecoder(keras.layers.Layer):
                 output_length,
                 (
                     0
-                    if attention_cache_update_index is None
-                    else attention_cache_update_index
+                    if cache_update_index is None
+                    else cache_update_index
                 ),
             )
             return (

--- a/keras_nlp/models/bloom/bloom_decoder.py
+++ b/keras_nlp/models/bloom/bloom_decoder.py
@@ -174,11 +174,7 @@ class BloomDecoder(keras.layers.Layer):
                 batch_size,
                 input_length,
                 output_length,
-                (
-                    0
-                    if cache_update_index is None
-                    else cache_update_index
-                ),
+                (0 if cache_update_index is None else cache_update_index),
             )
             return (
                 ops.minimum(decoder_mask, causal_mask)

--- a/keras_nlp/models/bloom/bloom_preprocessor.py
+++ b/keras_nlp/models/bloom/bloom_preprocessor.py
@@ -126,8 +126,8 @@ class BloomPreprocessor(Preprocessor):
         # Defer packer creation to `build()` so that we can be sure tokenizer
         # assets have loaded when restoring a saved model.
         self.packer = StartEndPacker(
-            start_value=self.tokenizer.bos_token_id,
-            end_value=self.tokenizer.eos_token_id,
+            start_value=self.tokenizer.start_token_id,
+            end_value=self.tokenizer.end_token_id,
             pad_value=self.tokenizer.pad_token_id,
             sequence_length=self.sequence_length,
             return_padding_mask=True,

--- a/keras_nlp/models/bloom/bloom_presets.py
+++ b/keras_nlp/models/bloom/bloom_presets.py
@@ -25,6 +25,6 @@ backbone_presets = {
             "path": "bloom",
             "model_card": "https://huggingface.co/bigscience/bloom",
         },
-        "kaggle_handle": "kaggle://keras/bloom/keras/bloom_560m_multi/2",
+        "kaggle_handle": "kaggle://keras/bloom/keras/bloom_560m_multi/3",
     },
 }

--- a/keras_nlp/models/bloom/bloom_presets.py
+++ b/keras_nlp/models/bloom/bloom_presets.py
@@ -25,6 +25,6 @@ backbone_presets = {
             "path": "bloom",
             "model_card": "https://huggingface.co/bigscience/bloom",
         },
-        "kaggle_handle": "kaggle://keras/bloom/keras/bloom_560m_multi/1",
+        "kaggle_handle": "kaggle://keras/bloom/keras/bloom_560m_multi/2",
     },
 }

--- a/keras_nlp/models/bloom/bloom_tokenizer.py
+++ b/keras_nlp/models/bloom/bloom_tokenizer.py
@@ -74,16 +74,16 @@ class BloomTokenizer(BytePairTokenizer):
         merges=None,
         **kwargs,
     ):
-        self.bos_token = "<s>"
-        self.eos_token = "</s>"
+        self.start_token = "<s>"
+        self.end_token = "</s>"
         self.pad_token = "<pad>"
 
         super().__init__(
             vocabulary=vocabulary,
             merges=merges,
             unsplittable_tokens=[
-                self.bos_token,
-                self.eos_token,
+                self.start_token,
+                self.end_token,
                 self.pad_token,
             ],
             **kwargs,
@@ -94,7 +94,7 @@ class BloomTokenizer(BytePairTokenizer):
 
         if vocabulary is not None:
             # Check for necessary special tokens.
-            for token in [self.bos_token, self.eos_token, self.pad_token]:
+            for token in [self.start_token, self.end_token, self.pad_token]:
                 if token not in self.get_vocabulary():
                     raise ValueError(
                         f"Cannot find token `'{token}'` in the provided "
@@ -102,12 +102,12 @@ class BloomTokenizer(BytePairTokenizer):
                         "your `vocabulary` or use a pretrained `vocabulary` name."
                     )
 
-            self.bos_token_id = self.token_to_id(self.bos_token)
-            self.eos_token_id = self.token_to_id(self.eos_token)
+            self.start_token_id = self.token_to_id(self.start_token)
+            self.end_token_id = self.token_to_id(self.end_token)
             self.pad_token_id = self.token_to_id(self.pad_token)
         else:
-            self.bos_token_id = None
-            self.eos_token_id = None
+            self.start_token_id = None
+            self.end_token_id = None
             self.pad_token_id = None
 
     @classproperty

--- a/tools/checkpoint_conversion/convert_bloom_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_bloom_checkpoints.py
@@ -36,7 +36,7 @@ PRESET_MAP = {
     "bloom_1.1b_multi": "bigscience/bloom-1b1",
     "bloom_1.7b_multi": "bigscience/bloom-1b7",
     "bloom_3b_multi": "bigscience/bloom-3b",
-    "bloom_7b_multi": "bigscience/bloom-7b1",
+    "bloom_7b1_multi": "bigscience/bloom-7b1",
     "bloom_multi": "bigscience/bloom",
     # Multitask finetuned on xP3 (Crosslingual Public Pool of Prompts) https://huggingface.co/datasets/bigscience/xP3
     # xP3 is a mixture of 13 training tasks in 46 languages with English prompts
@@ -44,16 +44,16 @@ PRESET_MAP = {
     "bloomz_1.1b_multi": "bigscience/bloomz-1b1",
     "bloomz_1.7b_multi": "bigscience/bloomz-1b7",
     "bloomz_3b_multi": "bigscience/bloomz-3b",
-    "bloomz_7b_multi": "bigscience/bloomz-7b1",
+    "bloomz_7b1_multi": "bigscience/bloomz-7b1",
     "bloomz_multi": "bigscience/bloomz",
     # Multitask finetuned on P3 (Public Pool of Prompts) https://huggingface.co/datasets/Muennighoff/P3
     # xP3mt is Mixture of 13 training tasks in 46 languages with prompts in 20 
     # languages (machine-translated from English)
-    "bloomz_7b_mt": "bigscience/bloomz-7b1-mt",
+    "bloomz_7b1_mt": "bigscience/bloomz-7b1-mt",
     "bloomz_mt": "bigscience/bloomz-mt",
     # Multitask finetuned on P3 (Public Pool of Prompts) https://huggingface.co/datasets/Muennighoff/P3
     # xP3 is a mixture of 8 training tasks with English-only prompts
-    "bloomz_7b_p3": "bigscience/bloomz-7b1-p3",
+    "bloomz_7b1_p3": "bigscience/bloomz-7b1-p3",
     "bloomz_p3": "bigscience/bloomz-p3",
 }
 

--- a/tools/checkpoint_conversion/convert_bloom_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_bloom_checkpoints.py
@@ -36,7 +36,7 @@ PRESET_MAP = {
     "bloom_1.1b_multi": "bigscience/bloom-1b1",
     "bloom_1.7b_multi": "bigscience/bloom-1b7",
     "bloom_3b_multi": "bigscience/bloom-3b",
-    "bloom_7b1_multi": "bigscience/bloom-7b1",
+    "bloom_7b_multi": "bigscience/bloom-7b1",
     "bloom_multi": "bigscience/bloom",
     # Multitask finetuned on xP3 (Crosslingual Public Pool of Prompts) https://huggingface.co/datasets/bigscience/xP3
     # xP3 is a mixture of 13 training tasks in 46 languages with English prompts
@@ -44,16 +44,16 @@ PRESET_MAP = {
     "bloomz_1.1b_multi": "bigscience/bloomz-1b1",
     "bloomz_1.7b_multi": "bigscience/bloomz-1b7",
     "bloomz_3b_multi": "bigscience/bloomz-3b",
-    "bloomz_7b1_multi": "bigscience/bloomz-7b1",
+    "bloomz_7b_multi": "bigscience/bloomz-7b1",
     "bloomz_multi": "bigscience/bloomz",
     # Multitask finetuned on P3 (Public Pool of Prompts) https://huggingface.co/datasets/Muennighoff/P3
     # xP3mt is Mixture of 13 training tasks in 46 languages with prompts in 20 
     # languages (machine-translated from English)
-    "bloomz_7b1_mt": "bigscience/bloomz-7b1-mt",
+    "bloomz_7b_mt": "bigscience/bloomz-7b1-mt",
     "bloomz_mt": "bigscience/bloomz-mt",
     # Multitask finetuned on P3 (Public Pool of Prompts) https://huggingface.co/datasets/Muennighoff/P3
     # xP3 is a mixture of 8 training tasks with English-only prompts
-    "bloomz_7b1_p3": "bigscience/bloomz-7b1-p3",
+    "bloomz_7b_p3": "bigscience/bloomz-7b1-p3",
     "bloomz_p3": "bigscience/bloomz-p3",
 }
 

--- a/tools/checkpoint_conversion/convert_bloom_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_bloom_checkpoints.py
@@ -254,7 +254,11 @@ def main(_):
         keras_tokenizer,
     )
     print("✅ Numerics validated")
-
+    
+    # Delete huggingface model
+    del hf_model
+    del hf_tokenizer
+    # Save keras preset
     keras_nlp.src.utils.preset_utils.save_to_preset(keras_model, preset)
     keras_nlp.src.utils.preset_utils.save_to_preset(
         keras_tokenizer, preset, config_filename="tokenizer.json"

--- a/tools/checkpoint_conversion/convert_bloom_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_bloom_checkpoints.py
@@ -71,7 +71,7 @@ def download_hf_model(hf_model_name):
     hf_model_dir = huggingface_hub.snapshot_download(
         repo_id=hf_model_name,
         allow_patterns=["*.json", "*.bin"],
-        ignore_patterns=["*/"],
+        ignore_patterns=["*/*"],
         local_dir=EXTRACT_DIR,
     )
 

--- a/tools/checkpoint_conversion/convert_bloom_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_bloom_checkpoints.py
@@ -33,16 +33,16 @@ FLAGS = flags.FLAGS
 
 PRESET_MAP = {
     "bloom_560m_multi": "bigscience/bloom-560m",
-    "bloom_1.1b_multi": "bigscience/bloom-1b1",
-    "bloom_1.7b_multi": "bigscience/bloom-1b7",
+    "bloom_1b1_multi": "bigscience/bloom-1b1",
+    "bloom_1b7_multi": "bigscience/bloom-1b7",
     "bloom_3b_multi": "bigscience/bloom-3b",
     "bloom_7b_multi": "bigscience/bloom-7b1",
     "bloom_multi": "bigscience/bloom",
     # Multitask finetuned on xP3 (Crosslingual Public Pool of Prompts) https://huggingface.co/datasets/bigscience/xP3
     # xP3 is a mixture of 13 training tasks in 46 languages with English prompts
     "bloomz_560m_multi": "bigscience/bloomz-560m",
-    "bloomz_1.1b_multi": "bigscience/bloomz-1b1",
-    "bloomz_1.7b_multi": "bigscience/bloomz-1b7",
+    "bloomz_1b1_multi": "bigscience/bloomz-1b1",
+    "bloomz_1b7_multi": "bigscience/bloomz-1b7",
     "bloomz_3b_multi": "bigscience/bloomz-3b",
     "bloomz_7b_multi": "bigscience/bloomz-7b1",
     "bloomz_multi": "bigscience/bloomz",

--- a/tools/checkpoint_conversion/convert_bloom_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_bloom_checkpoints.py
@@ -15,19 +15,16 @@
 import json
 import os
 
-os.environ["KERAS_BACKEND"] = "torch"
-os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+import huggingface_hub
+import numpy as np
+import transformers
+from absl import app
+from absl import flags
 
-import huggingface_hub  # noqa: E402
-import numpy as np  # noqa: E402
-import torch  # noqa: E402
-import transformers  # noqa: E402
-from absl import app  # noqa: E402
-from absl import flags  # noqa: E402
-
-import keras_nlp  # noqa: E402
-from keras_nlp.models import BloomBackbone  # noqa: E402
-from keras_nlp.models import BloomTokenizer  # noqa: E402
+import keras_nlp
+from keras_nlp.models import BloomBackbone
+from keras_nlp.models import BloomPreprocessor
+from keras_nlp.models import BloomTokenizer
 
 FLAGS = flags.FLAGS
 
@@ -117,51 +114,61 @@ def convert_weights(keras_model, hf_model):
     # assign huggingface weights to the keras model.
     # Embedding layer.
     keras_model.get_layer("token_embedding").embeddings.assign(
-        hf_wts["word_embeddings.weight"]
+        hf_wts["word_embeddings.weight"].detach().numpy()
     )
     # LayerNorm.
     keras_model.get_layer("token_embedding_layernorm").gamma.assign(
-        hf_wts["word_embeddings_layernorm.weight"]
+        hf_wts["word_embeddings_layernorm.weight"].detach().numpy()
     )
     keras_model.get_layer("token_embedding_layernorm").beta.assign(
-        hf_wts["word_embeddings_layernorm.bias"]
+        hf_wts["word_embeddings_layernorm.bias"].detach().numpy()
     )
 
-    keras_model.get_layer("final_layernorm").gamma.assign(hf_wts["ln_f.weight"])
-    keras_model.get_layer("final_layernorm").beta.assign(hf_wts["ln_f.bias"])
+    keras_model.get_layer("final_layernorm").gamma.assign(
+        hf_wts["ln_f.weight"].detach().numpy()
+    )
+    keras_model.get_layer("final_layernorm").beta.assign(
+        hf_wts["ln_f.bias"].detach().numpy()
+    )
 
     # Decoder layers.
     for i in range(num_layers):
         decoder_layer = keras_model.get_layer(f"transformer_layer_{i}")
         # LayrNorm.
         decoder_layer._pre_attention_layernorm.gamma.assign(
-            hf_wts[f"h.{i}.input_layernorm.weight"]
+            hf_wts[f"h.{i}.input_layernorm.weight"].detach().numpy()
         )
         decoder_layer._pre_attention_layernorm.beta.assign(
-            hf_wts[f"h.{i}.input_layernorm.bias"]
+            hf_wts[f"h.{i}.input_layernorm.bias"].detach().numpy()
         )
         decoder_layer._post_attention_layernorm.gamma.assign(
-            hf_wts[f"h.{i}.post_attention_layernorm.weight"]
+            hf_wts[f"h.{i}.post_attention_layernorm.weight"].detach().numpy()
         )
         decoder_layer._post_attention_layernorm.beta.assign(
-            hf_wts[f"h.{i}.post_attention_layernorm.bias"]
+            hf_wts[f"h.{i}.post_attention_layernorm.bias"].detach().numpy()
         )
 
         # Attention layer.
         attention_layer = decoder_layer._self_attention_layer
 
-        fused_qkv_kernal = hf_wts[
-            f"h.{i}.self_attention.query_key_value.weight"
-        ].T
-        fused_qkv_kernal = fused_qkv_kernal.view(
+        fused_qkv_kernal = (
+            hf_wts[f"h.{i}.self_attention.query_key_value.weight"]
+            .T.detach()
+            .numpy()
+        )
+        fused_qkv_kernal = fused_qkv_kernal.reshape(
             hidden_dim, num_heads, 3, head_dim
         )
         query_kernal = fused_qkv_kernal[..., 0, :]
         key_kernal = fused_qkv_kernal[..., 1, :]
         value_kernl = fused_qkv_kernal[..., 2, :]
 
-        fused_qkv_bais = hf_wts[f"h.{i}.self_attention.query_key_value.bias"]
-        fused_qkv_bais = fused_qkv_bais.view(num_heads, 3, head_dim)
+        fused_qkv_bais = (
+            hf_wts[f"h.{i}.self_attention.query_key_value.bias"]
+            .detach()
+            .numpy()
+        )
+        fused_qkv_bais = fused_qkv_bais.reshape(num_heads, 3, head_dim)
         query_bais = fused_qkv_bais[:, 0, :]
         key_bais = fused_qkv_bais[:, 1, :]
         value_bais = fused_qkv_bais[:, 2, :]
@@ -174,24 +181,24 @@ def convert_weights(keras_model, hf_model):
         attention_layer._value_dense.bias.assign(value_bais)
 
         attention_layer._output_dense.kernel.assign(
-            hf_wts[f"h.{i}.self_attention.dense.weight"].T
+            hf_wts[f"h.{i}.self_attention.dense.weight"].T.detach().numpy()
         )
         attention_layer._output_dense.bias.assign(
-            hf_wts[f"h.{i}.self_attention.dense.bias"]
+            hf_wts[f"h.{i}.self_attention.dense.bias"].detach().numpy()
         )
 
         # mlp.
         decoder_layer._mlp_intermediate_dense.kernel.assign(
-            hf_wts[f"h.{i}.mlp.dense_h_to_4h.weight"].T
+            hf_wts[f"h.{i}.mlp.dense_h_to_4h.weight"].T.detach().numpy()
         )
         decoder_layer._mlp_intermediate_dense.bias.assign(
-            hf_wts[f"h.{i}.mlp.dense_h_to_4h.bias"]
+            hf_wts[f"h.{i}.mlp.dense_h_to_4h.bias"].detach().numpy()
         )
         decoder_layer._mlp_output_dense.kernel.assign(
-            hf_wts[f"h.{i}.mlp.dense_4h_to_h.weight"].T
+            hf_wts[f"h.{i}.mlp.dense_4h_to_h.weight"].T.detach().numpy()
         )
         decoder_layer._mlp_output_dense.bias.assign(
-            hf_wts[f"h.{i}.mlp.dense_4h_to_h.bias"]
+            hf_wts[f"h.{i}.mlp.dense_4h_to_h.bias"].detach().numpy()
         )
 
 
@@ -203,19 +210,20 @@ def validate_output(
 ):
     input_str = ["the quick brown fox ran, galloped and jumped."]
 
-    # KerasNLP
-    token_ids = torch.tensor(keras_tokenizer(input_str))
-    padding_mask = token_ids != 3
-    keras_model_input = {
-        "token_ids": token_ids,
-        "padding_mask": padding_mask,
-    }
-    keras_model_outputs = keras_model.predict(keras_model_input)
-
+    # HuggingFace
     hf_model_input = hf_tokenizer(input_str, return_tensors="pt")
-
     hf_model_outputs = hf_model(**hf_model_input).last_hidden_state
     hf_model_outputs = hf_model_outputs.detach().numpy()
+
+    # KerasNLP
+    preprocessor = BloomPreprocessor(
+        tokenizer=keras_tokenizer,
+        sequence_length=hf_model_outputs.shape[1],
+        add_end_token=False,
+        add_start_token=False,
+    )
+    keras_model_input = preprocessor(input_str)
+    keras_model_outputs = keras_model.predict(keras_model_input)
 
     # Comparing the outputs.
     print("🔶 KerasNLP output:", keras_model_outputs[0, 0, :10])
@@ -236,7 +244,9 @@ def main(_):
     hf_model_dir = download_hf_model(hf_model_name)
     print("✅ Huggingface model downloaded from hub")
 
-    hf_model = transformers.BloomModel.from_pretrained(hf_model_dir)
+    hf_model = transformers.BloomModel.from_pretrained(
+        hf_model_dir,
+    )
     hf_tokenizer = transformers.BloomTokenizerFast.from_pretrained(hf_model_dir)
     print("✅ Huggingface model loaded")
 
@@ -254,15 +264,27 @@ def main(_):
         keras_tokenizer,
     )
     print("✅ Numerics validated")
-    
+
     # Delete huggingface model
     del hf_model
     del hf_tokenizer
-    # Save keras preset
+
+    # Save float32 keras preset
+    keras_nlp.src.utils.preset_utils.save_to_preset(keras_model, preset)
+
+    # Delete float32 Keras model
+    del keras_model
+
+    # Load The model in float16 percision
+    preset_path = os.path.join(os.getcwd(), preset)
+    keras_model = BloomBackbone.from_preset(preset_path, dtype="float16")
+
+    # Save float16 keras model
     keras_nlp.src.utils.preset_utils.save_to_preset(keras_model, preset)
     keras_nlp.src.utils.preset_utils.save_to_preset(
         keras_tokenizer, preset, config_filename="tokenizer.json"
     )
+
     print("✅ Preset saved")
 
 

--- a/tools/checkpoint_conversion/convert_bloom_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_bloom_checkpoints.py
@@ -37,7 +37,24 @@ PRESET_MAP = {
     "bloom_1.7b_multi": "bigscience/bloom-1b7",
     "bloom_3b_multi": "bigscience/bloom-3b",
     "bloom_7b_multi": "bigscience/bloom-7b1",
-    "bloom_176b_multi": "bigscience/bloom",
+    "bloom_multi": "bigscience/bloom",
+    # Multitask finetuned on xP3 (Crosslingual Public Pool of Prompts) https://huggingface.co/datasets/bigscience/xP3
+    # xP3 is a mixture of 13 training tasks in 46 languages with English prompts
+    "bloomz_560m_multi": "bigscience/bloomz-560m",
+    "bloomz_1.1b_multi": "bigscience/bloomz-1b1",
+    "bloomz_1.7b_multi": "bigscience/bloomz-1b7",
+    "bloomz_3b_multi": "bigscience/bloomz-3b",
+    "bloomz_7b_multi": "bigscience/bloomz-7b1",
+    "bloomz_multi": "bigscience/bloomz",
+    # Multitask finetuned on P3 (Public Pool of Prompts) https://huggingface.co/datasets/Muennighoff/P3
+    # xP3mt is Mixture of 13 training tasks in 46 languages with prompts in 20 
+    # languages (machine-translated from English)
+    "bloomz_7b_mt": "bigscience/bloomz-7b1-mt",
+    "bloomz_mt": "bigscience/bloomz-mt",
+    # Multitask finetuned on P3 (Public Pool of Prompts) https://huggingface.co/datasets/Muennighoff/P3
+    # xP3 is a mixture of 8 training tasks with English-only prompts
+    "bloomz_7b_p3": "bigscience/bloomz-7b1-p3",
+    "bloomz_p3": "bigscience/bloomz-p3",
 }
 
 EXTRACT_DIR = "./model"
@@ -53,7 +70,7 @@ def download_hf_model(hf_model_name):
     hf_model_dir = huggingface_hub.snapshot_download(
         repo_id=hf_model_name,
         allow_patterns=["*.json", "*.bin"],
-        ignore_patterns=["onnx/*"],
+        ignore_patterns=["*/"],
         local_dir=EXTRACT_DIR,
     )
 

--- a/tools/checkpoint_conversion/convert_bloom_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_bloom_checkpoints.py
@@ -46,8 +46,9 @@ PRESET_MAP = {
     "bloomz_3b_multi": "bigscience/bloomz-3b",
     "bloomz_7b_multi": "bigscience/bloomz-7b1",
     "bloomz_multi": "bigscience/bloomz",
-    # Multitask finetuned on P3 (Public Pool of Prompts) https://huggingface.co/datasets/Muennighoff/P3
-    # xP3mt is Mixture of 13 training tasks in 46 languages with prompts in 20 
+    # Multitask finetuned on xP3mt
+    # (Crosslingual Public Pool of Prompts machine-translated) https://huggingface.co/datasets/bigscience/xP3
+    # xP3mt is Mixture of 13 training tasks in 46 languages with prompts in 20
     # languages (machine-translated from English)
     "bloomz_7b_mt": "bigscience/bloomz-7b1-mt",
     "bloomz_mt": "bigscience/bloomz-mt",

--- a/tools/checkpoint_conversion/convert_bloom_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_bloom_checkpoints.py
@@ -30,16 +30,16 @@ FLAGS = flags.FLAGS
 
 PRESET_MAP = {
     "bloom_560m_multi": "bigscience/bloom-560m",
-    "bloom_1b1_multi": "bigscience/bloom-1b1",
-    "bloom_1b7_multi": "bigscience/bloom-1b7",
+    "bloom_1.1b_multi": "bigscience/bloom-1b1",
+    "bloom_1.7b_multi": "bigscience/bloom-1b7",
     "bloom_3b_multi": "bigscience/bloom-3b",
     "bloom_7b_multi": "bigscience/bloom-7b1",
     "bloom_multi": "bigscience/bloom",
     # Multitask finetuned on xP3 (Crosslingual Public Pool of Prompts) https://huggingface.co/datasets/bigscience/xP3
     # xP3 is a mixture of 13 training tasks in 46 languages with English prompts
     "bloomz_560m_multi": "bigscience/bloomz-560m",
-    "bloomz_1b1_multi": "bigscience/bloomz-1b1",
-    "bloomz_1b7_multi": "bigscience/bloomz-1b7",
+    "bloomz_1.1b_multi": "bigscience/bloomz-1b1",
+    "bloomz_1.7b_multi": "bigscience/bloomz-1b7",
     "bloomz_3b_multi": "bigscience/bloomz-3b",
     "bloomz_7b_multi": "bigscience/bloomz-7b1",
     "bloomz_multi": "bigscience/bloomz",


### PR DESCRIPTION
This PR:
- adds `BloomCausalLM`
I have compared `BloomCausalLM` with the huggingface output and both produces similar output

This is hf output with no start_token
![hf_with_no_ s](https://github.com/keras-team/keras-nlp/assets/64566340/49999f98-2b51-42d9-9b38-9269b5679fb8).


 This is keras output with no start_token
![keras_with_no_ s](https://github.com/keras-team/keras-nlp/assets/64566340/5086ea30-4914-413c-8e5d-92e9911bd89d).


 this is keras output with start_token (default)
![keras_with_ s](https://github.com/keras-team/keras-nlp/assets/64566340/a5abea5f-4986-411a-bdf6-8b8c0e128b1e).


- Fixes small nit in `AlibiBias`
when keras dtype is `float16` in the causalLM test, `AlibiBias` called `arange` function with dtype=int16 which causes error in tensorflow (I think). also this fix is the same in this PR keras-team/keras-nlp#1389.
- Adds the BLOOMz presets to the conversion script
BLOOMZ models are fintuned versions of the pretrained models and are better and recommended to use by bigscience
![bloom vs bloomz](https://github.com/keras-team/keras-nlp/assets/64566340/f483a39a-fe5b-4450-9fa9-ca36beeadd87)
reference: https://arxiv.org/abs/2211.01786 