### PR TITLE
Fix doc: `mistral_base_en` -> `mistral_7b_en`

### DIFF
--- a/keras_nlp/models/mistral/mistral_tokenizer.py
+++ b/keras_nlp/models/mistral/mistral_tokenizer.py
@@ -49,7 +49,7 @@ class MistralTokenizer(SentencePieceTokenizer):
     ```python
     # Unbatched input.
     tokenizer = keras_nlp.models.MistralTokenizer.from_preset(
-        "mistral_base_en",
+        "mistral_7b_en",
     )
     tokenizer("The quick brown fox jumped.")
 


### PR DESCRIPTION
I'm looking at the KerasNLP documentation: https://keras.io/api/keras_nlp/models/mistral/mistral_tokenizer/#mistraltokenizer-class

When trying to run the example:

```python
# Unbatched input.
tokenizer = keras_nlp.models.MistralTokenizer.from_preset(
    "mistral_base_en",
)
tokenizer("The quick brown fox jumped.")

# Batched input.
tokenizer(["The quick brown fox jumped.", "The fox slept."])

# Detokenization.
tokenizer.detokenize(tokenizer("The quick brown fox jumped."))
```

I get:

```python
ValueError: Unknown preset identifier. A preset must be a one of:
1) a built in preset identifier like `'bert_base_en'`
2) a Kaggle Models handle like `'kaggle://keras/bert/keras/bert_base_en'`
3) a path to a local preset directory like `'./bert_base_en`
Use `print(cls.presets.keys())` to view all built-in presets for API symbol `cls`.
Received: preset='mistral_base_en'
```

Changeing `mistral_base_en` -> `mistral_7b_en` seems to make this work.

---

There seem to be quite a few references to `mistral_base_en` in the doc. I'm happy to update all of these if helpful?

Thanks for this lib! :)