### PR TITLE
Fixes for the LLaMA backbone + add dropout

### DIFF
--- a/keras_nlp/models/llama/llama_attention.py
+++ b/keras_nlp/models/llama/llama_attention.py
@@ -17,35 +17,34 @@ from keras_nlp.layers.modeling.rotary_embedding import RotaryEmbedding
 from keras_nlp.utils.keras_utils import clone_initializer
 
 
-class LlamaAttention(keras.layers.Layer):
-    """Grouped query attention for Llama models"""
+class CachedLlamaAttention(keras.layers.Layer):
+    """A cached grounded query attention layer with sliding window."""
 
     def __init__(
         self,
         num_query_heads,
         num_key_value_heads,
+        rope_max_wavelength=10000,
         rope_scaling_factor=1.0,
         kernel_initializer="glorot_uniform",
-        rope_max_wavelength=10000,
-        max_sequence_length=512,
+        dropout=0,
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.num_query_heads = num_query_heads
-        self.num_key_value_heads = num_key_value_heads
+        self._num_query_heads = num_query_heads
+        self._num_key_value_heads = num_key_value_heads
+        self._dropout = dropout
 
-        self.num_key_value_groups = num_query_heads // num_key_value_heads
+        self._num_key_value_groups = num_query_heads // num_key_value_heads
+        self._rope_max_wavelength = rope_max_wavelength
 
-        self.kernel_initializer = keras.initializers.get(kernel_initializer)
-        self.max_sequence_length = max_sequence_length
+        self._kernel_initializer = keras.initializers.get(
+            clone_initializer(kernel_initializer)
+        )
 
-        self.rope_scaling_factor = rope_scaling_factor
-        self.rope_max_wavelength = rope_max_wavelength
+        self._rope_scaling_factor = rope_scaling_factor
 
     def build(self, inputs_shape):
-        self.hidden_dim = inputs_shape[-1]
-        self.attn_head_size = self.hidden_dim // self.num_query_heads
-
         # Einsum variables:
         # b = batch size
         # q = query length
@@ -54,18 +53,26 @@ class LlamaAttention(keras.layers.Layer):
         # u = num query heads
         # v = num key/value heads
         # h = head dim
+        self._hidden_dim = inputs_shape[-1]
+        self._head_dim = self._hidden_dim // self._num_query_heads
+
         self._query_dense = keras.layers.EinsumDense(
             equation="bqm,muh->bquh",
-            output_shape=(None, self.num_query_heads, self.attn_head_size),
-            kernel_initializer=clone_initializer(self.kernel_initializer),
+            output_shape=(None, self._num_query_heads, self._head_dim),
+            kernel_initializer=self._kernel_initializer,
             dtype=self.dtype_policy,
             name="query",
         )
         self._query_dense.build(inputs_shape)
+
         self._key_dense = keras.layers.EinsumDense(
             equation="bkm,mvh->bkvh",
-            output_shape=(None, self.num_key_value_heads, self.attn_head_size),
-            kernel_initializer=clone_initializer(self.kernel_initializer),
+            output_shape=(
+                None,
+                self._num_key_value_heads,
+                self._head_dim,
+            ),
+            kernel_initializer=self._kernel_initializer,
             dtype=self.dtype_policy,
             name="key",
         )
@@ -73,8 +80,12 @@ class LlamaAttention(keras.layers.Layer):
 
         self._value_dense = keras.layers.EinsumDense(
             equation="bkm,mvh->bkvh",
-            output_shape=(None, self.num_key_value_heads, self.attn_head_size),
-            kernel_initializer=clone_initializer(self.kernel_initializer),
+            output_shape=(
+                None,
+                self._num_key_value_heads,
+                self._head_dim,
+            ),
+            kernel_initializer=self._kernel_initializer,
             dtype=self.dtype_policy,
             name="value",
         )
@@ -86,21 +97,30 @@ class LlamaAttention(keras.layers.Layer):
             name="attention_softmax",
         )
 
+        self._dropout_layer = keras.layers.Dropout(
+            rate=self._dropout,
+            dtype=self.dtype_policy,
+        )
+
         self._output_dense = keras.layers.EinsumDense(
-            equation="bqm,mh->bqh",
-            output_shape=(None, self.hidden_dim),
-            kernel_initializer=clone_initializer(self.kernel_initializer),
+            equation="bquh,uhm->bqm",
+            output_shape=(None, self._hidden_dim),
+            kernel_initializer=self._kernel_initializer,
             dtype=self.dtype_policy,
             name="attention_output",
         )
-        self._output_dense.build(inputs_shape)
+        self._output_dense.build(
+            (None, None, self._num_query_heads, self._head_dim)
+        )
 
-        self._rotary_embedding_layer = RotaryEmbedding(
-            max_wavelength=self.rope_max_wavelength,
-            scaling_factor=self.rope_scaling_factor,
+        self.rotary_embedding_layer = RotaryEmbedding(
+            max_wavelength=self._rope_max_wavelength,
+            scaling_factor=self._rope_scaling_factor,
             dtype=self.dtype_policy,
         )
-        self._rotary_embedding_layer.build(inputs_shape)
+
+        self._dot_product_equation = "bquh,bkuh->buqk"
+        self._combine_equation = "buqk,bkuh->bquh"
 
         self.built = True
 
@@ -110,6 +130,7 @@ class LlamaAttention(keras.layers.Layer):
         attention_mask=None,
         cache=None,
         cache_update_index=None,
+        training=None,
     ):
         query = self._query_dense(hidden_states)
 
@@ -136,75 +157,63 @@ class LlamaAttention(keras.layers.Layer):
             key = self._key_dense(hidden_states)
             value = self._value_dense(hidden_states)
 
-        query = self._rotary_embedding_layer(query)
-        key = self._rotary_embedding_layer(key)
+        query = self.rotary_embedding_layer(query)
+        key = self.rotary_embedding_layer(key)
 
-        key = ops.tile(key, [1, 1, self.num_key_value_groups, 1])
-        value = ops.tile(value, [1, 1, self.num_key_value_groups, 1])
+        # [batch_shape, seq_len, num_key_value_heads, head_dim]
+        # -> [batch_shape, seq_len, num_heads, head_dim]
+        key = ops.repeat(key, repeats=self._num_key_value_groups, axis=2)
+        value = ops.repeat(value, repeats=self._num_key_value_groups, axis=2)
 
-        attention_output, attention_scores = self._compute_attention(
+        attention_output = self._compute_attention(
             query, key, value, attention_mask
         )
 
-        attention_output_shape = ops.shape(attention_output)
-
-        attention_output = ops.reshape(
-            attention_output,
-            [
-                attention_output_shape[0],
-                attention_output_shape[1],
-                self.hidden_dim,
-            ],
+        attention_output = self._dropout_layer(
+            attention_output, training=training
         )
 
         attention_output = self._output_dense(attention_output)
 
         if cache is not None:
-            return (attention_output, cache)
+            return attention_output, cache
         return attention_output
 
     def _masked_softmax(self, attention_scores, attention_mask=None):
         if attention_mask is not None:
-            mask_expansion_axis = -3
-            for _ in range(
-                len(attention_scores.shape) - len(attention_mask.shape)
-            ):
-                attention_mask = ops.expand_dims(
-                    attention_mask, axis=mask_expansion_axis
-                )
-        return self._softmax(attention_scores, attention_mask)
+            return self._softmax(
+                attention_scores, attention_mask[:, None, :, :]
+            )
+        return self._softmax(attention_scores)
 
     def _compute_attention(self, query, key, value, attention_mask=None):
-        attention_scores = ops.einsum("aecd,abcd->acbe", key, query)
+        attention_scores = ops.einsum(self._dot_product_equation, query, key)
 
-        norm_factor = ops.sqrt(
-            ops.convert_to_tensor(self.attn_head_size, self.compute_dtype)
-        )
+        norm_factor = ops.sqrt(ops.cast(self._head_dim, self.compute_dtype))
 
-        attention_scores /= norm_factor
+        attention_scores = attention_scores / norm_factor
         attention_scores = self._masked_softmax(
             attention_scores, attention_mask
         )
         attention_scores = ops.cast(attention_scores, self.compute_dtype)
         attention_output = ops.einsum(
-            "acbe,aecd->abcd", attention_scores, value
+            self._combine_equation, attention_scores, value
         )
 
-        return attention_output, attention_scores
+        return attention_output
 
     def get_config(self):
         config = super().get_config()
         config.update(
             {
-                "num_query_heads": self.num_query_heads,
-                "hidden_dim": self.hidden_dim,
+                "num_query_heads": self._num_query_heads,
+                "num_key_value_heads": self._num_key_value_heads,
+                "rope_max_wavelength": self._rope_max_wavelength,
+                "rope_scaling_factor": self._rope_scaling_factor,
                 "kernel_initializer": keras.initializers.serialize(
-                    self.kernel_initializer
+                    self._kernel_initializer
                 ),
-                "rope_max_wavelength": self.rope_max_wavelength,
-                "rope_scaling_factor": self.rope_scaling_factor,
-                "num_key_value_heads": self.num_key_value_heads,
-                "max_sequence_length": self.max_sequence_length,
+                "dropout": self._dropout,
             }
         )
         return config

--- a/keras_nlp/models/llama/llama_backbone_test.py
+++ b/keras_nlp/models/llama/llama_backbone_test.py
@@ -28,7 +28,6 @@ class LlamaTest(TestCase):
             "num_key_value_heads": 2,
             "hidden_dim": 8,
             "intermediate_dim": 8,
-            "max_sequence_length": 10,
         }
         self.input_data = {
             "token_ids": ops.ones((2, 5), dtype="int32"),

--- a/keras_nlp/models/llama/llama_decoder.py
+++ b/keras_nlp/models/llama/llama_decoder.py
@@ -19,7 +19,7 @@ from keras_nlp.layers.modeling.transformer_layer_utils import (
 from keras_nlp.layers.modeling.transformer_layer_utils import (
     merge_padding_and_attention_mask,
 )
-from keras_nlp.models.llama.llama_attention import CachedLlamaAttention
+from keras_nlp.models.llama.llama_attention import LlamaAttention
 from keras_nlp.models.llama.llama_layernorm import LlamaLayerNorm
 from keras_nlp.utils.keras_utils import clone_initializer
 
@@ -61,7 +61,7 @@ class LlamaTransformerDecoder(keras.layers.Layer):
         self.hidden_dim = decoder_sequence_shape[-1]
 
         # Self attention layer.
-        self._self_attention_layer = CachedLlamaAttention(
+        self._self_attention_layer = LlamaAttention(
             num_query_heads=self.num_query_heads,
             num_key_value_heads=self.num_key_value_heads,
             rope_max_wavelength=self.rope_max_wavelength,

--- a/keras_nlp/models/llama/llama_decoder.py
+++ b/keras_nlp/models/llama/llama_decoder.py
@@ -19,25 +19,25 @@ from keras_nlp.layers.modeling.transformer_layer_utils import (
 from keras_nlp.layers.modeling.transformer_layer_utils import (
     merge_padding_and_attention_mask,
 )
-from keras_nlp.models.llama.llama_attention import LlamaAttention
+from keras_nlp.models.llama.llama_attention import CachedLlamaAttention
 from keras_nlp.models.llama.llama_layernorm import LlamaLayerNorm
 from keras_nlp.utils.keras_utils import clone_initializer
 
 
-class LlamaDecoder(keras.layers.Layer):
-    """Llama decoder block."""
+class LlamaTransformerDecoder(keras.layers.Layer):
+    """A Transformer decoder layer for the Llama backbone."""
 
     def __init__(
         self,
         intermediate_dim,
         num_query_heads,
         num_key_value_heads,
+        rope_max_wavelength=10000,
         rope_scaling_factor=1.0,
-        activation="relu",
+        activation="silu",
         layer_norm_epsilon=1e-5,
         kernel_initializer="glorot_uniform",
-        rope_max_wavelength=10000,
-        max_sequence_length=512,
+        dropout=0,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -48,37 +48,50 @@ class LlamaDecoder(keras.layers.Layer):
         self.rope_max_wavelength = rope_max_wavelength
         self.rope_scaling_factor = rope_scaling_factor
 
-        self.max_sequence_length = max_sequence_length
+        self.dropout = dropout
+
         self.activation = keras.activations.get(activation)
         self.layer_norm_epsilon = layer_norm_epsilon
         self.kernel_initializer = keras.initializers.get(kernel_initializer)
 
+        self.supports_masking = True
+
     def build(self, decoder_sequence_shape):
+        self._decoder_sequence_shape = decoder_sequence_shape
         self.hidden_dim = decoder_sequence_shape[-1]
 
-        # Self attention layers.
-        self._self_attention_layer = LlamaAttention(
+        # Self attention layer.
+        self._self_attention_layer = CachedLlamaAttention(
             num_query_heads=self.num_query_heads,
             num_key_value_heads=self.num_key_value_heads,
             rope_max_wavelength=self.rope_max_wavelength,
-            max_sequence_length=self.max_sequence_length,
             rope_scaling_factor=self.rope_scaling_factor,
             kernel_initializer=clone_initializer(self.kernel_initializer),
+            dropout=self.dropout,
             dtype=self.dtype_policy,
+            name="self_attention",
         )
         self._self_attention_layer.build(decoder_sequence_shape)
 
         self._self_attention_layernorm = LlamaLayerNorm(
             epsilon=self.layer_norm_epsilon,
             dtype=self.dtype_policy,
+            name="self_attention_layernorm",
         )
         self._self_attention_layernorm.build(decoder_sequence_shape)
+        self._self_attention_dropout = keras.layers.Dropout(
+            rate=self.dropout,
+            dtype=self.dtype_policy,
+            name="self_attention_dropout",
+        )
 
         # Feedforward layers.
         self._feedforward_intermediate_dense = keras.layers.Dense(
             self.intermediate_dim,
             kernel_initializer=clone_initializer(self.kernel_initializer),
+            use_bias=False,
             dtype=self.dtype_policy,
+            name="feedforward_intermediate_dense",
         )
         self._feedforward_intermediate_dense.build(decoder_sequence_shape)
 
@@ -86,23 +99,30 @@ class LlamaDecoder(keras.layers.Layer):
             self.intermediate_dim,
             activation=self.activation,
             kernel_initializer=clone_initializer(self.kernel_initializer),
+            use_bias=False,
             dtype=self.dtype_policy,
+            name="feedforward_gate_dense",
         )
         self._feedforward_gate_dense.build(decoder_sequence_shape)
 
         self._feedforward_output_dense = keras.layers.Dense(
             self.hidden_dim,
             kernel_initializer=clone_initializer(self.kernel_initializer),
+            use_bias=False,
             dtype=self.dtype_policy,
+            name="feedforward_output_dense",
         )
 
-        intermediate_shape = list(decoder_sequence_shape)
-        intermediate_shape[-1] = self.intermediate_dim
-        self._feedforward_output_dense.build(tuple(intermediate_shape))
+        self._feedforward_output_dense.build(
+            self._feedforward_gate_dense.compute_output_shape(
+                decoder_sequence_shape
+            )
+        )
 
         self._feedforward_layernorm = LlamaLayerNorm(
             epsilon=self.layer_norm_epsilon,
             dtype=self.dtype_policy,
+            name="feedforward_layernorm",
         )
         self._feedforward_layernorm.build(decoder_sequence_shape)
 
@@ -115,6 +135,7 @@ class LlamaDecoder(keras.layers.Layer):
         decoder_attention_mask=None,
         self_attention_cache=None,
         self_attention_cache_update_index=None,
+        training=None,
     ):
         self_attention_mask = self._compute_self_attention_mask(
             decoder_sequence=decoder_sequence,
@@ -125,10 +146,9 @@ class LlamaDecoder(keras.layers.Layer):
         )
         residual = decoder_sequence
 
-        x = self._self_attention_layernorm(
-            decoder_sequence,
-        )
+        x = self._self_attention_layernorm(decoder_sequence)
 
+        # Self attention block.
         x = self._self_attention_layer(
             hidden_states=x,
             attention_mask=self_attention_mask,
@@ -138,6 +158,8 @@ class LlamaDecoder(keras.layers.Layer):
 
         if self_attention_cache is not None:
             x, self_attention_cache = x
+
+        x = self._self_attention_dropout(x, training=training)
 
         x = x + residual
         residual = x
@@ -152,7 +174,7 @@ class LlamaDecoder(keras.layers.Layer):
         decoder_output = x + residual
 
         if self_attention_cache is not None:
-            return (decoder_output, self_attention_cache)
+            return decoder_output, self_attention_cache
         return decoder_output
 
     def _compute_self_attention_mask(
@@ -160,8 +182,8 @@ class LlamaDecoder(keras.layers.Layer):
         decoder_sequence,
         decoder_padding_mask,
         decoder_attention_mask,
-        self_attention_cache=None,
-        self_attention_cache_update_index=None,
+        self_attention_cache,
+        self_attention_cache_update_index,
     ):
         decoder_mask = merge_padding_and_attention_mask(
             decoder_sequence, decoder_padding_mask, decoder_attention_mask
@@ -174,16 +196,16 @@ class LlamaDecoder(keras.layers.Layer):
         if self_attention_cache is not None:
             input_length = ops.shape(self_attention_cache)[2]
 
-        causal_mask = compute_causal_mask(
-            batch_size,
-            input_length,
-            output_length,
-            (
-                0
-                if self_attention_cache_update_index is None
-                else self_attention_cache_update_index
-            ),
+        cache_update_index = (
+            0
+            if self_attention_cache_update_index is None
+            else self_attention_cache_update_index
         )
+
+        causal_mask = compute_causal_mask(
+            batch_size, input_length, output_length, cache_update_index
+        )
+
         return (
             ops.minimum(decoder_mask, causal_mask)
             if decoder_mask is not None
@@ -198,17 +220,16 @@ class LlamaDecoder(keras.layers.Layer):
         config.update(
             {
                 "intermediate_dim": self.intermediate_dim,
-                "hidden_dim": self.hidden_dim,
                 "num_query_heads": self.num_query_heads,
                 "rope_max_wavelength": self.rope_max_wavelength,
                 "rope_scaling_factor": self.rope_scaling_factor,
                 "num_key_value_heads": self.num_key_value_heads,
-                "max_sequence_length": self.max_sequence_length,
                 "activation": keras.activations.serialize(self.activation),
                 "layer_norm_epsilon": self.layer_norm_epsilon,
                 "kernel_initializer": keras.initializers.serialize(
                     self.kernel_initializer
                 ),
+                "dropout": self.dropout,
             }
         )
         return config


### PR DESCRIPTION
Get the LLaMA backbone and its components closer to Mistral. Later, it would be nice to unify them to reduce code duplication. Tests haven't been modified, so the behavior of the components remain the same.

Note that I don't update the checkpoint file in this PR; it would be better to do it once the other components (preprocessor and generator) are in.