### PR TITLE
Fix the rotary embedding computation in LLaMA

### DIFF
--- a/keras_nlp/models/llama/llama_attention.py
+++ b/keras_nlp/models/llama/llama_attention.py
@@ -169,8 +169,8 @@ class LlamaAttention(keras.layers.Layer):
 
         # [batch_shape, seq_len, num_key_value_heads, head_dim]
         # -> [batch_shape, seq_len, num_heads, head_dim]
-        key = ops.repeat(key, repeats=self._num_key_value_groups, axis=2)
-        value = ops.repeat(value, repeats=self._num_key_value_groups, axis=2)
+        key = ops.repeat(key, repeats=self.num_key_value_groups, axis=2)
+        value = ops.repeat(value, repeats=self.num_key_value_groups, axis=2)
 
         attention_output = self._compute_attention(
             query, key, value, attention_mask

--- a/keras_nlp/models/llama/llama_backbone.py
+++ b/keras_nlp/models/llama/llama_backbone.py
@@ -109,6 +109,7 @@ class LlamaBackbone(Backbone):
             tie_weights=False,
             embeddings_initializer=_llama_kernel_initializer(stddev=0.01),
             dtype=dtype,
+            reverse_dtype=dtype,
             name="token_embedding",
         )
         self.transformer_layers = []

--- a/keras_nlp/models/mistral/mistral_attention.py
+++ b/keras_nlp/models/mistral/mistral_attention.py
@@ -144,11 +144,6 @@ class CachedMistralAttention(keras.layers.Layer):
         start_index = (
             cache_update_index if cache_update_index is not None else 0
         )
-        # If `cache_update_index` is a tensor, RotaryEmbedding expects it
-        # to have dtype `self.compute_dtype`.
-        start_index = ops.cast(
-            start_index, self.rotary_embedding_layer.compute_dtype
-        )
 
         query = self._query_dense(hidden_states)
 

--- a/keras_nlp/models/mistral/mistral_backbone.py
+++ b/keras_nlp/models/mistral/mistral_backbone.py
@@ -121,6 +121,7 @@ class MistralBackbone(Backbone):
             tie_weights=False,
             embeddings_initializer=_mistral_kernel_initializer(stddev=0.01),
             dtype=dtype,
+            reverse_dtype=dtype,
             name="token_embedding",
         )
         self.transformer_layers = []


### PR DESCRIPTION
LLaMA backbone ignored the start_index parameter when computing the rotary embeddings which lead to numerical issues during generation. This PR fixes it along with the reverse embedding layer in both Mistral and LLaMA: run the reverse embedding stage in `compute_dtype` instead of full-precision. This is how HF does it, so helps get the numerics closer.