### PR TITLE
[DO NOT MERGE] Experimental implementation of CausalLM with a Keras Functional backbone_with_cache

### DIFF
--- a/keras_nlp/layers/modeling/transformer_decoder.py
+++ b/keras_nlp/layers/modeling/transformer_decoder.py
@@ -503,3 +503,48 @@ class TransformerDecoder(keras.layers.Layer):
 
     def compute_output_shape(self, decoder_sequence_shape):
         return decoder_sequence_shape
+
+    def compute_output_spec(
+        self,
+        decoder_sequence,
+        encoder_sequence=None,
+        decoder_padding_mask=None,
+        decoder_attention_mask=None,
+        encoder_padding_mask=None,
+        encoder_attention_mask=None,
+        self_attention_cache=None,
+        self_attention_cache_update_index=None,
+        cross_attention_cache=None,
+        cross_attention_cache_update_index=None,
+        use_causal_mask=True,
+    ):
+        if self_attention_cache is not None:
+            has_cross_attention = self._cross_attention_layer is not None
+            if has_cross_attention:
+                return (
+                    keras.KerasTensor(
+                        decoder_sequence.shape, dtype=decoder_sequence.dtype
+                    ),
+                    keras.KerasTensor(
+                        self_attention_cache.shape,
+                        dtype=self_attention_cache.dtype,
+                    ),
+                    keras.KerasTensor(
+                        cross_attention_cache.shape,
+                        dtype=cross_attention_cache.dtype,
+                    ),
+                )
+            else:
+                return (
+                    keras.KerasTensor(
+                        decoder_sequence.shape, dtype=decoder_sequence.dtype
+                    ),
+                    keras.KerasTensor(
+                        self_attention_cache.shape,
+                        dtype=self_attention_cache.dtype,
+                    ),
+                )
+        else:
+            return keras.KerasTensor(
+                decoder_sequence.shape, dtype=decoder_sequence.dtype
+            )

--- a/keras_nlp/models/causal_lm.py
+++ b/keras_nlp/models/causal_lm.py
@@ -414,8 +414,7 @@ class CausalLM(Task):
         )
 
         # Split the cache on the num_layers axis=1 (number of transformer blocks).
-        caches = ops.split(cache_input, cache_input.shape[1], axis=1)
-        caches = [ops.squeeze(cache, axis=1) for cache in caches]
+        caches = ops.unstack(cache_input, cache_input.shape[1], axis=1)
         decoder_block_idx = 0
         next_caches = []
 


### PR DESCRIPTION
This is a proof of concept PR for the new layer graph cloning API in Keras (https://github.com/keras-team/keras/pull/19600).
It is not meant to be merged as such but provide a tangible use case for the design of the new layer graph cloning API.

The problem to solve was:

- XXXCausalLLM(backbone) accepted a Functional backbone but did not use the graph of layers of the backbone.
- Instead, XXXCausalLLM implemented its call_with_cache by calling selected layers from the backbone.
- If the user provided a backbone with extra layers between TransformerDecoder blocks (or any other layer graph), the graph of the backbone would be disregarded in call_with_cache.
- There are several LLM techniques that rely on a modified backbone (ex: control vectors https://arxiv.org/abs/2310.01405) and which could therefore not be used in Keras NLP.

In order to let users implement what they want in the backbone and have call_with_cache still work in XXXCausalLLM, it is necessary to add the caching to the backbone in a Keras Functional way, and respect the Functional layer graph of the backbone.

The new [layer graph cloning API](https://github.com/keras-team/keras/pull/19600) can be used:
- externally, to provide an easy UX for light-weight edits of pre-trained models, for example to implement [control vectors](https://arxiv.org/abs/2310.01405).
- internally, to wire caches into the backbone in order to implement call_with_cache in a Keras Functional way

This PR implements a Keras Functional call_with_cache for GPT2 and Gemma.
