### PR TITLE
Pin to TF 2.16 RC0

### DIFF
--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -1,6 +1,6 @@
 # Tensorflow cpu-only version.
-tf-nightly-cpu==2.16.0.dev20240201  # Pin a working nightly until rc0.
-tensorflow-text-nightly==2.16.0.dev20240201  # Pin a working nightly until rc0.
+tensorflow-cpu==2.16.0rc0  # Pin to rc until TF 2.16 release
+tensorflow-text==2.16.0rc0
 
 # Torch cpu-only version.
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -1,6 +1,6 @@
 # Tensorflow with cuda support.
-tf-nightly[and-cuda]==2.16.0.dev20240201  # Pin a working nightly until rc0.
-tensorflow-text-nightly==2.16.0.dev20240201  # Pin a working nightly until rc0.
+tensorflow[and-cuda]==2.16.0rc0  # Pin to rc until TF 2.16 release
+tensorflow-text==2.16.0rc0
 
 # Torch cpu-only version.
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -1,6 +1,6 @@
 # Tensorflow cpu-only version.
-tf-nightly-cpu==2.16.0.dev20240201  # Pin a working nightly until rc0.
-tensorflow-text-nightly==2.16.0.dev20240201  # Pin a working nightly until rc0.
+tensorflow-cpu==2.16.0rc0  # Pin to rc until TF 2.16 release
+tensorflow-text==2.16.0rc0
 
 # Torch with cuda support.
 --extra-index-url https://download.pytorch.org/whl/cu121

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Tensorflow.
-tf-nightly-cpu==2.16.0.dev20240201  # Pin a working nightly until rc0.
-tensorflow-text-nightly==2.16.0.dev20240201  # Pin a working nightly until rc0.
+tensorflow-cpu==2.16.0rc0  # Pin to rc until TF 2.16 release
+tensorflow-text==2.16.0rc0
 
 # Torch.
 --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
Now that 2.16 RC0 is out, use RC0 for CI.