### PR TITLE
Fix preprocessor from_preset bug

### DIFF
--- a/keras_nlp/models/preprocessor.py
+++ b/keras_nlp/models/preprocessor.py
@@ -130,23 +130,24 @@ class Preprocessor(PreprocessingLayer):
             )
         config_file = "tokenizer.json"
         preset_cls = check_config_class(preset, config_file=config_file)
-        subclasses = list_subclasses(cls)
-        subclasses = tuple(
-            filter(lambda x: x.tokenizer_cls == preset_cls, subclasses)
-        )
-        if len(subclasses) == 0:
-            raise ValueError(
-                f"No registered subclass of `{cls.__name__}` can load "
-                f"a `{preset_cls.__name__}`."
+        if preset_cls is not cls.tokenizer_cls:
+            subclasses = list_subclasses(cls)
+            subclasses = tuple(
+                filter(lambda x: x.tokenizer_cls == preset_cls, subclasses)
             )
-        if len(subclasses) > 1:
-            names = ", ".join(f"`{x.__name__}`" for x in subclasses)
-            raise ValueError(
-                f"Ambiguous call to `{cls.__name__}.from_preset()`. "
-                f"Found multiple possible subclasses {names}. "
-                "Please call `from_preset` on a subclass directly."
-            )
-        cls = subclasses[0]
+            if len(subclasses) == 0:
+                raise ValueError(
+                    f"No registered subclass of `{cls.__name__}` can load "
+                    f"a `{preset_cls.__name__}`."
+                )
+            if len(subclasses) > 1:
+                names = ", ".join(f"`{x.__name__}`" for x in subclasses)
+                raise ValueError(
+                    f"Ambiguous call to `{cls.__name__}.from_preset()`. "
+                    f"Found multiple possible subclasses {names}. "
+                    "Please call `from_preset` on a subclass directly."
+                )
+            cls = subclasses[0]
         tokenizer = load_from_preset(
             preset,
             config_file=config_file,

--- a/keras_nlp/models/preprocessor_test.py
+++ b/keras_nlp/models/preprocessor_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 import pytest
 
+from keras_nlp.models.bert.bert_masked_lm_preprocessor import (
+    BertMaskedLMPreprocessor,
+)
 from keras_nlp.models.bert.bert_preprocessor import BertPreprocessor
 from keras_nlp.models.gpt2.gpt2_preprocessor import GPT2Preprocessor
 from keras_nlp.models.preprocessor import Preprocessor
@@ -28,10 +31,21 @@ class TestTask(TestCase):
         self.assertContainsSubset(gpt2_presets, all_presets)
 
     @pytest.mark.large
+    def test_from_preset(self):
+        self.assertIsInstance(
+            BertPreprocessor.from_preset("bert_tiny_en_uncased"),
+            BertPreprocessor,
+        )
+        self.assertIsInstance(
+            BertMaskedLMPreprocessor.from_preset("bert_tiny_en_uncased"),
+            BertMaskedLMPreprocessor,
+        )
+
+    @pytest.mark.large
     def test_from_preset_errors(self):
         with self.assertRaises(ValueError):
             # No loading on a preprocessor directly (it is ambiguous).
-            Preprocessor.from_preset("bert_tiny_en_uncased", load_weights=False)
+            Preprocessor.from_preset("bert_tiny_en_uncased")
         with self.assertRaises(ValueError):
             # No loading on an incorrect class.
-            BertPreprocessor.from_preset("gpt2_base_en", load_weights=False)
+            BertPreprocessor.from_preset("gpt2_base_en")


### PR DESCRIPTION
Our logic was slight messed up where calls like
GemmaCausalLMPreprocessor.from_preset("gemma_2b_en") would always fail.