### PR TITLE
Fix dtype accessors of tasks/backbones

### DIFF
--- a/keras_nlp/models/albert/albert_backbone.py
+++ b/keras_nlp/models/albert/albert_backbone.py
@@ -230,6 +230,7 @@ class AlbertBackbone(Backbone):
                 "sequence_output": sequence_output,
                 "pooled_output": pooled_output,
             },
+            dtype=dtype,
             **kwargs,
         )
 

--- a/keras_nlp/models/backbone.py
+++ b/keras_nlp/models/backbone.py
@@ -29,15 +29,14 @@ class Backbone(keras.Model):
         )
         self._initialized = True
         if dtype is not None:
-            if isinstance(dtype, keras.mixed_precision.DTypePolicy):
-                policy = dtype
-            else:
-                policy = keras.mixed_precision.DTypePolicy(dtype)
             # Keras 2 and Keras 3 handle setting policy differently.
             if config.keras_3():
-                self.dtype_policy = policy
+                if isinstance(dtype, keras.DTypePolicy):
+                    self.dtype_policy = dtype
+                else:
+                    self.dtype_policy = keras.DTypePolicy(dtype)
             else:
-                self._dtype_policty = policy
+                self._set_dtype_policy(dtype)
 
     def __dir__(self):
         if config.keras_3():
@@ -77,7 +76,7 @@ class Backbone(keras.Model):
 
         This layer embeds integer token ids to the hidden dim of the model.
         """
-        return self._token_embedding
+        return getattr(self, "_token_embedding", None)
 
     @token_embedding.setter
     def token_embedding(self, value):

--- a/keras_nlp/models/backbone.py
+++ b/keras_nlp/models/backbone.py
@@ -28,6 +28,16 @@ class Backbone(keras.Model):
             id(layer) for layer in self._flatten_layers()
         )
         self._initialized = True
+        if dtype is not None:
+            if isinstance(dtype, keras.mixed_precision.DTypePolicy):
+                policy = dtype
+            else:
+                policy = keras.mixed_precision.DTypePolicy(dtype)
+            # Keras 2 and Keras 3 handle setting policy differently.
+            if config.keras_3():
+                self.dtype_policy = policy
+            else:
+                self._dtype_policty = policy
 
     def __dir__(self):
         if config.keras_3():

--- a/keras_nlp/models/bart/bart_backbone.py
+++ b/keras_nlp/models/bart/bart_backbone.py
@@ -232,6 +232,7 @@ class BartBackbone(Backbone):
                 "encoder_sequence_output": encoder_output,
                 "decoder_sequence_output": decoder_output,
             },
+            dtype=dtype,
             **kwargs,
         )
 

--- a/keras_nlp/models/bert/bert_backbone.py
+++ b/keras_nlp/models/bert/bert_backbone.py
@@ -196,6 +196,7 @@ class BertBackbone(Backbone):
                 "sequence_output": sequence_output,
                 "pooled_output": pooled_output,
             },
+            dtype=dtype,
             **kwargs,
         )
 

--- a/keras_nlp/models/bloom/bloom_backbone.py
+++ b/keras_nlp/models/bloom/bloom_backbone.py
@@ -149,6 +149,7 @@ class BloomBackbone(Backbone):
                 "padding_mask": padding_mask_input,
             },
             outputs=sequence_output,
+            dtype=dtype,
             **kwargs,
         )
 

--- a/keras_nlp/models/deberta_v3/deberta_v3_backbone.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_backbone.py
@@ -178,6 +178,7 @@ class DebertaV3Backbone(Backbone):
                 "padding_mask": padding_mask_input,
             },
             outputs=x,
+            dtype=dtype,
             **kwargs,
         )
 

--- a/keras_nlp/models/distil_bert/distil_bert_backbone.py
+++ b/keras_nlp/models/distil_bert/distil_bert_backbone.py
@@ -159,6 +159,7 @@ class DistilBertBackbone(Backbone):
                 "padding_mask": padding_mask_input,
             },
             outputs=x,
+            dtype=dtype,
             **kwargs,
         )
 

--- a/keras_nlp/models/electra/electra_backbone.py
+++ b/keras_nlp/models/electra/electra_backbone.py
@@ -202,6 +202,7 @@ class ElectraBackbone(Backbone):
                 "sequence_output": sequence_output,
                 "pooled_output": pooled_output,
             },
+            dtype=dtype,
             **kwargs,
         )
 

--- a/keras_nlp/models/f_net/f_net_backbone.py
+++ b/keras_nlp/models/f_net/f_net_backbone.py
@@ -206,6 +206,7 @@ class FNetBackbone(Backbone):
                 "sequence_output": sequence_output,
                 "pooled_output": pooled_output,
             },
+            dtype=dtype,
             **kwargs,
         )
 

--- a/keras_nlp/models/falcon/falcon_backbone.py
+++ b/keras_nlp/models/falcon/falcon_backbone.py
@@ -130,6 +130,7 @@ class FalconBackbone(Backbone):
                 "padding_mask": padding_mask,
             },
             outputs=sequence_output,
+            dtype=dtype,
             **kwargs,
         )
 

--- a/keras_nlp/models/gemma/gemma_backbone.py
+++ b/keras_nlp/models/gemma/gemma_backbone.py
@@ -157,6 +157,7 @@ class GemmaBackbone(Backbone):
                 "padding_mask": padding_mask_input,
             },
             outputs=sequence_output,
+            dtype=dtype,
             **kwargs,
         )
 

--- a/keras_nlp/models/gpt2/gpt2_backbone.py
+++ b/keras_nlp/models/gpt2/gpt2_backbone.py
@@ -170,6 +170,7 @@ class GPT2Backbone(Backbone):
                 "padding_mask": padding_mask_input,
             },
             outputs=sequence_output,
+            dtype=dtype,
             **kwargs,
         )
 

--- a/keras_nlp/models/gpt_neo_x/gpt_neo_x_backbone.py
+++ b/keras_nlp/models/gpt_neo_x/gpt_neo_x_backbone.py
@@ -137,6 +137,7 @@ class GPTNeoXBackbone(Backbone):
                 "padding_mask": padding_mask_input,
             },
             outputs=sequence_output,
+            dtype=dtype,
             **kwargs,
         )
 

--- a/keras_nlp/models/llama/llama_backbone.py
+++ b/keras_nlp/models/llama/llama_backbone.py
@@ -127,6 +127,7 @@ class LlamaBackbone(Backbone):
                 "padding_mask": padding_mask_input,
             },
             outputs=sequence_output,
+            dtype=dtype,
             **kwargs,
         )
 

--- a/keras_nlp/models/mistral/mistral_backbone.py
+++ b/keras_nlp/models/mistral/mistral_backbone.py
@@ -166,6 +166,7 @@ class MistralBackbone(Backbone):
                 "padding_mask": padding_mask_input,
             },
             outputs=sequence_output,
+            dtype=dtype,
             **kwargs,
         )
 

--- a/keras_nlp/models/opt/opt_backbone.py
+++ b/keras_nlp/models/opt/opt_backbone.py
@@ -146,6 +146,7 @@ class OPTBackbone(Backbone):
                 "padding_mask": padding_mask_input,
             },
             outputs=x,
+            dtype=dtype,
             **kwargs,
         )
 

--- a/keras_nlp/models/roberta/roberta_backbone.py
+++ b/keras_nlp/models/roberta/roberta_backbone.py
@@ -156,6 +156,7 @@ class RobertaBackbone(Backbone):
                 "padding_mask": padding_mask_input,
             },
             outputs=x,
+            dtype=dtype,
             **kwargs,
         )
 

--- a/keras_nlp/models/t5/t5_backbone.py
+++ b/keras_nlp/models/t5/t5_backbone.py
@@ -224,6 +224,7 @@ class T5Backbone(Backbone):
                 "encoder_sequence_output": encoder_output,
                 "decoder_sequence_output": decoder_output,
             },
+            dtype=dtype,
             **kwargs,
         )
 

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -36,6 +36,12 @@ class Task(PipelineModel):
             id(layer) for layer in self._flatten_layers()
         )
         self._initialized = True
+        if self.backbone is not None:
+            # Keras 2 and Keras 3 handle setting policy differently.
+            if config.keras_3():
+                self.dtype_policy = self._backbone.dtype_policy
+            else:
+                self._set_dtype_policy(self._backbone.dtype_policy)
 
     def __dir__(self):
         if config.keras_3():
@@ -128,21 +134,16 @@ class Task(PipelineModel):
     @property
     def backbone(self):
         """A `keras.Model` instance providing the backbone sub-model."""
-        return self._backbone
+        return getattr(self, "_backbone", None)
 
     @backbone.setter
     def backbone(self, value):
         self._backbone = value
-        # Keras 2 and Keras 3 handle setting policy differently.
-        if config.keras_3():
-            self.dtype_policy = value.dtype_policy
-        else:
-            self._dtype_policty = value.dtype_policy
 
     @property
     def preprocessor(self):
         """A `keras.layers.Layer` instance used to preprocess inputs."""
-        return self._preprocessor
+        return getattr(self, "_preprocessor", None)
 
     @preprocessor.setter
     def preprocessor(self, value):

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -133,6 +133,11 @@ class Task(PipelineModel):
     @backbone.setter
     def backbone(self, value):
         self._backbone = value
+        # Keras 2 and Keras 3 handle setting policy differently.
+        if config.keras_3():
+            self.dtype_policy = value.dtype_policy
+        else:
+            self._dtype_policty = value.dtype_policy
 
     @property
     def preprocessor(self):

--- a/keras_nlp/models/whisper/whisper_backbone.py
+++ b/keras_nlp/models/whisper/whisper_backbone.py
@@ -274,6 +274,7 @@ class WhisperBackbone(Backbone):
                 "encoder_sequence_output": encoder_output,
                 "decoder_sequence_output": decoder_output,
             },
+            dtype=dtype,
             **kwargs,
         )
 

--- a/keras_nlp/models/xlnet/xlnet_backbone.py
+++ b/keras_nlp/models/xlnet/xlnet_backbone.py
@@ -184,6 +184,7 @@ class XLNetBackbone(Backbone):
                 "segment_ids": segment_id_input,
             },
             outputs=output,
+            dtype=dtype,
             **kwargs,
         )
 

--- a/keras_nlp/tests/test_case.py
+++ b/keras_nlp/tests/test_case.py
@@ -329,10 +329,10 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             for weight in layer.weights:
                 if is_float_dtype(weight.dtype):
                     self.assertDTypeEqual(weight, policy.variable_dtype)
-            for sublayer in layer._flatten_layers(include_self=False):
-                if isinstance(
-                    sublayer, (keras.layers.Softmax, keras.layers.InputLayer)
-                ):
+            for sublayer in layer._flatten_layers():
+                if isinstance(sublayer, keras.layers.Softmax):
+                    continue
+                if isinstance(sublayer, keras.layers.InputLayer):
                     continue
                 self.assertEqual(policy.compute_dtype, sublayer.compute_dtype)
                 self.assertEqual(policy.variable_dtype, sublayer.variable_dtype)


### PR DESCRIPTION
Makes sure we have the correct values for `task.compute_dtype`, `task.variable_dtype`, `backbone.compute_dtype` and `backbone.variable_dtype`.