### PR TITLE
Allow a task preprocessor to be an argument in from_preset

### DIFF
--- a/keras_nlp/models/task.py
+++ b/keras_nlp/models/task.py
@@ -282,7 +282,10 @@ class Task(PipelineModel):
             load_weights=load_weights,
             config_overrides=config_overrides,
         )
-        preprocessor = cls.preprocessor_cls.from_preset(preset)
+        if "preprocessor" in kwargs:
+            preprocessor = kwargs.pop("preprocessor")
+        else:
+            preprocessor = cls.preprocessor_cls.from_preset(preset)
         return cls(backbone=backbone, preprocessor=preprocessor, **kwargs)
 
     def load_task_weights(self, filepath):

--- a/keras_nlp/models/task_test.py
+++ b/keras_nlp/models/task_test.py
@@ -138,3 +138,13 @@ class TestTask(TestCase):
         ref_out = model.predict(data)
         new_out = restored_model.predict(data)
         self.assertAllEqual(ref_out, new_out)
+
+    @pytest.mark.keras_3_only
+    @pytest.mark.large
+    def test_none_preprocessor(self):
+        model = Classifier.from_preset(
+            "bert_tiny_en_uncased",
+            preprocessor=None,
+            num_classes=2,
+        )
+        self.assertEqual(model.preprocessor, None)


### PR DESCRIPTION
This change is needed for [fine-tuning with user-controlled preprocessing guide](https://keras.io/guides/keras_nlp/getting_started/#fine-tuning-with-usercontrolled-preprocessing) to work.