### PR TITLE
Check kagglehub version before upload

### DIFF
--- a/keras_nlp/utils/preset_utils.py
+++ b/keras_nlp/utils/preset_utils.py
@@ -20,6 +20,7 @@ import os
 import re
 
 from absl import logging
+from packaging.version import parse
 
 from keras_nlp.api_export import keras_nlp_export
 from keras_nlp.backend import config as backend_config
@@ -442,10 +443,10 @@ def upload_preset(
                 "Uploading a model to Kaggle Hub requires the `kagglehub` package. "
                 "Please install with `pip install kagglehub`."
             )
-        if kagglehub.__version__ < "0.2.1":
+        if parse(kagglehub.__version__) < parse("0.2.1"):
             raise ImportError(
                 "Uploading a model to Kaggle Hub requires the `kagglehub` package version `0.2.1` or higher. "
-                "Please upgrade `kagglehub` with `pip install --upgrade kagglehub`."
+                "Please upgrade with `pip install --upgrade kagglehub`."
             )
         kaggle_handle = uri.removeprefix(KAGGLE_PREFIX)
         kagglehub.model_upload(kaggle_handle, preset)

--- a/keras_nlp/utils/preset_utils.py
+++ b/keras_nlp/utils/preset_utils.py
@@ -437,6 +437,16 @@ def upload_preset(
     _validate_tokenizer(preset, allow_incomplete)
 
     if uri.startswith(KAGGLE_PREFIX):
+        if kagglehub is None:
+            raise ImportError(
+                "Uploading a model to Kaggle Hub requires the `kagglehub` package. "
+                "Please install with `pip install kagglehub`."
+            )
+        if kagglehub.__version__ < "0.2.1":
+            raise ImportError(
+                "Uploading a model to Kaggle Hub requires the `kagglehub` package version `0.2.1` or higher. "
+                "Please upgrade `kagglehub` with `pip install --upgrade kagglehub`."
+            )
         kaggle_handle = uri.removeprefix(KAGGLE_PREFIX)
         kagglehub.model_upload(kaggle_handle, preset)
     elif uri.startswith(HF_PREFIX):


### PR DESCRIPTION
The `kagglehub` package added support for preserving file structure of directory upload in version `0.2.1`. This is required for Keras model upload so we should check that, prevent uploading and guide the user if an older `kagglehub` version is installed.