### PR TITLE
Pass kwargs to tokenizer when creating preprocessor

### DIFF
--- a/keras_nlp/src/models/preprocessor.py
+++ b/keras_nlp/src/models/preprocessor.py
@@ -181,7 +181,7 @@ class Preprocessor(PreprocessingLayer):
 
         tokenizer = load_serialized_object(preset, TOKENIZER_CONFIG_FILE)
         tokenizer.load_preset_assets(preset)
-        preprocessor = cls(tokenizer=tokenizer)
+        preprocessor = cls(tokenizer=tokenizer, **kwargs)
 
         return preprocessor
 

--- a/keras_nlp/src/models/preprocessor_test.py
+++ b/keras_nlp/src/models/preprocessor_test.py
@@ -53,6 +53,13 @@ class TestTask(TestCase):
         )
 
     @pytest.mark.large
+    def test_from_preset_with_sequence_length(self):
+        preprocessor = BertPreprocessor.from_preset(
+            "bert_tiny_en_uncased", sequence_length=16
+        )
+        self.assertEqual(preprocessor.sequence_length, 16)
+
+    @pytest.mark.large
     def test_from_preset_errors(self):
         with self.assertRaises(ValueError):
             # No loading on a preprocessor directly (it is ambiguous).


### PR DESCRIPTION
Pass kwargs to tokenizer when creating preprocessor from a `tokenizer.json`.
This PR addresses #1627. This is a bug that was missed in #1547.