### PR TITLE
Add an annotation to tests that need kaggle auth

### DIFF
--- a/keras_nlp/conftest.py
+++ b/keras_nlp/conftest.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import pytest
 import tensorflow as tf
 
@@ -83,6 +85,10 @@ def pytest_configure(config):
         "markers",
         "keras_3_only: mark test as a keras 3 only test",
     )
+    config.addinivalue_line(
+        "markers",
+        "kaggle_key_required: mark test needing a kaggle key",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -107,6 +113,16 @@ def pytest_collection_modifyitems(config, items):
         not backend_config.keras_3(),
         reason="tests only run on with multi-backend keras",
     )
+    found_kaggle_key = all(
+        [
+            os.environ.get("KAGGLE_USERNAME", None),
+            os.environ.get("KAGGLE_KEY", None),
+        ]
+    )
+    kaggle_key_required = pytest.mark.skipif(
+        not found_kaggle_key,
+        reason="tests only run with a kaggle api key",
+    )
     for item in items:
         if "large" in item.keywords:
             item.add_marker(skip_large)
@@ -116,6 +132,8 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(tf_only)
         if "keras_3_only" in item.keywords:
             item.add_marker(keras_3_only)
+        if "kaggle_key_required" in item.keywords:
+            item.add_marker(kaggle_key_required)
 
 
 # Disable traceback filtering for quicker debugging of tests failures.

--- a/keras_nlp/models/gemma/gemma_backbone_test.py
+++ b/keras_nlp/models/gemma/gemma_backbone_test.py
@@ -53,6 +53,7 @@ class GemmaBackboneTest(TestCase):
             input_data=self.input_data,
         )
 
+    @pytest.mark.kaggle_key_required
     @pytest.mark.large
     def test_smallest_preset(self):
         self.run_preset_test(
@@ -69,6 +70,7 @@ class GemmaBackboneTest(TestCase):
             ),
         )
 
+    @pytest.mark.kaggle_key_required
     @pytest.mark.extra_large
     def test_all_presets(self):
         for preset in GemmaBackbone.presets:

--- a/keras_nlp/models/gemma/gemma_causal_lm_preprocessor_test.py
+++ b/keras_nlp/models/gemma/gemma_causal_lm_preprocessor_test.py
@@ -82,6 +82,7 @@ class GemmaCausalLMPreprocessorTest(TestCase):
         x = preprocessor.generate_postprocess(input_data)
         self.assertAllEqual(x, "the quick brown fox")
 
+    @pytest.mark.kaggle_key_required
     @pytest.mark.extra_large
     def test_all_presets(self):
         for preset in GemmaCausalLMPreprocessor.presets:

--- a/keras_nlp/models/gemma/gemma_causal_lm_test.py
+++ b/keras_nlp/models/gemma/gemma_causal_lm_test.py
@@ -142,6 +142,7 @@ class GemmaCausalLMTest(TestCase):
         causal_lm.compile(sampler="greedy")
         self.assertIsNone(causal_lm.generate_function)
 
+    @pytest.mark.kaggle_key_required
     @pytest.mark.large
     def test_saved_model(self):
         self.run_model_saving_test(
@@ -150,6 +151,7 @@ class GemmaCausalLMTest(TestCase):
             input_data=self.input_data,
         )
 
+    @pytest.mark.kaggle_key_required
     @pytest.mark.extra_large
     def test_all_presets(self):
         for preset in GemmaCausalLM.presets:

--- a/keras_nlp/models/gemma/gemma_preprocessor_test.py
+++ b/keras_nlp/models/gemma/gemma_preprocessor_test.py
@@ -64,6 +64,7 @@ class GemmaPreprocessorTest(TestCase):
         x = preprocessor(input_data, sequence_length=4)
         self.assertAllEqual(x["token_ids"], [1, 4, 9, 2])
 
+    @pytest.mark.kaggle_key_required
     @pytest.mark.extra_large
     def test_all_presets(self):
         for preset in GemmaPreprocessor.presets:

--- a/keras_nlp/models/gemma/gemma_tokenizer_test.py
+++ b/keras_nlp/models/gemma/gemma_tokenizer_test.py
@@ -48,6 +48,7 @@ class GemmaTokenizerTest(TestCase):
                 )
             )
 
+    @pytest.mark.kaggle_key_required
     @pytest.mark.large
     def test_smallest_preset(self):
         self.run_preset_test(
@@ -57,6 +58,7 @@ class GemmaTokenizerTest(TestCase):
             expected_output=[[651, 4320, 8426, 25341, 235265]],
         )
 
+    @pytest.mark.kaggle_key_required
     @pytest.mark.extra_large
     def test_all_presets(self):
         for preset in GemmaTokenizer.presets:


### PR DESCRIPTION
We can skip these by default, for users who have not yet set them up. We will need to set them up for CI, see
https://github.com/keras-team/keras-nlp/pull/1459