### PR TITLE
Change the order of importing `keras`

### DIFF
--- a/keras_nlp/backend/__init__.py
+++ b/keras_nlp/backend/__init__.py
@@ -28,10 +28,10 @@ Keras 2. The sub-modules exposed are as follows:
 
 from keras_nlp.backend import config
 
-if config.keras_3():
-    import keras  # noqa: E402
-else:
+if not config.keras_3():
     import keras_nlp.backend.keras2 as keras  # noqa: E402
+else:
+    import keras  # noqa: E402
 
 from keras_nlp.backend import ops  # noqa: E402
 from keras_nlp.backend import random  # noqa: E402


### PR DESCRIPTION
This should fix the issue (after #1593) with type annotations for modern editors such as vscode.

|Before|After|
|-|-|
|![before](https://github.com/keras-team/keras-nlp/assets/20734616/4b7f234d-e62e-4639-8e99-69d361a64bbf)|![after](https://github.com/keras-team/keras-nlp/assets/20734616/c69beaa0-85a3-417b-90a0-52cbbc4121ec)|





