### PR TITLE
Support Task Saving/Loading

### DIFF
--- a/keras_nlp/models/backbone.py
+++ b/keras_nlp/models/backbone.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.backend import config
 from keras_nlp.backend import keras
@@ -217,7 +219,7 @@ class Backbone(keras.Model):
             preset_dir: The path to the local model preset directory.
         """
         save_serialized_object(self, preset_dir, config_file=CONFIG_FILE)
-        self.save_weights(get_file(preset_dir, MODEL_WEIGHTS_FILE))
+        self.save_weights(os.path.join(preset_dir, MODEL_WEIGHTS_FILE))
         save_metadata(self, preset_dir)
 
     def enable_lora(self, rank):

--- a/keras_nlp/models/backbone.py
+++ b/keras_nlp/models/backbone.py
@@ -209,7 +209,7 @@ class Backbone(keras.Model):
         backbone = load_serialized_object(preset, CONFIG_FILE)
         if load_weights:
             jax_memory_cleanup(backbone)
-            backbone.load_weights(get_file(preset, CONFIG_FILE))
+            backbone.load_weights(get_file(preset, MODEL_WEIGHTS_FILE))
 
         return backbone
 

--- a/keras_nlp/models/backbone.py
+++ b/keras_nlp/models/backbone.py
@@ -16,13 +16,17 @@ from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.backend import config
 from keras_nlp.backend import keras
 from keras_nlp.utils.preset_utils import CONFIG_FILE
+from keras_nlp.utils.preset_utils import MODEL_WEIGHTS_FILE
 from keras_nlp.utils.preset_utils import check_config_class
 from keras_nlp.utils.preset_utils import get_file
 from keras_nlp.utils.preset_utils import jax_memory_cleanup
 from keras_nlp.utils.preset_utils import list_presets
 from keras_nlp.utils.preset_utils import list_subclasses
 from keras_nlp.utils.preset_utils import load_serialized_object
-from keras_nlp.utils.preset_utils import save_to_preset
+from keras_nlp.utils.preset_utils import make_preset_dir
+from keras_nlp.utils.preset_utils import save_metadata
+from keras_nlp.utils.preset_utils import save_serialized_object
+from keras_nlp.utils.preset_utils import save_weights
 from keras_nlp.utils.python_utils import classproperty
 
 
@@ -214,7 +218,11 @@ class Backbone(keras.Model):
         Args:
             preset: The path to the local model preset directory.
         """
-        save_to_preset(self, preset)
+        make_preset_dir(preset)
+        save_serialized_object(self, preset, config_file=CONFIG_FILE)
+        save_weights(self, preset, MODEL_WEIGHTS_FILE)
+        save_metadata(self, preset)
+        # save_to_preset(self, preset)
 
     def enable_lora(self, rank):
         """Enable Lora on the backbone.

--- a/keras_nlp/models/backbone.py
+++ b/keras_nlp/models/backbone.py
@@ -210,15 +210,15 @@ class Backbone(keras.Model):
 
         return backbone
 
-    def save_to_preset(self, preset):
+    def save_to_preset(self, preset_dir):
         """Save backbone to a preset directory.
 
         Args:
-            preset: The path to the local model preset directory.
+            preset_dir: The path to the local model preset directory.
         """
-        save_serialized_object(self, preset, config_file=CONFIG_FILE)
-        self.save_weights(get_file(preset, MODEL_WEIGHTS_FILE))
-        save_metadata(self, preset)
+        save_serialized_object(self, preset_dir, config_file=CONFIG_FILE)
+        self.save_weights(get_file(preset_dir, MODEL_WEIGHTS_FILE))
+        save_metadata(self, preset_dir)
 
     def enable_lora(self, rank):
         """Enable Lora on the backbone.

--- a/keras_nlp/models/backbone.py
+++ b/keras_nlp/models/backbone.py
@@ -15,10 +15,13 @@
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.backend import config
 from keras_nlp.backend import keras
+from keras_nlp.utils.preset_utils import CONFIG_FILE
 from keras_nlp.utils.preset_utils import check_config_class
+from keras_nlp.utils.preset_utils import get_file
+from keras_nlp.utils.preset_utils import jax_memory_cleanup
 from keras_nlp.utils.preset_utils import list_presets
 from keras_nlp.utils.preset_utils import list_subclasses
-from keras_nlp.utils.preset_utils import load_from_preset
+from keras_nlp.utils.preset_utils import load_serialized_object
 from keras_nlp.utils.preset_utils import save_to_preset
 from keras_nlp.utils.python_utils import classproperty
 
@@ -197,11 +200,13 @@ class Backbone(keras.Model):
                 f"a subclass of calling class `{cls.__name__}`. Call "
                 f"`from_preset` directly on `{preset_cls.__name__}` instead."
             )
-        return load_from_preset(
-            preset,
-            load_weights=load_weights,
-            config_overrides=kwargs,
-        )
+
+        backbone = load_serialized_object(preset, CONFIG_FILE)
+        if load_weights:
+            jax_memory_cleanup(backbone)
+            backbone.load_weights(get_file(preset, CONFIG_FILE))
+
+        return backbone
 
     def save_to_preset(self, preset):
         """Save backbone to a preset directory.

--- a/keras_nlp/models/backbone.py
+++ b/keras_nlp/models/backbone.py
@@ -18,16 +18,13 @@ from keras_nlp.backend import keras
 from keras_nlp.utils.preset_utils import CONFIG_FILE
 from keras_nlp.utils.preset_utils import MODEL_WEIGHTS_FILE
 from keras_nlp.utils.preset_utils import check_config_class
-from keras_nlp.utils.preset_utils import check_keras_version
 from keras_nlp.utils.preset_utils import get_file
 from keras_nlp.utils.preset_utils import jax_memory_cleanup
 from keras_nlp.utils.preset_utils import list_presets
 from keras_nlp.utils.preset_utils import list_subclasses
 from keras_nlp.utils.preset_utils import load_serialized_object
-from keras_nlp.utils.preset_utils import make_preset_dir
 from keras_nlp.utils.preset_utils import save_metadata
 from keras_nlp.utils.preset_utils import save_serialized_object
-from keras_nlp.utils.preset_utils import save_weights
 from keras_nlp.utils.python_utils import classproperty
 
 
@@ -219,10 +216,8 @@ class Backbone(keras.Model):
         Args:
             preset: The path to the local model preset directory.
         """
-        check_keras_version()
-        make_preset_dir(preset)
         save_serialized_object(self, preset, config_file=CONFIG_FILE)
-        save_weights(self, preset, MODEL_WEIGHTS_FILE)
+        self.save_weights(get_file(preset, MODEL_WEIGHTS_FILE))
         save_metadata(self, preset)
 
     def enable_lora(self, rank):

--- a/keras_nlp/models/backbone.py
+++ b/keras_nlp/models/backbone.py
@@ -18,6 +18,7 @@ from keras_nlp.backend import keras
 from keras_nlp.utils.preset_utils import CONFIG_FILE
 from keras_nlp.utils.preset_utils import MODEL_WEIGHTS_FILE
 from keras_nlp.utils.preset_utils import check_config_class
+from keras_nlp.utils.preset_utils import check_keras_version
 from keras_nlp.utils.preset_utils import get_file
 from keras_nlp.utils.preset_utils import jax_memory_cleanup
 from keras_nlp.utils.preset_utils import list_presets
@@ -218,6 +219,7 @@ class Backbone(keras.Model):
         Args:
             preset: The path to the local model preset directory.
         """
+        check_keras_version()
         make_preset_dir(preset)
         save_serialized_object(self, preset, config_file=CONFIG_FILE)
         save_weights(self, preset, MODEL_WEIGHTS_FILE)

--- a/keras_nlp/models/backbone.py
+++ b/keras_nlp/models/backbone.py
@@ -224,7 +224,6 @@ class Backbone(keras.Model):
         save_serialized_object(self, preset, config_file=CONFIG_FILE)
         save_weights(self, preset, MODEL_WEIGHTS_FILE)
         save_metadata(self, preset)
-        # save_to_preset(self, preset)
 
     def enable_lora(self, rank):
         """Enable Lora on the backbone.

--- a/keras_nlp/models/preprocessor.py
+++ b/keras_nlp/models/preprocessor.py
@@ -12,15 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import os
+
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.backend import keras
 from keras_nlp.layers.preprocessing.preprocessing_layer import (
     PreprocessingLayer,
 )
+from keras_nlp.utils.preset_utils import PREPROCESSOR_CONFIG_FILE
+from keras_nlp.utils.preset_utils import TOKENIZER_CONFIG_FILE
 from keras_nlp.utils.preset_utils import check_config_class
 from keras_nlp.utils.preset_utils import list_presets
 from keras_nlp.utils.preset_utils import list_subclasses
 from keras_nlp.utils.preset_utils import load_from_preset
+from keras_nlp.utils.preset_utils import save_to_preset
 from keras_nlp.utils.python_utils import classproperty
 
 
@@ -153,3 +159,18 @@ class Preprocessor(PreprocessingLayer):
             config_file=config_file,
         )
         return cls(tokenizer=tokenizer, **kwargs)
+
+    def save_to_preset(self, preset):
+        """TODO: add docstring."""
+        save_to_preset(
+            self.tokenizer,
+            preset,
+            config_filename=TOKENIZER_CONFIG_FILE,
+        )
+
+        preprocessor_config_path = os.path.join(
+            preset, PREPROCESSOR_CONFIG_FILE
+        )
+        preprocessor_config = keras.saving.serialize_keras_object(self)
+        with open(preprocessor_config_path, "w") as config_file:
+            config_file.write(json.dumps(preprocessor_config, indent=4))

--- a/keras_nlp/models/preprocessor.py
+++ b/keras_nlp/models/preprocessor.py
@@ -23,7 +23,7 @@ from keras_nlp.layers.preprocessing.preprocessing_layer import (
 from keras_nlp.utils.preset_utils import PREPROCESSOR_CONFIG_FILE
 from keras_nlp.utils.preset_utils import TOKENIZER_ASSET_DIR
 from keras_nlp.utils.preset_utils import TOKENIZER_CONFIG_FILE
-from keras_nlp.utils.preset_utils import check_file_exists
+from keras_nlp.utils.preset_utils import get_file
 from keras_nlp.utils.preset_utils import list_presets
 from keras_nlp.utils.preset_utils import list_subclasses
 from keras_nlp.utils.preset_utils import load_serialized_object
@@ -136,10 +136,14 @@ class Preprocessor(PreprocessingLayer):
                 "`keras_nlp.models.BertPreprocessor.from_preset()`."
             )
 
-        if not check_file_exists(preset, PREPROCESSOR_CONFIG_FILE):
+        try:
+            get_file(preset, PREPROCESSOR_CONFIG_FILE)
+        except FileNotFoundError:
             raise FileNotFoundError(
-                f"preset should contain a `{PREPROCESSOR_CONFIG_FILE}`"
-            )  # TODO: update error message.
+                f"Preset directory `{preset}` should contain preprocessor "
+                "config `{PREPROCESSOR_CONFIG_FILE}`."
+            )
+
         preprocessor = load_serialized_object(preset, PREPROCESSOR_CONFIG_FILE)
         preprocessor.tokenizer = load_tokenizer(
             preset,

--- a/keras_nlp/models/preprocessor.py
+++ b/keras_nlp/models/preprocessor.py
@@ -132,17 +132,16 @@ class Preprocessor(PreprocessingLayer):
                 "choose a particular task class, e.g. "
                 "`keras_nlp.models.BertPreprocessor.from_preset()`."
             )
-
+        # Check if we should load a `preprocessor.json` directly.
+        load_preprocessor_config = False
         if check_file_exists(preset, PREPROCESSOR_CONFIG_FILE):
             preprocessor_preset_cls = check_config_class(
                 preset, PREPROCESSOR_CONFIG_FILE
             )
-            if not issubclass(preprocessor_preset_cls, cls):
-                raise ValueError(
-                    f"`{PREPROCESSOR_CONFIG_FILE}` has type `{preprocessor_preset_cls.__name__}` "
-                    f"which is not a subclass of calling class `{cls.__name__}`. Call "
-                    f"`from_preset` directly on `{preprocessor_preset_cls.__name__}` instead."
-                )
+            if issubclass(preprocessor_preset_cls, cls):
+                load_preprocessor_config = True
+        if load_preprocessor_config:
+            # Preprocessor case.
             preprocessor = load_serialized_object(
                 preset,
                 PREPROCESSOR_CONFIG_FILE,
@@ -150,7 +149,10 @@ class Preprocessor(PreprocessingLayer):
             preprocessor.tokenizer.load_preset_assets(preset)
             return preprocessor
 
-        # Ensure loading is not from an incorrect class.
+        # Tokenizer case.
+        # If `preprocessor.json` doesn't exist or preprocessor class is
+        # different from the calling class, create the preprocessor based on
+        # `tokenizer.json`.
         tokenizer_preset_cls = check_config_class(
             preset, config_file=TOKENIZER_CONFIG_FILE
         )

--- a/keras_nlp/models/preprocessor.py
+++ b/keras_nlp/models/preprocessor.py
@@ -20,12 +20,14 @@ from keras_nlp.backend import keras
 from keras_nlp.layers.preprocessing.preprocessing_layer import (
     PreprocessingLayer,
 )
-from keras_nlp.models import Tokenizer
 from keras_nlp.utils.preset_utils import PREPROCESSOR_CONFIG_FILE
+from keras_nlp.utils.preset_utils import TOKENIZER_ASSET_DIR
+from keras_nlp.utils.preset_utils import TOKENIZER_CONFIG_FILE
 from keras_nlp.utils.preset_utils import check_file_exists
 from keras_nlp.utils.preset_utils import list_presets
 from keras_nlp.utils.preset_utils import list_subclasses
 from keras_nlp.utils.preset_utils import load_serialized_object
+from keras_nlp.utils.preset_utils import load_tokenizer
 from keras_nlp.utils.python_utils import classproperty
 
 
@@ -139,7 +141,11 @@ class Preprocessor(PreprocessingLayer):
                 f"preset should contain a `{PREPROCESSOR_CONFIG_FILE}`"
             )  # TODO: update error message.
         preprocessor = load_serialized_object(preset, PREPROCESSOR_CONFIG_FILE)
-        preprocessor.tokenizer = Tokenizer.from_preset(preset)
+        preprocessor.tokenizer = load_tokenizer(
+            preset,
+            config_file=TOKENIZER_CONFIG_FILE,
+            asset_dir=TOKENIZER_ASSET_DIR,
+        )
 
         return preprocessor
 

--- a/keras_nlp/models/preprocessor.py
+++ b/keras_nlp/models/preprocessor.py
@@ -24,8 +24,10 @@ from keras_nlp.utils.preset_utils import check_config_class
 from keras_nlp.utils.preset_utils import get_file
 from keras_nlp.utils.preset_utils import list_presets
 from keras_nlp.utils.preset_utils import list_subclasses
+from keras_nlp.utils.preset_utils import load_config
 from keras_nlp.utils.preset_utils import load_serialized_object
 from keras_nlp.utils.preset_utils import load_tokenizer
+from keras_nlp.utils.preset_utils import make_preset_dir
 from keras_nlp.utils.preset_utils import save_serialized_object
 from keras_nlp.utils.python_utils import classproperty
 
@@ -167,8 +169,14 @@ class Preprocessor(PreprocessingLayer):
                     f"Found multiple possible subclasses {names}. "
                     "Please call `from_preset` on a subclass directly."
                 )
-
-        preprocessor = load_serialized_object(preset, PREPROCESSOR_CONFIG_FILE)
+        tokenizer_config = load_config(preset, TOKENIZER_CONFIG_FILE)
+        # TODO: this is not really an override! It's an addition! Should I rename this?
+        config_overrides = {"tokenizer": tokenizer_config}
+        preprocessor = load_serialized_object(
+            preset,
+            PREPROCESSOR_CONFIG_FILE,
+            config_overrides=config_overrides,
+        )
         preprocessor.tokenizer = load_tokenizer(
             preset,
             config_file=TOKENIZER_CONFIG_FILE,
@@ -183,6 +191,7 @@ class Preprocessor(PreprocessingLayer):
         Args:
             preset: The path to the local model preset directory.
         """
+        make_preset_dir(preset)
         self.tokenizer.save_to_preset(preset)
         save_serialized_object(
             self,

--- a/keras_nlp/models/preprocessor.py
+++ b/keras_nlp/models/preprocessor.py
@@ -23,7 +23,6 @@ from keras_nlp.utils.preset_utils import TOKENIZER_ASSET_DIR
 from keras_nlp.utils.preset_utils import TOKENIZER_CONFIG_FILE
 from keras_nlp.utils.preset_utils import check_config_class
 from keras_nlp.utils.preset_utils import check_file_exists
-from keras_nlp.utils.preset_utils import get_asset_dir
 from keras_nlp.utils.preset_utils import get_file
 from keras_nlp.utils.preset_utils import list_presets
 from keras_nlp.utils.preset_utils import list_subclasses
@@ -163,30 +162,28 @@ class Preprocessor(PreprocessingLayer):
                 )
 
         if check_file_exists(preset, PREPROCESSOR_CONFIG_FILE):
-            get_file(preset, PREPROCESSOR_CONFIG_FILE)
             preprocessor = load_serialized_object(
                 preset,
                 PREPROCESSOR_CONFIG_FILE,
             )
+            asset_path = None
             for asset in preprocessor.tokenizer.file_assets:
-                get_file(preset, os.path.join(TOKENIZER_ASSET_DIR, asset))
-            tokenizer_asset_dir = get_asset_dir(
-                preset,
-                config_file=TOKENIZER_CONFIG_FILE,
-                asset_dir=TOKENIZER_ASSET_DIR,
-            )
+                asset_path = get_file(
+                    preset, os.path.join(TOKENIZER_ASSET_DIR, asset)
+                )
+            tokenizer_asset_dir = os.path.dirname(asset_path)
             preprocessor.tokenizer.load_assets(tokenizer_asset_dir)
-        else:
-            tokenizer = load_serialized_object(preset, TOKENIZER_CONFIG_FILE)
-            for asset in tokenizer.file_assets:
-                get_file(preset, os.path.join(TOKENIZER_ASSET_DIR, asset))
-            tokenizer_asset_dir = get_asset_dir(
-                preset,
-                config_file=TOKENIZER_CONFIG_FILE,
-                asset_dir=TOKENIZER_ASSET_DIR,
+            return preprocessor
+
+        tokenizer = load_serialized_object(preset, TOKENIZER_CONFIG_FILE)
+        asset_path = None
+        for asset in preprocessor.tokenizer.file_assets:
+            asset_path = get_file(
+                preset, os.path.join(TOKENIZER_ASSET_DIR, asset)
             )
-            tokenizer.load_assets(tokenizer_asset_dir)
-            preprocessor = cls(tokenizer=tokenizer)
+        tokenizer_asset_dir = os.path.dirname(asset_path)
+        tokenizer.load_assets(tokenizer_asset_dir)
+        preprocessor = cls(tokenizer=tokenizer)
 
         return preprocessor
 

--- a/keras_nlp/models/preprocessor.py
+++ b/keras_nlp/models/preprocessor.py
@@ -190,15 +190,15 @@ class Preprocessor(PreprocessingLayer):
 
         return preprocessor
 
-    def save_to_preset(self, preset):
+    def save_to_preset(self, preset_dir):
         """Save preprocessor to a preset directory.
 
         Args:
-            preset: The path to the local model preset directory.
+            preset_dir: The path to the local model preset directory.
         """
         save_serialized_object(
             self,
-            preset,
+            preset_dir,
             config_file=PREPROCESSOR_CONFIG_FILE,
         )
-        self.tokenizer.save_to_preset(preset)
+        self.tokenizer.save_to_preset(preset_dir)

--- a/keras_nlp/models/preprocessor.py
+++ b/keras_nlp/models/preprocessor.py
@@ -21,6 +21,7 @@ from keras_nlp.layers.preprocessing.preprocessing_layer import (
 from keras_nlp.utils.preset_utils import PREPROCESSOR_CONFIG_FILE
 from keras_nlp.utils.preset_utils import TOKENIZER_ASSET_DIR
 from keras_nlp.utils.preset_utils import TOKENIZER_CONFIG_FILE
+from keras_nlp.utils.preset_utils import check_config_class
 from keras_nlp.utils.preset_utils import check_keras_version
 from keras_nlp.utils.preset_utils import get_asset_dir
 from keras_nlp.utils.preset_utils import get_file
@@ -161,6 +162,29 @@ class Preprocessor(PreprocessingLayer):
             preprocessor.tokenizer.load_assets(tokenizer_asset_dir)
         except FileNotFoundError:
             # `preprocessor.json` doesn't exist.
+            tokenizer_preset_cls = check_config_class(
+                preset, config_file=TOKENIZER_CONFIG_FILE
+            )
+            if tokenizer_preset_cls is not cls.tokenizer_cls:
+                subclasses = list_subclasses(cls)
+                subclasses = tuple(
+                    filter(
+                        lambda x: x.tokenizer_cls == tokenizer_preset_cls,
+                        subclasses,
+                    )
+                )
+                if len(subclasses) == 0:
+                    raise ValueError(
+                        f"No registered subclass of `{cls.__name__}` can load "
+                        f"a `{tokenizer_preset_cls.__name__}`."
+                    )
+                if len(subclasses) > 1:
+                    names = ", ".join(f"`{x.__name__}`" for x in subclasses)
+                    raise ValueError(
+                        f"Ambiguous call to `{cls.__name__}.from_preset()`. "
+                        f"Found multiple possible subclasses {names}. "
+                        "Please call `from_preset` on a subclass directly."
+                    )
             tokenizer = load_serialized_object(preset, TOKENIZER_CONFIG_FILE)
             for asset in tokenizer.file_assets:
                 get_file(preset, os.path.join(TOKENIZER_ASSET_DIR, asset))

--- a/keras_nlp/models/preprocessor.py
+++ b/keras_nlp/models/preprocessor.py
@@ -150,7 +150,7 @@ class Preprocessor(PreprocessingLayer):
             return preprocessor
 
         # Tokenizer case.
-        # If `preprocessor.json` doesn't exist or preprocessor class is
+        # If `preprocessor.json` doesn't exist or preprocessor preset class is
         # different from the calling class, create the preprocessor based on
         # `tokenizer.json`.
         tokenizer_preset_cls = check_config_class(

--- a/keras_nlp/models/preprocessor.py
+++ b/keras_nlp/models/preprocessor.py
@@ -23,8 +23,6 @@ from keras_nlp.layers.preprocessing.preprocessing_layer import (
 from keras_nlp.utils.preset_utils import PREPROCESSOR_CONFIG_FILE
 from keras_nlp.utils.preset_utils import list_presets
 from keras_nlp.utils.preset_utils import list_subclasses
-
-# from keras_nlp.utils.preset_utils import save_to_preset
 from keras_nlp.utils.python_utils import classproperty
 
 

--- a/keras_nlp/models/preprocessor.py
+++ b/keras_nlp/models/preprocessor.py
@@ -21,6 +21,7 @@ from keras_nlp.utils.preset_utils import PREPROCESSOR_CONFIG_FILE
 from keras_nlp.utils.preset_utils import TOKENIZER_ASSET_DIR
 from keras_nlp.utils.preset_utils import TOKENIZER_CONFIG_FILE
 from keras_nlp.utils.preset_utils import check_config_class
+from keras_nlp.utils.preset_utils import check_keras_version
 from keras_nlp.utils.preset_utils import get_file
 from keras_nlp.utils.preset_utils import list_presets
 from keras_nlp.utils.preset_utils import list_subclasses
@@ -191,6 +192,7 @@ class Preprocessor(PreprocessingLayer):
         Args:
             preset: The path to the local model preset directory.
         """
+        check_keras_version()
         make_preset_dir(preset)
         self.tokenizer.save_to_preset(preset)
         save_serialized_object(

--- a/keras_nlp/models/preprocessor.py
+++ b/keras_nlp/models/preprocessor.py
@@ -133,6 +133,8 @@ class Preprocessor(PreprocessingLayer):
 
         # TODO: Move this to load_from_preset in preset_utils.py?
         # TODO: This loading a config and deserializing the object has been repeated multiple times. Make it into a function.
+        # TODO: preprocessor.json can have a tokenizer class so we can load the tokenizer like TokenizerClass.from_preset(preset).
+        # TODO: Tokenizer config should be dropped from the preprocessor.json because tokenizer has a tokenizer.json config.
         preprocessor_config_path = os.path.join(
             preset, PREPROCESSOR_CONFIG_FILE
         )

--- a/keras_nlp/models/preprocessor.py
+++ b/keras_nlp/models/preprocessor.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.backend import keras
@@ -19,11 +18,9 @@ from keras_nlp.layers.preprocessing.preprocessing_layer import (
     PreprocessingLayer,
 )
 from keras_nlp.utils.preset_utils import PREPROCESSOR_CONFIG_FILE
-from keras_nlp.utils.preset_utils import TOKENIZER_ASSET_DIR
 from keras_nlp.utils.preset_utils import TOKENIZER_CONFIG_FILE
 from keras_nlp.utils.preset_utils import check_config_class
 from keras_nlp.utils.preset_utils import check_file_exists
-from keras_nlp.utils.preset_utils import get_file
 from keras_nlp.utils.preset_utils import list_presets
 from keras_nlp.utils.preset_utils import list_subclasses
 from keras_nlp.utils.preset_utils import load_serialized_object
@@ -150,13 +147,7 @@ class Preprocessor(PreprocessingLayer):
                 preset,
                 PREPROCESSOR_CONFIG_FILE,
             )
-            asset_path = None
-            for asset in preprocessor.tokenizer.file_assets:
-                asset_path = get_file(
-                    preset, os.path.join(TOKENIZER_ASSET_DIR, asset)
-                )
-            tokenizer_asset_dir = os.path.dirname(asset_path)
-            preprocessor.tokenizer.load_assets(tokenizer_asset_dir)
+            preprocessor.tokenizer.load_preset_assets(preset)
             return preprocessor
 
         # Ensure loading is not from an incorrect class.
@@ -185,13 +176,7 @@ class Preprocessor(PreprocessingLayer):
                 )
 
         tokenizer = load_serialized_object(preset, TOKENIZER_CONFIG_FILE)
-        asset_path = None
-        for asset in preprocessor.tokenizer.file_assets:
-            asset_path = get_file(
-                preset, os.path.join(TOKENIZER_ASSET_DIR, asset)
-            )
-        tokenizer_asset_dir = os.path.dirname(asset_path)
-        tokenizer.load_assets(tokenizer_asset_dir)
+        tokenizer.load_preset_assets(preset)
         preprocessor = cls(tokenizer=tokenizer)
 
         return preprocessor

--- a/keras_nlp/models/preprocessor_test.py
+++ b/keras_nlp/models/preprocessor_test.py
@@ -49,3 +49,5 @@ class TestTask(TestCase):
         with self.assertRaises(ValueError):
             # No loading on an incorrect class.
             BertPreprocessor.from_preset("gpt2_base_en")
+
+    # TODO: Add more tests when we added a model that has `preprocessor.json`.

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -300,16 +300,15 @@ class Task(PipelineModel):
         if load_weights:
             task.load_weights(get_file(preset, TASK_WEIGHTS_FILE))
             task.backbone.load_weights(get_file(preset, MODEL_WEIGHTS_FILE))
-        # TODO: is task.preprocessor None before this assignment?
+        # `task.preprocessor` is None before this assignment.
         task.preprocessor = preprocessor
         return task
 
-    def load_weights(self, filepath, skip_mismatch=False):
+    def load_weights(self, filepath):
         """Load only the tasks specific weights not in the backbone."""
         if not str(filepath).endswith(".weights.h5"):
             raise ValueError(
-                "The filename must end in `.weights.h5`. "
-                f"Received: filepath={filepath}"
+                "The filename must end in `.weights.h5`. Received: filepath={filepath}"
             )
         backbone_layer_ids = set(id(w) for w in self.backbone._flatten_layers())
         keras.saving.save_weights(

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -332,22 +332,22 @@ class Task(PipelineModel):
             objects_to_skip=backbone_layer_ids,
         )
 
-    def save_to_preset(self, preset):
+    def save_to_preset(self, preset_dir):
         """Save task to a preset directory.
 
         Args:
-            preset: The path to the local model preset directory.
+            preset_dir: The path to the local model preset directory.
         """
         if self.preprocessor is None:
             raise ValueError(
                 "Cannot save `task` to preset: `Preprocessor` is not initialized."
             )
 
-        save_serialized_object(self, preset, config_file=TASK_CONFIG_FILE)
-        self.save_task_weights(get_file(preset, TASK_WEIGHTS_FILE))
+        save_serialized_object(self, preset_dir, config_file=TASK_CONFIG_FILE)
+        self.save_task_weights(get_file(preset_dir, TASK_WEIGHTS_FILE))
 
-        self.preprocessor.save_to_preset(preset)
-        self.backbone.save_to_preset(preset)
+        self.preprocessor.save_to_preset(preset_dir)
+        self.backbone.save_to_preset(preset_dir)
 
     @property
     def layers(self):

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -19,11 +19,10 @@ from rich import table as rich_table
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.backend import config
 from keras_nlp.backend import keras
-from keras_nlp.models import Backbone
 from keras_nlp.models.preprocessor import Preprocessor
 from keras_nlp.utils.keras_utils import print_msg
 from keras_nlp.utils.pipeline_model import PipelineModel
-from keras_nlp.utils.preset_utils import CONFIG_FILE
+from keras_nlp.utils.preset_utils import MODEL_WEIGHTS_FILE
 from keras_nlp.utils.preset_utils import PREPROCESSOR_CONFIG_FILE
 from keras_nlp.utils.preset_utils import TASK_CONFIG_FILE
 from keras_nlp.utils.preset_utils import TASK_WEIGHTS_FILE
@@ -233,7 +232,7 @@ class Task(PipelineModel):
             raise ValueError(
                 f"`{PREPROCESSOR_CONFIG_FILE}` in `{preset}` should be a subclass of `Preprocessor`."
             )
-        preprocessor = Preprocessor.from_preset(preset)
+        preprocessor = preprocessor_preset_cls.from_preset(preset)
 
         # Backbone case.
         backbone_preset_cls = check_config_class(preset)
@@ -267,7 +266,7 @@ class Task(PipelineModel):
                 config_overrides = {}
                 if "dtype" in kwargs:
                     config_overrides["dtype"] = kwargs.pop("dtype")
-                backbone = Backbone.from_preset(
+                backbone = backbone_preset_cls.from_preset(
                     preset,
                     load_weights=load_weights,
                     config_overrides=config_overrides,
@@ -286,14 +285,10 @@ class Task(PipelineModel):
                 f"`from_preset` directly on `{task_preset_cls.__name__}` instead."
             )
 
-        task = load_serialized_object(
-            preset,
-            TASK_CONFIG_FILE,
-            config_overrides,
-        )
+        task = load_serialized_object(preset, TASK_CONFIG_FILE)
         if load_weights:
             task.load_weights(get_file(preset, TASK_WEIGHTS_FILE))
-            task.backbone.load_weights(get_file(preset, CONFIG_FILE))
+            task.backbone.load_weights(get_file(preset, MODEL_WEIGHTS_FILE))
         # TODO: is task.preprocessor None before this assignment?
         task.preprocessor = preprocessor
         return task

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -238,7 +238,7 @@ class Task(PipelineModel):
             if load_weights:
                 task.load_task_weights(get_file(preset, TASK_WEIGHTS_FILE))
                 task.backbone.load_weights(get_file(preset, MODEL_WEIGHTS_FILE))
-            task.preprocessor = task.preprocessor_cls.from_preset(preset)
+            task.preprocessor.tokenizer.load_preset_assets(preset)
             return task
 
         # Backbone case.

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -229,15 +229,21 @@ class Task(PipelineModel):
                 f"Received: backbone={kwargs['backbone']}."
             )
 
-        # Load preprocessor from preset.
-        preprocessor_preset_cls = check_config_class(
-            preset, PREPROCESSOR_CONFIG_FILE
-        )
-        if not issubclass(preprocessor_preset_cls, Preprocessor):
-            raise ValueError(
-                f"`{PREPROCESSOR_CONFIG_FILE}` in `{preset}` should be a subclass of `Preprocessor`."
+        if not get_file(preset, PREPROCESSOR_CONFIG_FILE):
+            # Load tokenizer and create a preprocessor based on that.
+            preprocessor = cls.preprocessor_cls(
+                tokenizer=cls.preprocessor_clstokenizer_cls.from_preset(preset)
             )
-        preprocessor = preprocessor_preset_cls.from_preset(preset)
+        else:
+            # Load preprocessor from preset.
+            preprocessor_preset_cls = check_config_class(
+                preset, PREPROCESSOR_CONFIG_FILE
+            )
+            if not issubclass(preprocessor_preset_cls, Preprocessor):
+                raise ValueError(
+                    f"`{PREPROCESSOR_CONFIG_FILE}` in `{preset}` should be a subclass of `Preprocessor`."
+                )
+            preprocessor = preprocessor_preset_cls.from_preset(preset)
 
         # Backbone case.
         backbone_preset_cls = check_config_class(preset)

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -28,6 +28,7 @@ from keras_nlp.utils.preset_utils import PREPROCESSOR_CONFIG_FILE
 from keras_nlp.utils.preset_utils import TASK_CONFIG_FILE
 from keras_nlp.utils.preset_utils import TASK_WEIGHTS_FILE
 from keras_nlp.utils.preset_utils import check_config_class
+from keras_nlp.utils.preset_utils import check_keras_version
 from keras_nlp.utils.preset_utils import get_file
 from keras_nlp.utils.preset_utils import list_presets
 from keras_nlp.utils.preset_utils import list_subclasses
@@ -344,6 +345,7 @@ class Task(PipelineModel):
         Args:
             preset: The path to the local model preset directory.
         """
+        check_keras_version()
         make_preset_dir(preset)
         if self.preprocessor is None:
             raise ValueError(

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -29,6 +29,7 @@ from keras_nlp.utils.pipeline_model import PipelineModel
 from keras_nlp.utils.preset_utils import CONFIG_FILE
 from keras_nlp.utils.preset_utils import PREPROCESSOR_CONFIG_FILE
 from keras_nlp.utils.preset_utils import TASK_CONFIG_FILE
+from keras_nlp.utils.preset_utils import TASK_WEIGHTS_FILE
 from keras_nlp.utils.preset_utils import check_config_class
 from keras_nlp.utils.preset_utils import list_presets
 from keras_nlp.utils.preset_utils import list_subclasses
@@ -320,7 +321,6 @@ class Task(PipelineModel):
         weights_store = keras.src.saving.saving_lib.H5IOStore(
             filepath, mode="r"
         )
-        # Q: when loading task weights, there shouldn't be any backbone layers, why calculate and exclude backbone layers?
         backbone_layer_ids = set(id(w) for w in self.backbone._flatten_layers())
         # TODO: It's better not to use this private API here. Francois recommends chaning our public saving API and skip objects to it. Francoins will do this.
         keras.src.saving.saving_lib._load_state(
@@ -371,7 +371,7 @@ class Task(PipelineModel):
 
         self.preprocessor.save_to_preset(preset)
         self.backbone.save_to_preset(preset)
-        weights_filename = "task.weights.h5"
+        weights_filename = TASK_WEIGHTS_FILE
 
         # TODO: the serialization and saving logic should probably be moved to preset_utils.py
         task_config_path = os.path.join(preset, TASK_CONFIG_FILE)

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -301,25 +301,11 @@ class Task(PipelineModel):
                 f"Received: filepath={filepath}"
             )
         backbone_layer_ids = set(id(w) for w in self.backbone._flatten_layers())
-        weights_store = keras.src.saving.saving_lib.H5IOStore(
-            filepath, mode="r"
-        )
-        keras.src.saving.saving_lib._load_state(
+        keras.saving.save_weights(
             self,
-            weights_store=weights_store,
-            assets_store=None,
-            inner_path="",
-            skip_mismatch=skip_mismatch,
-            visited_trackables=backbone_layer_ids,
-            failed_trackables=set(),
+            filepath,
+            objects_to_skip=backbone_layer_ids,
         )
-        weights_store.close()
-        # TODO: use the following for weight loading when a new version of keras is released.
-        # keras.saving.save_weights(
-        #     self,
-        #     filepath,
-        #     objecst_to_skip=backbone_layer_ids,
-        # )
 
     def save_weights(self, filepath):
         """Save only the tasks specific weights not in the backbone."""
@@ -336,19 +322,11 @@ class Task(PipelineModel):
                 f"Task {self} has no weights not in the `backbone`. "
                 "`save_task_weights()` has nothing to save."
             )
-        weights_store = keras.src.saving.saving_lib.H5IOStore(
-            filepath, mode="w"
-        )
-        keras.src.saving.saving_lib._save_state(
+        keras.saving.save_weights(
             self,
-            weights_store=weights_store,
-            assets_store=None,
-            inner_path="",
-            visited_trackables=backbone_layer_ids,
+            filepath=filepath,
+            objects_to_skip=backbone_layer_ids,
         )
-        weights_store.close()
-        # TODO: use the following for weight loading.
-        # keras.saving.load_weights(filepath, objects_to_skip=backbone_layer_ids)
 
     def save_to_preset(self, preset):
         """Save task to a preset directory.

--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -238,7 +238,7 @@ class Task(PipelineModel):
             task_preset_cls = check_config_class(preset, TASK_CONFIG_FILE)
             task = load_serialized_object(preset, TASK_CONFIG_FILE)
             if load_weights:
-                jax_memory_cleanup()
+                jax_memory_cleanup(task)
                 if check_file_exists(preset, TASK_WEIGHTS_FILE):
                     task.load_task_weights(get_file(preset, TASK_WEIGHTS_FILE))
                 task.backbone.load_weights(get_file(preset, MODEL_WEIGHTS_FILE))

--- a/keras_nlp/models/task_test.py
+++ b/keras_nlp/models/task_test.py
@@ -15,12 +15,13 @@
 import pytest
 
 from keras_nlp.backend import keras
+from keras_nlp.models import CausalLM
+from keras_nlp.models import Preprocessor
+from keras_nlp.models import Task
+from keras_nlp.models import Tokenizer
 from keras_nlp.models.bert.bert_classifier import BertClassifier
 from keras_nlp.models.gpt2.gpt2_causal_lm import GPT2CausalLM
-from keras_nlp.models.preprocessor import Preprocessor
-from keras_nlp.models.task import Task
 from keras_nlp.tests.test_case import TestCase
-from keras_nlp.tokenizers.tokenizer import Tokenizer
 
 
 class SimpleTokenizer(Tokenizer):
@@ -50,6 +51,15 @@ class TestTask(TestCase):
         all_presets = set(Task.presets.keys())
         self.assertContainsSubset(bert_presets, all_presets)
         self.assertContainsSubset(gpt2_presets, all_presets)
+
+    @pytest.mark.large
+    def test_from_preset(self):
+        self.assertIsInstance(
+            CausalLM.from_preset("gpt2_base_en", load_weights=False),
+            GPT2CausalLM,
+        )
+        # TODO: Add a classifier task loading test when there is a classifier
+        # with new design available on Kaggle.
 
     @pytest.mark.large
     def test_from_preset_errors(self):

--- a/keras_nlp/tokenizers/byte_pair_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer.py
@@ -294,6 +294,7 @@ class BytePairTokenizer(tokenizer.Tokenizer):
         self.sequence_length = sequence_length
         self.add_prefix_space = add_prefix_space
         self.unsplittable_tokens = unsplittable_tokens
+        self.file_assets = [VOCAB_FILENAME, MERGES_FILENAME]
 
         # Create byte <=> unicode mapping. This is useful for handling
         # whitespace tokens.

--- a/keras_nlp/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/sentence_piece_tokenizer.py
@@ -124,6 +124,7 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
         self.proto = None
         self.sequence_length = sequence_length
         self.set_proto(proto)
+        self.file_assets = [VOCAB_FILENAME]
 
     def save_assets(self, dir_path):
         path = os.path.join(dir_path, VOCAB_FILENAME)

--- a/keras_nlp/tokenizers/tokenizer.py
+++ b/keras_nlp/tokenizers/tokenizer.py
@@ -152,6 +152,15 @@ class Tokenizer(PreprocessingLayer):
     def call(self, inputs, *args, training=None, **kwargs):
         return self.tokenize(inputs, *args, **kwargs)
 
+    def load_preset_assets(self, preset):
+        asset_path = None
+        for asset in self.file_assets:
+            asset_path = get_file(
+                preset, os.path.join(TOKENIZER_ASSET_DIR, asset)
+            )
+        tokenizer_asset_dir = os.path.dirname(asset_path)
+        self.load_assets(tokenizer_asset_dir)
+
     @classproperty
     def presets(cls):
         """List built-in presets for a `Task` subclass."""
@@ -216,11 +225,5 @@ class Tokenizer(PreprocessingLayer):
             )
 
         tokenizer = load_serialized_object(preset, TOKENIZER_CONFIG_FILE)
-        asset_path = None
-        for asset in tokenizer.file_assets:
-            asset_path = get_file(
-                preset, os.path.join(TOKENIZER_ASSET_DIR, asset)
-            )
-        tokenizer_asset_dir = os.path.dirname(asset_path)
-        tokenizer.load_assets(tokenizer_asset_dir)
+        tokenizer.load_preset_assets(preset)
         return tokenizer

--- a/keras_nlp/tokenizers/tokenizer.py
+++ b/keras_nlp/tokenizers/tokenizer.py
@@ -22,7 +22,9 @@ from keras_nlp.utils.preset_utils import check_config_class
 from keras_nlp.utils.preset_utils import list_presets
 from keras_nlp.utils.preset_utils import list_subclasses
 from keras_nlp.utils.preset_utils import load_tokenizer
-from keras_nlp.utils.preset_utils import save_to_preset
+from keras_nlp.utils.preset_utils import make_preset_dir
+from keras_nlp.utils.preset_utils import save_serialized_object
+from keras_nlp.utils.preset_utils import save_tokenizer_assets
 from keras_nlp.utils.python_utils import classproperty
 
 
@@ -139,7 +141,10 @@ class Tokenizer(PreprocessingLayer):
         Args:
             preset: The path to the local model preset directory.
         """
-        save_to_preset(self, preset, config_filename=TOKENIZER_CONFIG_FILE)
+        make_preset_dir(preset)
+        save_tokenizer_assets(self, preset)
+        save_serialized_object(self, preset, config_file=TOKENIZER_CONFIG_FILE)
+        # save_to_preset(self, preset, config_filename=TOKENIZER_CONFIG_FILE)
 
     def call(self, inputs, *args, training=None, **kwargs):
         return self.tokenize(inputs, *args, **kwargs)

--- a/keras_nlp/tokenizers/tokenizer.py
+++ b/keras_nlp/tokenizers/tokenizer.py
@@ -20,7 +20,6 @@ from keras_nlp.layers.preprocessing.preprocessing_layer import (
 from keras_nlp.utils.preset_utils import TOKENIZER_ASSET_DIR
 from keras_nlp.utils.preset_utils import TOKENIZER_CONFIG_FILE
 from keras_nlp.utils.preset_utils import check_config_class
-from keras_nlp.utils.preset_utils import get_asset_dir
 from keras_nlp.utils.preset_utils import get_file
 from keras_nlp.utils.preset_utils import list_presets
 from keras_nlp.utils.preset_utils import list_subclasses
@@ -217,12 +216,11 @@ class Tokenizer(PreprocessingLayer):
             )
 
         tokenizer = load_serialized_object(preset, TOKENIZER_CONFIG_FILE)
+        asset_path = None
         for asset in tokenizer.file_assets:
-            get_file(preset, os.path.join(TOKENIZER_ASSET_DIR, asset))
-        tokenizer_asset_dir = get_asset_dir(
-            preset,
-            config_file=TOKENIZER_CONFIG_FILE,
-            asset_dir=TOKENIZER_ASSET_DIR,
-        )
+            asset_path = get_file(
+                preset, os.path.join(TOKENIZER_ASSET_DIR, asset)
+            )
+        tokenizer_asset_dir = os.path.dirname(asset_path)
         tokenizer.load_assets(tokenizer_asset_dir)
         return tokenizer

--- a/keras_nlp/tokenizers/tokenizer.py
+++ b/keras_nlp/tokenizers/tokenizer.py
@@ -19,6 +19,7 @@ from keras_nlp.layers.preprocessing.preprocessing_layer import (
 from keras_nlp.utils.preset_utils import TOKENIZER_ASSET_DIR
 from keras_nlp.utils.preset_utils import TOKENIZER_CONFIG_FILE
 from keras_nlp.utils.preset_utils import check_config_class
+from keras_nlp.utils.preset_utils import check_keras_version
 from keras_nlp.utils.preset_utils import list_presets
 from keras_nlp.utils.preset_utils import list_subclasses
 from keras_nlp.utils.preset_utils import load_tokenizer
@@ -141,6 +142,7 @@ class Tokenizer(PreprocessingLayer):
         Args:
             preset: The path to the local model preset directory.
         """
+        check_keras_version()
         make_preset_dir(preset)
         save_tokenizer_assets(self, preset)
         save_serialized_object(self, preset, config_file=TOKENIZER_CONFIG_FILE)

--- a/keras_nlp/tokenizers/tokenizer.py
+++ b/keras_nlp/tokenizers/tokenizer.py
@@ -204,33 +204,29 @@ class Tokenizer(PreprocessingLayer):
                 f"a subclass of calling class `{cls.__name__}`. Call "
                 f"`from_preset` directly on `{preset_cls.__name__}` instead."
             )
-
-        # TODO: preprocessor.json can have a tokenizer class so we can load the tokenizer like TokenizerClass.from_preset(preset).
-        # TODO: Then this tokenizer class validation logic can be moved to Tokenizer.from_preset().
-        # TODO: Tokenizer config should be dropped from the preprocessor.json because tokenizer has a tokenizer.json config.
-        # tokenizer_preset_cls = check_config_class(
-        #     preset, config_file=TOKENIZER_CONFIG_FILE
-        # )
-        # subclasses = list_subclasses(cls)
-        # subclasses = tuple(
-        #     filter(
-        #         lambda x: x.tokenizer_cls == tokenizer_preset_cls,
-        #         subclasses,
-        #     )
-        # )
-        # if len(subclasses) == 0:
-        #     raise ValueError(
-        #         f"No registered subclass of `{cls.__name__}` can load "
-        #         f"a `{tokenizer_preset_cls.__name__}`."
-        #     )
-        # if len(subclasses) > 1:
-        #     names = ", ".join(f"`{x.__name__}`" for x in subclasses)
-        #     raise ValueError(
-        #         f"Ambiguous call to `{cls.__name__}.from_preset()`. "
-        #         f"Found multiple possible subclasses {names}. "
-        #         "Please call `from_preset` on a subclass directly."
-        #     )
-        # tokenizer_cls = subclasses[0]
+        tokenizer_preset_cls = check_config_class(
+            preset, config_file=TOKENIZER_CONFIG_FILE
+        )
+        if tokenizer_preset_cls is not cls:
+            subclasses = list_subclasses(cls)
+            subclasses = tuple(
+                filter(
+                    lambda x: x.tokenizer_cls == tokenizer_preset_cls,
+                    subclasses,
+                )
+            )
+            if len(subclasses) == 0:
+                raise ValueError(
+                    f"No registered subclass of `{cls.__name__}` can load "
+                    f"a `{tokenizer_preset_cls.__name__}`."
+                )
+            if len(subclasses) > 1:
+                names = ", ".join(f"`{x.__name__}`" for x in subclasses)
+                raise ValueError(
+                    f"Ambiguous call to `{cls.__name__}.from_preset()`. "
+                    f"Found multiple possible subclasses {names}. "
+                    "Please call `from_preset` on a subclass directly."
+                )
 
         return load_from_preset(
             preset,

--- a/keras_nlp/tokenizers/tokenizer.py
+++ b/keras_nlp/tokenizers/tokenizer.py
@@ -19,11 +19,9 @@ from keras_nlp.layers.preprocessing.preprocessing_layer import (
 from keras_nlp.utils.preset_utils import TOKENIZER_ASSET_DIR
 from keras_nlp.utils.preset_utils import TOKENIZER_CONFIG_FILE
 from keras_nlp.utils.preset_utils import check_config_class
-from keras_nlp.utils.preset_utils import get_asset_dir
-from keras_nlp.utils.preset_utils import get_file
 from keras_nlp.utils.preset_utils import list_presets
 from keras_nlp.utils.preset_utils import list_subclasses
-from keras_nlp.utils.preset_utils import load_serialized_object
+from keras_nlp.utils.preset_utils import load_tokenizer
 from keras_nlp.utils.preset_utils import save_to_preset
 from keras_nlp.utils.python_utils import classproperty
 
@@ -232,14 +230,8 @@ class Tokenizer(PreprocessingLayer):
                     "Please call `from_preset` on a subclass directly."
                 )
 
-        tokenizer = load_serialized_object(preset, TOKENIZER_CONFIG_FILE)
-
-        # Ensure all the assets exist.
-        for asset in tokenizer_preset_cls.file_assets:
-            get_file(preset, asset)
-        asset_dir = get_asset_dir(
+        return load_tokenizer(
             preset,
-            TOKENIZER_CONFIG_FILE,
-            TOKENIZER_ASSET_DIR,
+            config_file=TOKENIZER_CONFIG_FILE,
+            asset_dir=TOKENIZER_ASSET_DIR,
         )
-        tokenizer.load_assets(asset_dir)

--- a/keras_nlp/tokenizers/tokenizer.py
+++ b/keras_nlp/tokenizers/tokenizer.py
@@ -206,21 +206,18 @@ class Tokenizer(PreprocessingLayer):
                 f"a subclass of calling class `{cls.__name__}`. Call "
                 f"`from_preset` directly on `{preset_cls.__name__}` instead."
             )
-        tokenizer_preset_cls = check_config_class(
-            preset, config_file=TOKENIZER_CONFIG_FILE
-        )
-        if tokenizer_preset_cls is not cls:
+        if preset_cls is not cls:
             subclasses = list_subclasses(cls)
             subclasses = tuple(
                 filter(
-                    lambda x: x.tokenizer_cls == tokenizer_preset_cls,
+                    lambda x: x.tokenizer_cls == preset_cls,
                     subclasses,
                 )
             )
             if len(subclasses) == 0:
                 raise ValueError(
                     f"No registered subclass of `{cls.__name__}` can load "
-                    f"a `{tokenizer_preset_cls.__name__}`."
+                    f"a `{preset_cls.__name__}`."
                 )
             if len(subclasses) > 1:
                 names = ", ".join(f"`{x.__name__}`" for x in subclasses)

--- a/keras_nlp/tokenizers/tokenizer.py
+++ b/keras_nlp/tokenizers/tokenizer.py
@@ -16,11 +16,14 @@ from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.layers.preprocessing.preprocessing_layer import (
     PreprocessingLayer,
 )
+from keras_nlp.utils.preset_utils import TOKENIZER_ASSET_DIR
 from keras_nlp.utils.preset_utils import TOKENIZER_CONFIG_FILE
 from keras_nlp.utils.preset_utils import check_config_class
+from keras_nlp.utils.preset_utils import get_asset_dir
+from keras_nlp.utils.preset_utils import get_file
 from keras_nlp.utils.preset_utils import list_presets
 from keras_nlp.utils.preset_utils import list_subclasses
-from keras_nlp.utils.preset_utils import load_from_preset
+from keras_nlp.utils.preset_utils import load_serialized_object
 from keras_nlp.utils.preset_utils import save_to_preset
 from keras_nlp.utils.python_utils import classproperty
 
@@ -75,6 +78,7 @@ class Tokenizer(PreprocessingLayer):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.file_assets = None
 
     def tokenize(self, inputs, *args, **kwargs):
         """Transform input tensors of strings into output tokens.
@@ -228,8 +232,14 @@ class Tokenizer(PreprocessingLayer):
                     "Please call `from_preset` on a subclass directly."
                 )
 
-        return load_from_preset(
+        tokenizer = load_serialized_object(preset, TOKENIZER_CONFIG_FILE)
+
+        # Ensure all the assets exist.
+        for asset in tokenizer_preset_cls.file_assets:
+            get_file(preset, asset)
+        asset_dir = get_asset_dir(
             preset,
-            config_file=TOKENIZER_CONFIG_FILE,
-            config_overrides=kwargs,
+            TOKENIZER_CONFIG_FILE,
+            TOKENIZER_ASSET_DIR,
         )
+        tokenizer.load_assets(asset_dir)

--- a/keras_nlp/tokenizers/tokenizer.py
+++ b/keras_nlp/tokenizers/tokenizer.py
@@ -20,13 +20,11 @@ from keras_nlp.layers.preprocessing.preprocessing_layer import (
 from keras_nlp.utils.preset_utils import TOKENIZER_ASSET_DIR
 from keras_nlp.utils.preset_utils import TOKENIZER_CONFIG_FILE
 from keras_nlp.utils.preset_utils import check_config_class
-from keras_nlp.utils.preset_utils import check_keras_version
 from keras_nlp.utils.preset_utils import get_asset_dir
 from keras_nlp.utils.preset_utils import get_file
 from keras_nlp.utils.preset_utils import list_presets
 from keras_nlp.utils.preset_utils import list_subclasses
 from keras_nlp.utils.preset_utils import load_serialized_object
-from keras_nlp.utils.preset_utils import make_preset_dir
 from keras_nlp.utils.preset_utils import save_serialized_object
 from keras_nlp.utils.preset_utils import save_tokenizer_assets
 from keras_nlp.utils.python_utils import classproperty
@@ -145,11 +143,8 @@ class Tokenizer(PreprocessingLayer):
         Args:
             preset: The path to the local model preset directory.
         """
-        check_keras_version()
-        make_preset_dir(preset)
-        save_tokenizer_assets(self, preset)
         save_serialized_object(self, preset, config_file=TOKENIZER_CONFIG_FILE)
-        # save_to_preset(self, preset, config_filename=TOKENIZER_CONFIG_FILE)
+        save_tokenizer_assets(self, preset)
 
     def call(self, inputs, *args, training=None, **kwargs):
         return self.tokenize(inputs, *args, **kwargs)

--- a/keras_nlp/tokenizers/tokenizer.py
+++ b/keras_nlp/tokenizers/tokenizer.py
@@ -137,14 +137,18 @@ class Tokenizer(PreprocessingLayer):
             f"{self.__class__.__name__}."
         )
 
-    def save_to_preset(self, preset):
+    def save_to_preset(self, preset_dir):
         """Save tokenizer to a preset directory.
 
         Args:
-            preset: The path to the local model preset directory.
+            preset_dir: The path to the local model preset directory.
         """
-        save_serialized_object(self, preset, config_file=TOKENIZER_CONFIG_FILE)
-        save_tokenizer_assets(self, preset)
+        save_serialized_object(
+            self,
+            preset_dir,
+            config_file=TOKENIZER_CONFIG_FILE,
+        )
+        save_tokenizer_assets(self, preset_dir)
 
     def call(self, inputs, *args, training=None, **kwargs):
         return self.tokenize(inputs, *args, **kwargs)

--- a/keras_nlp/tokenizers/tokenizer.py
+++ b/keras_nlp/tokenizers/tokenizer.py
@@ -195,16 +195,45 @@ class Tokenizer(PreprocessingLayer):
         tokenizer.detokenize([5, 6, 7, 8, 9])
         ```
         """
-        config_file = "tokenizer.json"
-        preset_cls = check_config_class(preset, config_file=config_file)
+        preset_cls = check_config_class(
+            preset, config_file=TOKENIZER_CONFIG_FILE
+        )
         if not issubclass(preset_cls, cls):
             raise ValueError(
                 f"Preset has type `{preset_cls.__name__}` which is not a "
                 f"a subclass of calling class `{cls.__name__}`. Call "
                 f"`from_preset` directly on `{preset_cls.__name__}` instead."
             )
+
+        # TODO: preprocessor.json can have a tokenizer class so we can load the tokenizer like TokenizerClass.from_preset(preset).
+        # TODO: Then this tokenizer class validation logic can be moved to Tokenizer.from_preset().
+        # TODO: Tokenizer config should be dropped from the preprocessor.json because tokenizer has a tokenizer.json config.
+        # tokenizer_preset_cls = check_config_class(
+        #     preset, config_file=TOKENIZER_CONFIG_FILE
+        # )
+        # subclasses = list_subclasses(cls)
+        # subclasses = tuple(
+        #     filter(
+        #         lambda x: x.tokenizer_cls == tokenizer_preset_cls,
+        #         subclasses,
+        #     )
+        # )
+        # if len(subclasses) == 0:
+        #     raise ValueError(
+        #         f"No registered subclass of `{cls.__name__}` can load "
+        #         f"a `{tokenizer_preset_cls.__name__}`."
+        #     )
+        # if len(subclasses) > 1:
+        #     names = ", ".join(f"`{x.__name__}`" for x in subclasses)
+        #     raise ValueError(
+        #         f"Ambiguous call to `{cls.__name__}.from_preset()`. "
+        #         f"Found multiple possible subclasses {names}. "
+        #         "Please call `from_preset` on a subclass directly."
+        #     )
+        # tokenizer_cls = subclasses[0]
+
         return load_from_preset(
             preset,
-            config_file=config_file,
+            config_file=TOKENIZER_CONFIG_FILE,
             config_overrides=kwargs,
         )

--- a/keras_nlp/tokenizers/word_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer.py
@@ -388,6 +388,7 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
                 self.special_tokens
             )
         self.set_vocabulary(vocabulary)
+        self.file_assets = [VOCAB_FILENAME]
 
     def save_assets(self, dir_path):
         path = os.path.join(dir_path, VOCAB_FILENAME)

--- a/keras_nlp/utils/preset_utils.py
+++ b/keras_nlp/utils/preset_utils.py
@@ -401,11 +401,6 @@ def get_asset_dir(
     return os.path.join(config_dir, asset_dir)
 
 
-def check_file_exists(preset, config_file):
-    # TODO: implement this.
-    return True
-
-
 def jax_memory_cleanup(layer):
     # For jax, delete all previous allocated memory to avoid temporarily
     # duplicating variable allocations. torch and tensorflow have stateful

--- a/keras_nlp/utils/preset_utils.py
+++ b/keras_nlp/utils/preset_utils.py
@@ -310,24 +310,17 @@ def _validate_backbone(preset):
         )
     try:
         with open(config_path) as config_file:
-            config = json.load(config_file)
+            json.load(config_file)
     except Exception as e:
         raise ValueError(
             f"Config file `{config_path}` is an invalid json file. "
             f"Error message: {e}"
         )
 
-    if config["weights"]:
-        weights_path = os.path.join(preset, config["weights"])
-        if not os.path.exists(weights_path):
-            raise FileNotFoundError(
-                f"The weights file is missing from the preset directory `{preset}`."
-            )
-    else:
-        raise ValueError(
-            f"No weights listed in `{CONFIG_FILE}`. Make sure to use "
-            "`save_to_preset()` which adds additional data to a serialized "
-            "Keras object."
+    weights_path = os.path.join(preset, MODEL_WEIGHTS_FILE)
+    if not os.path.exists(weights_path):
+        raise FileNotFoundError(
+            f"The weights file is missing from the preset directory `{preset}`."
         )
 
 

--- a/keras_nlp/utils/preset_utils.py
+++ b/keras_nlp/utils/preset_utils.py
@@ -42,6 +42,8 @@ HF_PREFIX = "hf://"
 TOKENIZER_ASSET_DIR = "assets/tokenizer"
 CONFIG_FILE = "config.json"
 TOKENIZER_CONFIG_FILE = "tokenizer.json"
+TASK_CONFIG_FILE = "task.json"
+PREPROCESSOR_CONFIG_FILE = "preprocessor.json"
 
 # Global state for preset registry.
 BUILTIN_PRESETS = {}
@@ -157,6 +159,17 @@ def get_tokenizer(layer):
     if hasattr(layer, "preprocessor"):
         return getattr(layer.preprocessor, "tokenizer", None)
     return None
+
+
+# TODO: delete these:
+# def get_task(layer):
+#     """Get the task from any KerasNLP model or layer."""
+#     # Avoid circular import.
+#     from keras_nlp.models.task import Task
+
+#     if isinstance(layer, Task):
+#         return layer
+#     return None
 
 
 def recursive_pop(config, key):
@@ -364,7 +377,7 @@ def upload_preset(
 def load_from_preset(
     preset,
     load_weights=True,
-    config_file="config.json",
+    config_file=CONFIG_FILE,
     config_overrides={},
 ):
     """Load a KerasNLP layer to a preset directory."""

--- a/keras_nlp/utils/preset_utils.py
+++ b/keras_nlp/utils/preset_utils.py
@@ -161,17 +161,6 @@ def get_tokenizer(layer):
     return None
 
 
-# TODO: delete these:
-# def get_task(layer):
-#     """Get the task from any KerasNLP model or layer."""
-#     # Avoid circular import.
-#     from keras_nlp.models.task import Task
-
-#     if isinstance(layer, Task):
-#         return layer
-#     return None
-
-
 def recursive_pop(config, key):
     """Remove a key from a nested config object"""
     config.pop(key, None)

--- a/keras_nlp/utils/preset_utils.py
+++ b/keras_nlp/utils/preset_utils.py
@@ -414,3 +414,18 @@ def jax_memory_cleanup(layer):
         for weight in layer.weights:
             if getattr(weight, "_value", None) is not None:
                 weight._value.delete()
+
+
+def load_tokenizer(
+    preset, config_file=TOKENIZER_CONFIG_FILE, asset_dir=TOKENIZER_ASSET_DIR
+):
+    tokenizer = load_serialized_object(preset, config_file)
+    for asset in tokenizer.file_assets:
+        get_file(preset, asset)
+    asset_dir = get_asset_dir(
+        preset,
+        config_file,
+        asset_dir,
+    )
+    tokenizer.load_assets(asset_dir)
+    return tokenizer

--- a/keras_nlp/utils/preset_utils.py
+++ b/keras_nlp/utils/preset_utils.py
@@ -262,8 +262,7 @@ def save_metadata(layer, preset):
 
 
 def _validate_tokenizer(preset, allow_incomplete=False):
-    config_path = get_file(preset, TOKENIZER_CONFIG_FILE)
-    if not os.path.exists(config_path):
+    if not check_file_exists(preset, TOKENIZER_CONFIG_FILE):
         if allow_incomplete:
             logging.warning(
                 f"`{TOKENIZER_CONFIG_FILE}` is missing from the preset directory `{preset}`."
@@ -275,6 +274,7 @@ def _validate_tokenizer(preset, allow_incomplete=False):
                 "To upload the model without a tokenizer, "
                 "set `allow_incomplete=True`."
             )
+    config_path = get_file(preset, TOKENIZER_CONFIG_FILE)
     try:
         with open(config_path) as config_file:
             config = json.load(config_file)

--- a/keras_nlp/utils/preset_utils.py
+++ b/keras_nlp/utils/preset_utils.py
@@ -411,14 +411,6 @@ def check_config_class(
     return keras.saving.get_registered_object(config["registered_name"])
 
 
-def get_asset_dir(
-    preset, config_file=TOKENIZER_CONFIG_FILE, asset_dir=TOKENIZER_ASSET_DIR
-):
-    config_path = get_file(preset, config_file)
-    config_dir = os.path.dirname(config_path)
-    return os.path.join(config_dir, asset_dir)
-
-
 def jax_memory_cleanup(layer):
     # For jax, delete all previous allocated memory to avoid temporarily
     # duplicating variable allocations. torch and tensorflow have stateful

--- a/keras_nlp/utils/preset_utils.py
+++ b/keras_nlp/utils/preset_utils.py
@@ -40,10 +40,16 @@ GS_PREFIX = "gs://"
 HF_PREFIX = "hf://"
 
 TOKENIZER_ASSET_DIR = "assets/tokenizer"
+
+# Config file names.
 CONFIG_FILE = "config.json"
 TOKENIZER_CONFIG_FILE = "tokenizer.json"
 TASK_CONFIG_FILE = "task.json"
 PREPROCESSOR_CONFIG_FILE = "preprocessor.json"
+
+# Weight file names.
+MODEL_WEIGHTS_FILE = "model.weights.h5"
+TASK_WEIGHTS_FILE = "task.weights.h5"
 
 # Global state for preset registry.
 BUILTIN_PRESETS = {}
@@ -173,8 +179,8 @@ def save_to_preset(
     layer,
     preset,
     save_weights=True,
-    config_filename="config.json",
-    weights_filename="model.weights.h5",
+    config_filename=CONFIG_FILE,
+    weights_filename=MODEL_WEIGHTS_FILE,
 ):
     """Save a KerasNLP layer to a preset directory."""
     if not backend_config.keras_3():

--- a/keras_nlp/utils/preset_utils.py
+++ b/keras_nlp/utils/preset_utils.py
@@ -286,10 +286,12 @@ def _validate_tokenizer(preset, allow_incomplete=False):
     layer = keras.saving.deserialize_keras_object(config)
 
     for asset in layer.file_assets:
-        asset_path = os.path.join(preset, asset)
+        asset_path = get_file(preset, os.path.join(TOKENIZER_ASSET_DIR, asset))
         if not os.path.exists(asset_path):
+            tokenizer_asset_dir = os.path.dirname(asset_path)
             raise FileNotFoundError(
-                f"Asset `{asset}` doesn't exist in the preset direcotry `{preset}`."
+                f"Asset `{asset}` doesn't exist in the tokenizer asset direcotry"
+                f" `{tokenizer_asset_dir}`."
             )
     config_dir = os.path.dirname(config_path)
     asset_dir = os.path.join(config_dir, TOKENIZER_ASSET_DIR)

--- a/keras_nlp/utils/preset_utils.py
+++ b/keras_nlp/utils/preset_utils.py
@@ -116,7 +116,7 @@ def get_file(preset, path):
             message = str(e)
             if message.find("403 Client Error"):
                 raise FileNotFoundError(
-                    f"`{path}` doesn't exist in preset directory `{preset}`.\n"
+                    f"`{path}` doesn't exist in preset directory `{preset}`."
                 )
             else:
                 raise ValueError(message)
@@ -154,7 +154,7 @@ def get_file(preset, path):
             message = str(e)
             if message.find("403 Client Error"):
                 raise FileNotFoundError(
-                    f"`{path}` doesn't exist in preset directory `{preset}`.\n"
+                    f"`{path}` doesn't exist in preset directory `{preset}`."
                 )
             else:
                 raise ValueError(message)
@@ -163,7 +163,7 @@ def get_file(preset, path):
         local_path = os.path.join(preset, path)
         if not os.path.exists(local_path):
             raise FileNotFoundError(
-                f"`{path}` doesn't exist in preset directory `{preset}`.\n"
+                f"`{path}` doesn't exist in preset directory `{preset}`."
             )
         return local_path
     else:
@@ -209,7 +209,7 @@ def recursive_pop(config, key):
             recursive_pop(value, key)
 
 
-def check_keras_version():
+def check_keras_3():
     if not backend_config.keras_3():
         raise ValueError(
             "`save_to_preset` requires Keras 3. Run `pip install -U keras` "
@@ -235,7 +235,7 @@ def save_serialized_object(
     config_file=CONFIG_FILE,
     config_to_skip=[],
 ):
-    check_keras_version()
+    check_keras_3()
     make_preset_dir(preset)
     config_path = os.path.join(preset, config_file)
     config = keras.saving.serialize_keras_object(layer)

--- a/keras_nlp/utils/preset_utils.py
+++ b/keras_nlp/utils/preset_utils.py
@@ -407,6 +407,17 @@ def load_serialized_object(preset, config_file, config_overrides={}):
     return keras.saving.deserialize_keras_object(config)
 
 
+def save_serialized_object(
+    layer, preset, config_file=CONFIG_FILE, config_to_skip=[]
+):
+    config_path = os.path.join(preset, config_file)
+    config = keras.saving.serialize_keras_object(layer)
+    for c in config_to_skip:
+        recursive_pop(config, c)
+    with open(config_path, "w") as config_file:
+        config_file.write(json.dumps(config, indent=4))
+
+
 def check_config_class(
     preset,
     config_file=CONFIG_FILE,
@@ -441,11 +452,11 @@ def load_tokenizer(
 ):
     tokenizer = load_serialized_object(preset, config_file)
     for asset in tokenizer.file_assets:
-        get_file(preset, asset)
-    asset_dir = get_asset_dir(
+        get_file(preset, os.path.join(asset_dir, asset))
+    tokenizer_asset_dir = get_asset_dir(
         preset,
         config_file,
         asset_dir,
     )
-    tokenizer.load_assets(asset_dir)
+    tokenizer.load_assets(tokenizer_asset_dir)
     return tokenizer

--- a/keras_nlp/utils/preset_utils.py
+++ b/keras_nlp/utils/preset_utils.py
@@ -436,18 +436,3 @@ def jax_memory_cleanup(layer):
         for weight in layer.weights:
             if getattr(weight, "_value", None) is not None:
                 weight._value.delete()
-
-
-def load_tokenizer(
-    preset, config_file=TOKENIZER_CONFIG_FILE, asset_dir=TOKENIZER_ASSET_DIR
-):
-    tokenizer = load_serialized_object(preset, config_file)
-    for asset in tokenizer.file_assets:
-        get_file(preset, os.path.join(asset_dir, asset))
-    tokenizer_asset_dir = get_asset_dir(
-        preset,
-        config_file,
-        asset_dir,
-    )
-    tokenizer.load_assets(tokenizer_asset_dir)
-    return tokenizer

--- a/keras_nlp/utils/preset_utils.py
+++ b/keras_nlp/utils/preset_utils.py
@@ -201,6 +201,15 @@ def recursive_pop(config, key):
             recursive_pop(value, key)
 
 
+def check_keras_version():
+    if not backend_config.keras_3():
+        raise ValueError(
+            "`save_to_preset` requires Keras 3. Run `pip install -U keras` "
+            "upgrade your Keras version, or see https://keras.io/getting_started/ "
+            "for more info on Keras versions and installation."
+        )
+
+
 def make_preset_dir(preset):
     os.makedirs(preset, exist_ok=True)
 

--- a/keras_nlp/utils/preset_utils.py
+++ b/keras_nlp/utils/preset_utils.py
@@ -120,6 +120,14 @@ def get_file(preset, path):
                 )
             else:
                 raise ValueError(message)
+        except ValueError as e:
+            message = str(e)
+            if message.find("is not present in the model files"):
+                raise FileNotFoundError(
+                    f"`{path}` doesn't exist in preset directory `{preset}`."
+                )
+            else:
+                raise ValueError(message)
 
     elif preset.startswith(GS_PREFIX):
         url = os.path.join(preset, path)

--- a/keras_nlp/utils/preset_utils_test.py
+++ b/keras_nlp/utils/preset_utils_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import os
 
 import pytest
@@ -21,83 +20,13 @@ from absl.testing import parameterized
 from keras_nlp import upload_preset
 from keras_nlp.models import AlbertClassifier
 from keras_nlp.models import BertBackbone
-from keras_nlp.models import BertClassifier
 from keras_nlp.models import BertTokenizer
-from keras_nlp.models import RobertaClassifier
 from keras_nlp.tests.test_case import TestCase
 from keras_nlp.utils.preset_utils import CONFIG_FILE
 from keras_nlp.utils.preset_utils import TOKENIZER_CONFIG_FILE
-from keras_nlp.utils.preset_utils import check_config_class
-from keras_nlp.utils.preset_utils import load_from_preset
-from keras_nlp.utils.preset_utils import save_to_preset
 
 
 class PresetUtilsTest(TestCase):
-    @parameterized.parameters(
-        (AlbertClassifier, "albert_base_en_uncased", "sentencepiece"),
-        (RobertaClassifier, "roberta_base_en", "bytepair"),
-        (BertClassifier, "bert_tiny_en_uncased", "wordpiece"),
-    )
-    @pytest.mark.keras_3_only
-    @pytest.mark.large
-    def test_preset_saving(self, cls, preset_name, tokenizer_type):
-        save_dir = self.get_temp_dir()
-        model = cls.from_preset(preset_name, num_classes=2)
-        save_to_preset(model, save_dir)
-
-        if tokenizer_type == "bytepair":
-            vocab_filename = "assets/tokenizer/vocabulary.json"
-            expected_assets = [
-                "assets/tokenizer/vocabulary.json",
-                "assets/tokenizer/merges.txt",
-            ]
-        elif tokenizer_type == "sentencepiece":
-            vocab_filename = "assets/tokenizer/vocabulary.spm"
-            expected_assets = ["assets/tokenizer/vocabulary.spm"]
-        else:
-            vocab_filename = "assets/tokenizer/vocabulary.txt"
-            expected_assets = ["assets/tokenizer/vocabulary.txt"]
-
-        # Check existence of files
-        self.assertTrue(os.path.exists(os.path.join(save_dir, vocab_filename)))
-        self.assertTrue(os.path.exists(os.path.join(save_dir, "config.json")))
-        self.assertTrue(
-            os.path.exists(os.path.join(save_dir, "model.weights.h5"))
-        )
-        self.assertTrue(os.path.exists(os.path.join(save_dir, "metadata.json")))
-
-        # Check the model config (`config.json`)
-        config_json = open(os.path.join(save_dir, "config.json"), "r").read()
-        self.assertTrue(
-            "build_config" not in config_json
-        )  # Test on raw json to include nested keys
-        self.assertTrue(
-            "compile_config" not in config_json
-        )  # Test on raw json to include nested keys
-        config = json.loads(config_json)
-        self.assertEqual(set(config["assets"]), set(expected_assets))
-        self.assertEqual(config["weights"], "model.weights.h5")
-
-        # Try loading the model from preset directory
-        self.assertEqual(cls, check_config_class(save_dir))
-
-        # Try loading the model from preset directory
-        restored_model = load_from_preset(save_dir)
-
-        train_data = (
-            ["the quick brown fox.", "the slow brown fox."],  # Features.
-        )
-        model_input_data = model.preprocessor(*train_data)
-        restored_model_input_data = restored_model.preprocessor(*train_data)
-
-        # Check that saved vocab is equal to the original preset vocab
-        self.assertAllClose(model_input_data, restored_model_input_data)
-
-        # Check model outputs
-        self.assertAllEqual(
-            model(model_input_data), restored_model(restored_model_input_data)
-        )
-
     def test_preset_errors(self):
         with self.assertRaisesRegex(ValueError, "must be a string"):
             AlbertClassifier.from_preset(AlbertClassifier)


### PR DESCRIPTION
To support saving and loading `Task`, the following changes have been made:
* support saving and loading `task.json` and `task.weights.h5`.
* support saving and loading `Preprocessor` (added `preprocessor.json`).
* move preset saving and loading logic to base classes, e.g. Tokenizer, Backbone, etc. and only kept the low-level preset manipulation in `preset_utils.py`.

TODO:
* add unit tests for new functions added to `preset_utils.py`.
* add unit test for saving and loading in each base class.

Future plan: currently backbone and config are called `config.json` and `model.weights.h5`. Our plan is to rename these to `backbone.json` and `backbone.weights.h5` in a followup PR.