### PR TITLE
Bump `bert_tiny_en_uncased_sst2` classifier version

### DIFF
--- a/keras_nlp/models/bert/bert_presets.py
+++ b/keras_nlp/models/bert/bert_presets.py
@@ -142,6 +142,6 @@ classifier_presets = {
             "path": "bert",
             "model_card": "https://github.com/google-research/bert/blob/master/README.md",
         },
-        "kaggle_handle": "kaggle://keras/bert/keras/bert_tiny_en_uncased_sst2/3",
+        "kaggle_handle": "kaggle://keras/bert/keras/bert_tiny_en_uncased_sst2/4",
     }
 }


### PR DESCRIPTION
Created a new `bert_tiny_en_uncased_sst2` classifier and uploaded to kaggle https://www.kaggle.com/models/keras/bert/keras/bert_tiny_en_uncased_sst2/4

We should bump the version so the latest model is used.