### PR TITLE
Add Saving Tests

### DIFF
--- a/keras_nlp/models/backbone_test.py
+++ b/keras_nlp/models/backbone_test.py
@@ -11,13 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
+
+import numpy as np
 import pytest
 
 from keras_nlp.models.backbone import Backbone
 from keras_nlp.models.bert.bert_backbone import BertBackbone
 from keras_nlp.models.gpt2.gpt2_backbone import GPT2Backbone
 from keras_nlp.tests.test_case import TestCase
+from keras_nlp.utils.preset_utils import CONFIG_FILE
 from keras_nlp.utils.preset_utils import METADATA_FILE
+from keras_nlp.utils.preset_utils import MODEL_WEIGHTS_FILE
+from keras_nlp.utils.preset_utils import check_config_class
+from keras_nlp.utils.preset_utils import load_config
 
 
 class TestTask(TestCase):
@@ -48,3 +55,39 @@ class TestTask(TestCase):
         ):
             # No loading on a non-keras model.
             Backbone.from_preset("hf://google-bert/bert-base-uncased")
+
+    @pytest.mark.keras_3_only
+    @pytest.mark.large
+    def test_save_to_preset(self):
+        save_dir = self.get_temp_dir()
+        backbone = Backbone.from_preset("bert_tiny_en_uncased")
+        backbone.save_to_preset(save_dir)
+
+        # Check existence of files.
+        self.assertTrue(os.path.exists(os.path.join(save_dir, CONFIG_FILE)))
+        self.assertTrue(
+            os.path.exists(os.path.join(save_dir, MODEL_WEIGHTS_FILE))
+        )
+        self.assertTrue(os.path.exists(os.path.join(save_dir, METADATA_FILE)))
+
+        # Check the backbone config (`config.json`).
+        backbone_config = load_config(save_dir, CONFIG_FILE)
+        self.assertTrue("build_config" not in backbone_config)
+        self.assertTrue("compile_config" not in backbone_config)
+
+        # Try config class.
+        self.assertEqual(BertBackbone, check_config_class(save_dir))
+
+        # Try loading the model from preset directory.
+        restored_backbone = Backbone.from_preset(save_dir)
+
+        data = {
+            "token_ids": np.ones(shape=(2, 10), dtype="int32"),
+            "segment_ids": np.array([[0, 0, 0, 1, 1, 1, 1, 1, 0, 0]] * 2),
+            "padding_mask": np.array([[1, 1, 1, 1, 1, 1, 1, 1, 0, 0]] * 2),
+        }
+
+        # Check the model output.
+        ref_out = backbone(data)
+        new_out = restored_backbone(data)
+        self.assertAllClose(ref_out, new_out)

--- a/keras_nlp/models/preprocessor_test.py
+++ b/keras_nlp/models/preprocessor_test.py
@@ -91,7 +91,7 @@ class TestTask(TestCase):
             vocab_filename = "vocabulary.txt"
             expected_assets = ["vocabulary.txt"]
 
-        # Check existence of files.
+        # Check existence of vocab file.
         vocab_path = os.path.join(
             save_dir, os.path.join(TOKENIZER_ASSET_DIR, vocab_filename)
         )

--- a/keras_nlp/models/preprocessor_test.py
+++ b/keras_nlp/models/preprocessor_test.py
@@ -11,16 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import pytest
+import os
 
+import pytest
+from absl.testing import parameterized
+
+from keras_nlp.models.albert.albert_preprocessor import AlbertPreprocessor
 from keras_nlp.models.bert.bert_masked_lm_preprocessor import (
     BertMaskedLMPreprocessor,
 )
 from keras_nlp.models.bert.bert_preprocessor import BertPreprocessor
 from keras_nlp.models.gpt2.gpt2_preprocessor import GPT2Preprocessor
 from keras_nlp.models.preprocessor import Preprocessor
+from keras_nlp.models.roberta.roberta_preprocessor import RobertaPreprocessor
 from keras_nlp.tests.test_case import TestCase
 from keras_nlp.utils.preset_utils import METADATA_FILE
+from keras_nlp.utils.preset_utils import PREPROCESSOR_CONFIG_FILE
+from keras_nlp.utils.preset_utils import TOKENIZER_ASSET_DIR
+from keras_nlp.utils.preset_utils import check_config_class
 
 
 class TestTask(TestCase):
@@ -57,3 +65,45 @@ class TestTask(TestCase):
             Preprocessor.from_preset("hf://google-bert/bert-base-uncased")
 
     # TODO: Add more tests when we added a model that has `preprocessor.json`.
+
+    @parameterized.parameters(
+        (AlbertPreprocessor, "albert_base_en_uncased", "sentencepiece"),
+        (RobertaPreprocessor, "roberta_base_en", "bytepair"),
+        (BertPreprocessor, "bert_tiny_en_uncased", "wordpiece"),
+    )
+    @pytest.mark.keras_3_only
+    @pytest.mark.large
+    def test_save_to_preset(self, cls, preset_name, tokenizer_type):
+        save_dir = self.get_temp_dir()
+        preprocessor = cls.from_preset(preset_name)
+        preprocessor.save_to_preset(save_dir)
+
+        if tokenizer_type == "bytepair":
+            vocab_filename = "vocabulary.json"
+            expected_assets = [
+                "vocabulary.json",
+                "merges.txt",
+            ]
+        elif tokenizer_type == "sentencepiece":
+            vocab_filename = "vocabulary.spm"
+            expected_assets = ["vocabulary.spm"]
+        else:
+            vocab_filename = "vocabulary.txt"
+            expected_assets = ["vocabulary.txt"]
+
+        # Check existence of files.
+        vocab_path = os.path.join(
+            save_dir, os.path.join(TOKENIZER_ASSET_DIR, vocab_filename)
+        )
+        self.assertTrue(os.path.exists(vocab_path))
+
+        # Check assets.
+        self.assertEqual(
+            set(preprocessor.tokenizer.file_assets),
+            set(expected_assets),
+        )
+
+        # Check config class.
+        self.assertEqual(
+            cls, check_config_class(save_dir, PREPROCESSOR_CONFIG_FILE)
+        )

--- a/keras_nlp/tokenizers/tokenizer_test.py
+++ b/keras_nlp/tokenizers/tokenizer_test.py
@@ -12,14 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import pytest
 import tensorflow as tf
+from absl.testing import parameterized
 
+from keras_nlp.models.albert.albert_tokenizer import AlbertTokenizer
 from keras_nlp.models.bert.bert_tokenizer import BertTokenizer
 from keras_nlp.models.gpt2.gpt2_tokenizer import GPT2Tokenizer
+from keras_nlp.models.roberta.roberta_tokenizer import RobertaTokenizer
 from keras_nlp.tests.test_case import TestCase
 from keras_nlp.tokenizers.tokenizer import Tokenizer
 from keras_nlp.utils.preset_utils import METADATA_FILE
+from keras_nlp.utils.preset_utils import TOKENIZER_ASSET_DIR
+from keras_nlp.utils.preset_utils import TOKENIZER_CONFIG_FILE
+from keras_nlp.utils.preset_utils import check_config_class
+from keras_nlp.utils.preset_utils import get_file
 
 
 class SimpleTokenizer(Tokenizer):
@@ -78,3 +87,45 @@ class TokenizerTest(TestCase):
     def test_missing_tokenize_raises(self):
         with self.assertRaises(NotImplementedError):
             Tokenizer()(["the quick brown fox"])
+
+    @parameterized.parameters(
+        (AlbertTokenizer, "albert_base_en_uncased", "sentencepiece"),
+        (RobertaTokenizer, "roberta_base_en", "bytepair"),
+        (BertTokenizer, "bert_tiny_en_uncased", "wordpiece"),
+    )
+    @pytest.mark.keras_3_only
+    @pytest.mark.large
+    def test_save_to_preset(self, cls, preset_name, tokenizer_type):
+        save_dir = self.get_temp_dir()
+        tokenizer = cls.from_preset(preset_name)
+        tokenizer.save_to_preset(save_dir)
+
+        if tokenizer_type == "bytepair":
+            vocab_filename = "vocabulary.json"
+            expected_assets = [
+                "vocabulary.json",
+                "merges.txt",
+            ]
+        elif tokenizer_type == "sentencepiece":
+            vocab_filename = "vocabulary.spm"
+            expected_assets = ["vocabulary.spm"]
+        else:
+            vocab_filename = "vocabulary.txt"
+            expected_assets = ["vocabulary.txt"]
+
+        # Check existence of files.
+        self.assertTrue(
+            os.path.exists(
+                get_file(
+                    save_dir, os.path.join(TOKENIZER_ASSET_DIR, vocab_filename)
+                )
+            )
+        )
+
+        # Check assets.
+        self.assertEqual(set(tokenizer.file_assets), set(expected_assets))
+
+        # Check config class.
+        self.assertEqual(
+            cls, check_config_class(save_dir, TOKENIZER_CONFIG_FILE)
+        )

--- a/keras_nlp/tokenizers/tokenizer_test.py
+++ b/keras_nlp/tokenizers/tokenizer_test.py
@@ -28,7 +28,6 @@ from keras_nlp.utils.preset_utils import METADATA_FILE
 from keras_nlp.utils.preset_utils import TOKENIZER_ASSET_DIR
 from keras_nlp.utils.preset_utils import TOKENIZER_CONFIG_FILE
 from keras_nlp.utils.preset_utils import check_config_class
-from keras_nlp.utils.preset_utils import get_file
 
 
 class SimpleTokenizer(Tokenizer):
@@ -113,14 +112,11 @@ class TokenizerTest(TestCase):
             vocab_filename = "vocabulary.txt"
             expected_assets = ["vocabulary.txt"]
 
-        # Check existence of files.
-        self.assertTrue(
-            os.path.exists(
-                get_file(
-                    save_dir, os.path.join(TOKENIZER_ASSET_DIR, vocab_filename)
-                )
-            )
+        # Check existence of vocab file.
+        vocab_path = os.path.join(
+            save_dir, os.path.join(TOKENIZER_ASSET_DIR, vocab_filename)
         )
+        self.assertTrue(os.path.exists(vocab_path))
 
         # Check assets.
         self.assertEqual(set(tokenizer.file_assets), set(expected_assets))


### PR DESCRIPTION
In #1547, saving logic was moved from `preset_utils.py` to base classes such as `Task`, `Preprocessor`, etc. This PR adds saving tests for each base class.