### PR TITLE
Fix newline characters for pali_gemma

### DIFF
--- a/keras_nlp/src/models/pali_gemma/pali_gemma_causal_lm.py
+++ b/keras_nlp/src/models/pali_gemma/pali_gemma_causal_lm.py
@@ -60,7 +60,7 @@ class PaliGemmaCausalLM(CausalLM):
     pali_gemma_lm.generate(
       {
         "images": image,
-        "text": ["answer en where is the cow standing?\n"]
+        "text": ["answer en where is the cow standing?\\n"]
       }
     )
 
@@ -68,7 +68,7 @@ class PaliGemmaCausalLM(CausalLM):
     pali_gemma_lm.generate(
       {
         "images": [image, image],
-        "text": ["answer en where is the cow standing?\n", "caption en\n"]
+        "text": ["answer en where is the cow standing?\\n", "caption en\\n"]
       }
     )
     ```


### PR DESCRIPTION
They need to be escaped, or they will be literal newline characters in the python string itself, which is not what we want.