### PR TITLE
Improve error handling for missing TensorFlow dependency in keras_nlp.

### DIFF
--- a/examples/utils/data_utils.py
+++ b/examples/utils/data_utils.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 from google import protobuf
 

--- a/examples/utils/data_utils.py
+++ b/examples/utils/data_utils.py
@@ -15,7 +15,13 @@
 
 import os
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 from google import protobuf
 
 

--- a/keras_nlp/backend/keras.py
+++ b/keras_nlp/backend/keras.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.backend import config

--- a/keras_nlp/backend/keras.py
+++ b/keras_nlp/backend/keras.py
@@ -14,7 +14,13 @@
 
 import types
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.backend import config
 

--- a/keras_nlp/conftest.py
+++ b/keras_nlp/conftest.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.backend import config as backend_config

--- a/keras_nlp/conftest.py
+++ b/keras_nlp/conftest.py
@@ -15,7 +15,14 @@
 import os
 
 import pytest
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.backend import config as backend_config
 from keras_nlp.backend import keras

--- a/keras_nlp/layers/preprocessing/masked_lm_mask_generator.py
+++ b/keras_nlp/layers/preprocessing/masked_lm_mask_generator.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.layers.preprocessing.preprocessing_layer import (

--- a/keras_nlp/layers/preprocessing/masked_lm_mask_generator.py
+++ b/keras_nlp/layers/preprocessing/masked_lm_mask_generator.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/layers/preprocessing/masked_lm_mask_generator_test.py
+++ b/keras_nlp/layers/preprocessing/masked_lm_mask_generator_test.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.backend import ops

--- a/keras_nlp/layers/preprocessing/masked_lm_mask_generator_test.py
+++ b/keras_nlp/layers/preprocessing/masked_lm_mask_generator_test.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.backend import ops
 from keras_nlp.layers.preprocessing.masked_lm_mask_generator import (

--- a/keras_nlp/layers/preprocessing/multi_segment_packer.py
+++ b/keras_nlp/layers/preprocessing/multi_segment_packer.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.layers.preprocessing.preprocessing_layer import (

--- a/keras_nlp/layers/preprocessing/multi_segment_packer.py
+++ b/keras_nlp/layers/preprocessing/multi_segment_packer.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/layers/preprocessing/preprocessing_layer.py
+++ b/keras_nlp/layers/preprocessing/preprocessing_layer.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 import tree
 

--- a/keras_nlp/layers/preprocessing/preprocessing_layer.py
+++ b/keras_nlp/layers/preprocessing/preprocessing_layer.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 import tree
 
 from keras_nlp.backend import config

--- a/keras_nlp/layers/preprocessing/random_deletion.py
+++ b/keras_nlp/layers/preprocessing/random_deletion.py
@@ -14,7 +14,13 @@
 
 import random
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.layers.preprocessing.preprocessing_layer import (

--- a/keras_nlp/layers/preprocessing/random_deletion.py
+++ b/keras_nlp/layers/preprocessing/random_deletion.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/layers/preprocessing/random_deletion_test.py
+++ b/keras_nlp/layers/preprocessing/random_deletion_test.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.backend import keras

--- a/keras_nlp/layers/preprocessing/random_deletion_test.py
+++ b/keras_nlp/layers/preprocessing/random_deletion_test.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.backend import keras
 from keras_nlp.layers.preprocessing.random_deletion import RandomDeletion

--- a/keras_nlp/layers/preprocessing/random_swap.py
+++ b/keras_nlp/layers/preprocessing/random_swap.py
@@ -14,7 +14,13 @@
 
 import random
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.layers.preprocessing.preprocessing_layer import (

--- a/keras_nlp/layers/preprocessing/random_swap.py
+++ b/keras_nlp/layers/preprocessing/random_swap.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/layers/preprocessing/random_swap_test.py
+++ b/keras_nlp/layers/preprocessing/random_swap_test.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.backend import keras

--- a/keras_nlp/layers/preprocessing/random_swap_test.py
+++ b/keras_nlp/layers/preprocessing/random_swap_test.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.backend import keras
 from keras_nlp.layers.preprocessing.random_swap import RandomSwap

--- a/keras_nlp/layers/preprocessing/start_end_packer.py
+++ b/keras_nlp/layers/preprocessing/start_end_packer.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.layers.preprocessing.preprocessing_layer import (

--- a/keras_nlp/layers/preprocessing/start_end_packer.py
+++ b/keras_nlp/layers/preprocessing/start_end_packer.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/layers/preprocessing/start_end_packer_test.py
+++ b/keras_nlp/layers/preprocessing/start_end_packer_test.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.layers.preprocessing.start_end_packer import StartEndPacker

--- a/keras_nlp/layers/preprocessing/start_end_packer_test.py
+++ b/keras_nlp/layers/preprocessing/start_end_packer_test.py
@@ -14,7 +14,14 @@
 
 import keras
 import pytest
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.layers.preprocessing.start_end_packer import StartEndPacker
 from keras_nlp.tests.test_case import TestCase

--- a/keras_nlp/metrics/bleu.py
+++ b/keras_nlp/metrics/bleu.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/metrics/bleu.py
+++ b/keras_nlp/metrics/bleu.py
@@ -15,7 +15,13 @@
 import collections
 import math
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.backend import keras

--- a/keras_nlp/metrics/bleu_test.py
+++ b/keras_nlp/metrics/bleu_test.py
@@ -13,7 +13,14 @@
 # limitations under the License.
 
 import pytest
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.backend import keras
 from keras_nlp.metrics.bleu import Bleu

--- a/keras_nlp/metrics/bleu_test.py
+++ b/keras_nlp/metrics/bleu_test.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.backend import keras

--- a/keras_nlp/metrics/edit_distance.py
+++ b/keras_nlp/metrics/edit_distance.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/metrics/edit_distance.py
+++ b/keras_nlp/metrics/edit_distance.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.backend import keras

--- a/keras_nlp/metrics/edit_distance_test.py
+++ b/keras_nlp/metrics/edit_distance_test.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.backend import keras

--- a/keras_nlp/metrics/edit_distance_test.py
+++ b/keras_nlp/metrics/edit_distance_test.py
@@ -13,7 +13,14 @@
 # limitations under the License.
 
 import pytest
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.backend import keras
 from keras_nlp.metrics.edit_distance import EditDistance

--- a/keras_nlp/metrics/rouge_base.py
+++ b/keras_nlp/metrics/rouge_base.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.backend import keras

--- a/keras_nlp/metrics/rouge_base.py
+++ b/keras_nlp/metrics/rouge_base.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.backend import keras
 from keras_nlp.backend import ops

--- a/keras_nlp/metrics/rouge_l_test.py
+++ b/keras_nlp/metrics/rouge_l_test.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.metrics.rouge_l import RougeL

--- a/keras_nlp/metrics/rouge_l_test.py
+++ b/keras_nlp/metrics/rouge_l_test.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.metrics.rouge_l import RougeL
 from keras_nlp.tests.test_case import TestCase

--- a/keras_nlp/metrics/rouge_n_test.py
+++ b/keras_nlp/metrics/rouge_n_test.py
@@ -13,7 +13,14 @@
 # limitations under the License.
 
 import pytest
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.backend import keras
 from keras_nlp.metrics.rouge_n import RougeN

--- a/keras_nlp/metrics/rouge_n_test.py
+++ b/keras_nlp/metrics/rouge_n_test.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.backend import keras

--- a/keras_nlp/models/bart/bart_preprocessor_test.py
+++ b/keras_nlp/models/bart/bart_preprocessor_test.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.models.bart.bart_preprocessor import BartPreprocessor

--- a/keras_nlp/models/bart/bart_preprocessor_test.py
+++ b/keras_nlp/models/bart/bart_preprocessor_test.py
@@ -13,7 +13,14 @@
 # limitations under the License.
 
 import pytest
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.models.bart.bart_preprocessor import BartPreprocessor
 from keras_nlp.models.bart.bart_tokenizer import BartTokenizer

--- a/keras_nlp/models/bart/bart_seq_2_seq_lm_preprocessor.py
+++ b/keras_nlp/models/bart/bart_seq_2_seq_lm_preprocessor.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 from absl import logging
 

--- a/keras_nlp/models/bart/bart_seq_2_seq_lm_preprocessor.py
+++ b/keras_nlp/models/bart/bart_seq_2_seq_lm_preprocessor.py
@@ -13,7 +13,13 @@
 # limitations under the License.
 
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 from absl import logging
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/models/bloom/bloom_causal_lm_preprocessor.py
+++ b/keras_nlp/models/bloom/bloom_causal_lm_preprocessor.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 from absl import logging
 

--- a/keras_nlp/models/bloom/bloom_causal_lm_preprocessor.py
+++ b/keras_nlp/models/bloom/bloom_causal_lm_preprocessor.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 from absl import logging
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/models/causal_lm.py
+++ b/keras_nlp/models/causal_lm.py
@@ -15,7 +15,13 @@
 import itertools
 from functools import partial
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 import tree
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/models/causal_lm.py
+++ b/keras_nlp/models/causal_lm.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 import tree
 

--- a/keras_nlp/models/deberta_v3/deberta_v3_tokenizer.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_tokenizer.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/models/deberta_v3/deberta_v3_tokenizer.py
+++ b/keras_nlp/models/deberta_v3/deberta_v3_tokenizer.py
@@ -13,7 +13,13 @@
 # limitations under the License.
 
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.tokenizers.sentence_piece_tokenizer import SentencePieceTokenizer

--- a/keras_nlp/models/falcon/falcon_causal_lm_preprocessor.py
+++ b/keras_nlp/models/falcon/falcon_causal_lm_preprocessor.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 from absl import logging
 

--- a/keras_nlp/models/falcon/falcon_causal_lm_preprocessor.py
+++ b/keras_nlp/models/falcon/falcon_causal_lm_preprocessor.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 from absl import logging
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/models/gemma/gemma_causal_lm_preprocessor.py
+++ b/keras_nlp/models/gemma/gemma_causal_lm_preprocessor.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 from absl import logging
 

--- a/keras_nlp/models/gemma/gemma_causal_lm_preprocessor.py
+++ b/keras_nlp/models/gemma/gemma_causal_lm_preprocessor.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 from absl import logging
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/models/gpt2/gpt2_causal_lm_preprocessor.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm_preprocessor.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 from absl import logging
 

--- a/keras_nlp/models/gpt2/gpt2_causal_lm_preprocessor.py
+++ b/keras_nlp/models/gpt2/gpt2_causal_lm_preprocessor.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 from absl import logging
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/models/gpt_neo_x/gpt_neo_x_causal_lm_preprocessor.py
+++ b/keras_nlp/models/gpt_neo_x/gpt_neo_x_causal_lm_preprocessor.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 from absl import logging
 

--- a/keras_nlp/models/gpt_neo_x/gpt_neo_x_causal_lm_preprocessor.py
+++ b/keras_nlp/models/gpt_neo_x/gpt_neo_x_causal_lm_preprocessor.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 from absl import logging
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/models/gpt_neo_x/gpt_neo_x_causal_lm_preprocessor_test.py
+++ b/keras_nlp/models/gpt_neo_x/gpt_neo_x_causal_lm_preprocessor_test.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.models.gpt_neo_x.gpt_neo_x_causal_lm_preprocessor import (

--- a/keras_nlp/models/gpt_neo_x/gpt_neo_x_causal_lm_preprocessor_test.py
+++ b/keras_nlp/models/gpt_neo_x/gpt_neo_x_causal_lm_preprocessor_test.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.models.gpt_neo_x.gpt_neo_x_causal_lm_preprocessor import (
     GPTNeoXCausalLMPreprocessor,

--- a/keras_nlp/models/llama/llama_causal_lm_preprocessor.py
+++ b/keras_nlp/models/llama/llama_causal_lm_preprocessor.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 from absl import logging
 

--- a/keras_nlp/models/llama/llama_causal_lm_preprocessor.py
+++ b/keras_nlp/models/llama/llama_causal_lm_preprocessor.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 from absl import logging
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/models/mistral/mistral_causal_lm_preprocessor.py
+++ b/keras_nlp/models/mistral/mistral_causal_lm_preprocessor.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 from absl import logging
 

--- a/keras_nlp/models/mistral/mistral_causal_lm_preprocessor.py
+++ b/keras_nlp/models/mistral/mistral_causal_lm_preprocessor.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 from absl import logging
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/models/opt/opt_causal_lm_preprocessor.py
+++ b/keras_nlp/models/opt/opt_causal_lm_preprocessor.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 from absl import logging
 

--- a/keras_nlp/models/opt/opt_causal_lm_preprocessor.py
+++ b/keras_nlp/models/opt/opt_causal_lm_preprocessor.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 from absl import logging
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/models/whisper/whisper_audio_feature_extractor.py
+++ b/keras_nlp/models/whisper/whisper_audio_feature_extractor.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/models/whisper/whisper_audio_feature_extractor.py
+++ b/keras_nlp/models/whisper/whisper_audio_feature_extractor.py
@@ -14,7 +14,14 @@
 
 
 import numpy as np
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.layers.preprocessing.preprocessing_layer import (

--- a/keras_nlp/models/whisper/whisper_audio_feature_extractor_test.py
+++ b/keras_nlp/models/whisper/whisper_audio_feature_extractor_test.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.models.whisper.whisper_audio_feature_extractor import (
     WhisperAudioFeatureExtractor,

--- a/keras_nlp/models/whisper/whisper_audio_feature_extractor_test.py
+++ b/keras_nlp/models/whisper/whisper_audio_feature_extractor_test.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.models.whisper.whisper_audio_feature_extractor import (

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_tokenizer.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_tokenizer.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/models/xlm_roberta/xlm_roberta_tokenizer.py
+++ b/keras_nlp/models/xlm_roberta/xlm_roberta_tokenizer.py
@@ -13,7 +13,13 @@
 # limitations under the License.
 
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.tokenizers.sentence_piece_tokenizer import SentencePieceTokenizer

--- a/keras_nlp/samplers/beam_sampler.py
+++ b/keras_nlp/samplers/beam_sampler.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 import tree
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/samplers/beam_sampler.py
+++ b/keras_nlp/samplers/beam_sampler.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 import tree
 

--- a/keras_nlp/samplers/beam_sampler_test.py
+++ b/keras_nlp/samplers/beam_sampler_test.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 from absl.testing import parameterized
 

--- a/keras_nlp/samplers/beam_sampler_test.py
+++ b/keras_nlp/samplers/beam_sampler_test.py
@@ -13,7 +13,14 @@
 # limitations under the License.
 
 import pytest
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 from absl.testing import parameterized
 
 from keras_nlp.backend import ops

--- a/keras_nlp/samplers/contrastive_sampler_test.py
+++ b/keras_nlp/samplers/contrastive_sampler_test.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 from absl.testing import parameterized
 

--- a/keras_nlp/samplers/contrastive_sampler_test.py
+++ b/keras_nlp/samplers/contrastive_sampler_test.py
@@ -14,7 +14,14 @@
 
 import numpy as np
 import pytest
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 from absl.testing import parameterized
 
 from keras_nlp.backend import ops

--- a/keras_nlp/samplers/greedy_sampler_test.py
+++ b/keras_nlp/samplers/greedy_sampler_test.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 from absl.testing import parameterized
 

--- a/keras_nlp/samplers/greedy_sampler_test.py
+++ b/keras_nlp/samplers/greedy_sampler_test.py
@@ -13,7 +13,14 @@
 # limitations under the License.
 
 import pytest
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 from absl.testing import parameterized
 
 from keras_nlp.backend import ops

--- a/keras_nlp/samplers/random_sampler_test.py
+++ b/keras_nlp/samplers/random_sampler_test.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 from absl.testing import parameterized
 

--- a/keras_nlp/samplers/random_sampler_test.py
+++ b/keras_nlp/samplers/random_sampler_test.py
@@ -14,7 +14,14 @@
 
 import numpy as np
 import pytest
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 from absl.testing import parameterized
 
 from keras_nlp.backend import ops

--- a/keras_nlp/samplers/top_k_sampler_test.py
+++ b/keras_nlp/samplers/top_k_sampler_test.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 from absl.testing import parameterized
 

--- a/keras_nlp/samplers/top_k_sampler_test.py
+++ b/keras_nlp/samplers/top_k_sampler_test.py
@@ -13,7 +13,14 @@
 # limitations under the License.
 
 import pytest
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 from absl.testing import parameterized
 
 from keras_nlp.backend import ops

--- a/keras_nlp/samplers/top_p_sampler_test.py
+++ b/keras_nlp/samplers/top_p_sampler_test.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 from absl.testing import parameterized
 

--- a/keras_nlp/samplers/top_p_sampler_test.py
+++ b/keras_nlp/samplers/top_p_sampler_test.py
@@ -14,7 +14,14 @@
 
 import numpy as np
 import pytest
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 from absl.testing import parameterized
 
 from keras_nlp.backend import ops

--- a/keras_nlp/tests/doc_tests/docstring_test.py
+++ b/keras_nlp/tests/doc_tests/docstring_test.py
@@ -21,7 +21,14 @@ import unittest
 import numpy as np
 import pytest
 import sentencepiece
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 import keras_nlp
 from keras_nlp.backend import keras

--- a/keras_nlp/tests/doc_tests/docstring_test.py
+++ b/keras_nlp/tests/doc_tests/docstring_test.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 import keras_nlp

--- a/keras_nlp/tests/test_case.py
+++ b/keras_nlp/tests/test_case.py
@@ -22,7 +22,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 import tree
 from absl.testing import parameterized

--- a/keras_nlp/tests/test_case.py
+++ b/keras_nlp/tests/test_case.py
@@ -17,7 +17,13 @@ import os
 import pathlib
 import re
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 import tree
 from absl.testing import parameterized
 

--- a/keras_nlp/tokenizers/byte_pair_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer.py
@@ -31,7 +31,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/tokenizers/byte_pair_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_pair_tokenizer.py
@@ -25,7 +25,14 @@ from typing import Iterable
 
 import keras
 import regex as re
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.tokenizers import tokenizer

--- a/keras_nlp/tokenizers/byte_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_tokenizer.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/tokenizers/byte_tokenizer.py
+++ b/keras_nlp/tokenizers/byte_tokenizer.py
@@ -13,7 +13,14 @@
 # limitations under the License.
 
 import numpy as np
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.tokenizers import tokenizer

--- a/keras_nlp/tokenizers/byte_tokenizer_test.py
+++ b/keras_nlp/tokenizers/byte_tokenizer_test.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.tests.test_case import TestCase
 from keras_nlp.tokenizers.byte_tokenizer import ByteTokenizer

--- a/keras_nlp/tokenizers/byte_tokenizer_test.py
+++ b/keras_nlp/tokenizers/byte_tokenizer_test.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.tests.test_case import TestCase

--- a/keras_nlp/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/sentence_piece_tokenizer.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/sentence_piece_tokenizer.py
@@ -17,7 +17,14 @@ import binascii
 import os
 
 import keras
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.tokenizers import tokenizer

--- a/keras_nlp/tokenizers/sentence_piece_tokenizer_test.py
+++ b/keras_nlp/tokenizers/sentence_piece_tokenizer_test.py
@@ -14,7 +14,13 @@
 
 import os
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.tests.test_case import TestCase
 from keras_nlp.tokenizers.sentence_piece_tokenizer import SentencePieceTokenizer

--- a/keras_nlp/tokenizers/sentence_piece_tokenizer_test.py
+++ b/keras_nlp/tokenizers/sentence_piece_tokenizer_test.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.tests.test_case import TestCase

--- a/keras_nlp/tokenizers/sentence_piece_tokenizer_trainer.py
+++ b/keras_nlp/tokenizers/sentence_piece_tokenizer_trainer.py
@@ -14,7 +14,13 @@
 
 import io
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 try:
     import sentencepiece as spm

--- a/keras_nlp/tokenizers/sentence_piece_tokenizer_trainer.py
+++ b/keras_nlp/tokenizers/sentence_piece_tokenizer_trainer.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 try:

--- a/keras_nlp/tokenizers/sentence_piece_tokenizer_trainer_test.py
+++ b/keras_nlp/tokenizers/sentence_piece_tokenizer_trainer_test.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.tests.test_case import TestCase

--- a/keras_nlp/tokenizers/sentence_piece_tokenizer_trainer_test.py
+++ b/keras_nlp/tokenizers/sentence_piece_tokenizer_trainer_test.py
@@ -15,7 +15,13 @@
 import os
 import re
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.tests.test_case import TestCase
 from keras_nlp.tokenizers.sentence_piece_tokenizer import SentencePieceTokenizer

--- a/keras_nlp/tokenizers/tokenizer_test.py
+++ b/keras_nlp/tokenizers/tokenizer_test.py
@@ -15,7 +15,14 @@
 import os
 
 import pytest
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 from absl.testing import parameterized
 
 from keras_nlp.models.albert.albert_tokenizer import AlbertTokenizer

--- a/keras_nlp/tokenizers/tokenizer_test.py
+++ b/keras_nlp/tokenizers/tokenizer_test.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 from absl.testing import parameterized
 

--- a/keras_nlp/tokenizers/unicode_codepoint_tokenizer_test.py
+++ b/keras_nlp/tokenizers/unicode_codepoint_tokenizer_test.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.tests.test_case import TestCase

--- a/keras_nlp/tokenizers/unicode_codepoint_tokenizer_test.py
+++ b/keras_nlp/tokenizers/unicode_codepoint_tokenizer_test.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.tests.test_case import TestCase
 from keras_nlp.tokenizers.unicode_codepoint_tokenizer import (

--- a/keras_nlp/tokenizers/word_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/tokenizers/word_piece_tokenizer.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer.py
@@ -17,7 +17,14 @@ import re
 from typing import Iterable
 
 import keras
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.tokenizers import tokenizer

--- a/keras_nlp/tokenizers/word_piece_tokenizer_test.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer_test.py
@@ -14,7 +14,13 @@
 
 import os
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.tests.test_case import TestCase
 from keras_nlp.tokenizers.word_piece_tokenizer import WordPieceTokenizer

--- a/keras_nlp/tokenizers/word_piece_tokenizer_test.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer_test.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.tests.test_case import TestCase

--- a/keras_nlp/tokenizers/word_piece_tokenizer_trainer.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer_trainer.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.api_export import keras_nlp_export

--- a/keras_nlp/tokenizers/word_piece_tokenizer_trainer.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer_trainer.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.tokenizers.word_piece_tokenizer import pretokenize

--- a/keras_nlp/tokenizers/word_piece_tokenizer_trainer_test.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer_trainer_test.py
@@ -14,7 +14,13 @@
 
 import os
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.tests.test_case import TestCase
 from keras_nlp.tokenizers.word_piece_tokenizer_trainer import (

--- a/keras_nlp/tokenizers/word_piece_tokenizer_trainer_test.py
+++ b/keras_nlp/tokenizers/word_piece_tokenizer_trainer_test.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.tests.test_case import TestCase

--- a/keras_nlp/utils/keras_utils.py
+++ b/keras_nlp/utils/keras_utils.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 from absl import logging
 

--- a/keras_nlp/utils/keras_utils.py
+++ b/keras_nlp/utils/keras_utils.py
@@ -14,7 +14,13 @@
 
 import sys
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 from absl import logging
 
 from keras_nlp.backend import keras

--- a/keras_nlp/utils/keras_utils_test.py
+++ b/keras_nlp/utils/keras_utils_test.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.backend import keras

--- a/keras_nlp/utils/keras_utils_test.py
+++ b/keras_nlp/utils/keras_utils_test.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.backend import keras
 from keras_nlp.tests.test_case import TestCase

--- a/keras_nlp/utils/pipeline_model.py
+++ b/keras_nlp/utils/pipeline_model.py
@@ -15,7 +15,13 @@
 import functools
 import math
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 import tree
 
 from keras_nlp.backend import keras

--- a/keras_nlp/utils/pipeline_model.py
+++ b/keras_nlp/utils/pipeline_model.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 import tree
 

--- a/keras_nlp/utils/pipeline_model_test.py
+++ b/keras_nlp/utils/pipeline_model_test.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.backend import keras

--- a/keras_nlp/utils/pipeline_model_test.py
+++ b/keras_nlp/utils/pipeline_model_test.py
@@ -15,7 +15,14 @@
 import os
 
 import numpy as np
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.backend import keras
 from keras_nlp.tests.test_case import TestCase

--- a/keras_nlp/utils/tensor_utils.py
+++ b/keras_nlp/utils/tensor_utils.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.backend import config

--- a/keras_nlp/utils/tensor_utils.py
+++ b/keras_nlp/utils/tensor_utils.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.backend import config
 from keras_nlp.backend import keras

--- a/keras_nlp/utils/tensor_utils_test.py
+++ b/keras_nlp/utils/tensor_utils_test.py
@@ -13,7 +13,14 @@
 # limitations under the License.
 
 import numpy as np
-import tensorflow as tf
+
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "Tensorflow package is required for data preprocessing with any backend."
+    )
 
 from keras_nlp.backend import ops
 from keras_nlp.tests.test_case import TestCase

--- a/keras_nlp/utils/tensor_utils_test.py
+++ b/keras_nlp/utils/tensor_utils_test.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     raise ImportError(
         "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "Tensorflow package is required for data preprocessing with any backend."
+        "The TensorFlow package is required for data preprocessing with any backend."
     )
 
 from keras_nlp.backend import ops


### PR DESCRIPTION
This PR addresses [this issue](https://github.com/keras-team/keras/issues/19542): user doesn't have `tensorflow` installed and doesn't expect to get error as they're using `pytorch` backend.