### PR TITLE
Implement compute_output_spec() for tokenizers with vocabulary.

### DIFF
--- a/keras_nlp/tokenizers/byte_pair_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer.py
@@ -606,7 +606,7 @@ class BytePairTokenizer(tokenizer.Tokenizer):
             outputs = tf.squeeze(outputs, 0)
         return outputs
 
-    def compute_output_spec(self, input_spec) -> keras.KerasTensor:
+    def compute_output_spec(self, input_spec):
         return keras.KerasTensor(
             input_spec.shape + (self.sequence_length,), dtype=self.compute_dtype
         )

--- a/keras_nlp/tokenizers/byte_pair_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer.py
@@ -24,6 +24,7 @@ import os
 from typing import Iterable
 from typing import List
 
+import keras
 import regex as re
 import tensorflow as tf
 
@@ -604,6 +605,11 @@ class BytePairTokenizer(tokenizer.Tokenizer):
         if unbatched:
             outputs = tf.squeeze(outputs, 0)
         return outputs
+
+    def compute_output_spec(self, input_spec) -> keras.KerasTensor:
+        return keras.KerasTensor(
+            input_spec.shape + (self.sequence_length,), dtype=self.compute_dtype
+        )
 
     def _transform_bytes(self, tokens):
         """Map token bytes to unicode using `byte2unicode`."""

--- a/keras_nlp/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/sentence_piece_tokenizer.py
@@ -17,6 +17,7 @@ import binascii
 import os
 from typing import List
 
+import keras
 import tensorflow as tf
 
 from keras_nlp.api_export import keras_nlp_export
@@ -255,3 +256,8 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
         if unbatched:
             outputs = tf.squeeze(outputs, 0)
         return outputs
+
+    def compute_output_spec(self, input_spec) -> keras.KerasTensor:
+        return keras.KerasTensor(
+            input_spec.shape + (self.sequence_length,), dtype=self.compute_dtype
+        )

--- a/keras_nlp/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/sentence_piece_tokenizer.py
@@ -257,7 +257,7 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
             outputs = tf.squeeze(outputs, 0)
         return outputs
 
-    def compute_output_spec(self, input_spec) -> keras.KerasTensor:
+    def compute_output_spec(self, input_spec):
         return keras.KerasTensor(
             input_spec.shape + (self.sequence_length,), dtype=self.compute_dtype
         )

--- a/keras_nlp/tokenizers/word_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer.py
@@ -17,6 +17,7 @@ import re
 from typing import Iterable
 from typing import List
 
+import keras
 import tensorflow as tf
 
 from keras_nlp.api_export import keras_nlp_export
@@ -528,3 +529,8 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
         if unbatched:
             outputs = tf.squeeze(outputs, 0)
         return outputs
+
+    def compute_output_spec(self, input_spec) -> keras.KerasTensor:
+        return keras.KerasTensor(
+            input_spec.shape + (self.sequence_length,), dtype=self.compute_dtype
+        )

--- a/keras_nlp/tokenizers/word_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer.py
@@ -530,7 +530,7 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
             outputs = tf.squeeze(outputs, 0)
         return outputs
 
-    def compute_output_spec(self, input_spec) -> keras.KerasTensor:
+    def compute_output_spec(self, input_spec):
         return keras.KerasTensor(
             input_spec.shape + (self.sequence_length,), dtype=self.compute_dtype
         )


### PR DESCRIPTION
Small fix for [Issue 1522](https://github.com/keras-team/keras-nlp/issues/1522)

Implements the same `compute_output_spec()` method for `BytePairTokenizer`, `WordPieceTokenizer`, and `SentencePieceTokenizer`.