### PR TITLE
Fix gemma rms_normalization's use of epsilon

### DIFF
--- a/keras_nlp/models/gemma/rms_normalization.py
+++ b/keras_nlp/models/gemma/rms_normalization.py
@@ -35,6 +35,6 @@ class RMSNormalization(keras.layers.Layer):
         x = ops.cast(x, "float32")
         scale = ops.cast(self.scale, "float32")
         var = ops.mean(ops.square(x), axis=-1, keepdims=True)
-        normed_inputs = x * ops.reciprocal(ops.sqrt(var + 1e-06))
+        normed_inputs = x * ops.reciprocal(ops.sqrt(var + self.epsilon))
         normed_inputs = normed_inputs * (1 + scale)
         return ops.cast(normed_inputs, self.compute_dtype)


### PR DESCRIPTION
Hi wonderful Keras folks,

I was browsing the new Gemma source and noticed that the RMSNorm code didn't use the epsilon parameter it takes in. This fixes that.

While we're here, I'm curious what drove the 1+scale multiplier (instead of just initializing scale to 1). Would love to learn if you're down to share.

Thanks,
Chris
(ex-Googler)