### PR TITLE
Add Mistral Instruct V0.2 preset

### DIFF
--- a/keras_nlp/models/mistral/mistral_presets.py
+++ b/keras_nlp/models/mistral/mistral_presets.py
@@ -35,4 +35,14 @@ backbone_presets = {
         },
         "kaggle_handle": "kaggle://keras/mistral/keras/mistral_instruct_7b_en/6",
     },
+    "mistral_instruct_7b_v0.2_en": {
+        "metadata": {
+            "description": "Mistral 7B instruct Version 0.2 model",
+            "params": 7241732096,
+            "official_name": "Mistral",
+            "path": "mistral",
+            "model_card": "https://github.com/mistralai/mistral-src/blob/main/README.md",
+        },
+        "kaggle_handle": "kaggle://keras/mistral/keras/mistral_instruct_7b_v0.2_en/1",
+    },
 }

--- a/keras_nlp/models/mistral/mistral_presets.py
+++ b/keras_nlp/models/mistral/mistral_presets.py
@@ -35,7 +35,7 @@ backbone_presets = {
         },
         "kaggle_handle": "kaggle://keras/mistral/keras/mistral_instruct_7b_en/6",
     },
-    "mistral_instruct_7b_v0.2_en": {
+    "mistral_0.2_instruct_7b_en": {
         "metadata": {
             "description": "Mistral 7B instruct Version 0.2 model",
             "params": 7241732096,
@@ -43,6 +43,6 @@ backbone_presets = {
             "path": "mistral",
             "model_card": "https://github.com/mistralai/mistral-src/blob/main/README.md",
         },
-        "kaggle_handle": "kaggle://keras/mistral/keras/mistral_instruct_7b_v0.2_en/1",
+        "kaggle_handle": "kaggle://keras/mistral/keras/mistral_0.2_instruct_7b_en/1",
     },
 }

--- a/tools/checkpoint_conversion/convert_mistral_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_mistral_checkpoints.py
@@ -33,7 +33,7 @@ from keras_nlp.utils.preset_utils import save_to_preset
 PRESET_MAP = {
     "mistral_7b_en": "mistralai/Mistral-7B-v0.1",
     "mistral_instruct_7b_en": "mistralai/Mistral-7B-Instruct-v0.1",
-    "mistral_instruct_7b_v0.2_en": "mistralai/Mistral-7B-Instruct-v0.2",
+    "mistral_0.2_instruct_7b_en": "mistralai/Mistral-7B-Instruct-v0.2",
 }
 
 FLAGS = flags.FLAGS

--- a/tools/checkpoint_conversion/convert_mistral_checkpoints.py
+++ b/tools/checkpoint_conversion/convert_mistral_checkpoints.py
@@ -33,6 +33,7 @@ from keras_nlp.utils.preset_utils import save_to_preset
 PRESET_MAP = {
     "mistral_7b_en": "mistralai/Mistral-7B-v0.1",
     "mistral_instruct_7b_en": "mistralai/Mistral-7B-Instruct-v0.1",
+    "mistral_instruct_7b_v0.2_en": "mistralai/Mistral-7B-Instruct-v0.2",
 }
 
 FLAGS = flags.FLAGS


### PR DESCRIPTION
Closes #1515 

Adds Mistral Instruct v0.2 as a preset. The model has been uploaded on Kaggle.

~Just need to test the generator to make sure HF and Keras outputs match.~