### PR TITLE
Don't auto-update JAX GPU

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,6 @@ updates:
       python:
         patterns:
           - "*"
+    ignore:
+        # TODO: ignore all updates for JAX GPU due to cuda version issue
+      - dependency-name: "jax[cuda12_pip]"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,5 +22,5 @@ updates:
         patterns:
           - "*"
     ignore:
-        # TODO: ignore all updates for JAX GPU due to cuda version issue
+        # ignore all updates for JAX GPU due to cuda version issue
       - dependency-name: "jax[cuda12_pip]"

--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -1,6 +1,6 @@
 # Tensorflow cpu-only version.
 tensorflow-cpu~=2.16.1  # Pin to TF 2.16
-tensorflow-text~=2.16.0
+tensorflow-text~=2.16.1
 
 # Torch cpu-only version.
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -1,6 +1,6 @@
 # Tensorflow with cuda support.
 tensorflow[and-cuda]~=2.16.1  # Pin to TF 2.16
-tensorflow-text~=2.16.0
+tensorflow-text~=2.16.1
 
 # Torch cpu-only version.
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -1,6 +1,6 @@
 # Tensorflow cpu-only version.
 tensorflow-cpu~=2.16.1  # Pin to TF 2.16
-tensorflow-text~=2.16.0
+tensorflow-text~=2.16.1
 
 # Torch with cuda support.
 --extra-index-url https://download.pytorch.org/whl/cu121

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Tensorflow.
 tensorflow-cpu~=2.16.1  # Pin to TF 2.16
-tensorflow-text~=2.16.0
+tensorflow-text~=2.16.1
 
 # Torch.
 --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
Don't auto-update Dependabot for JAX GPU due to Cuda Issue.  Added a TODO to test it.