### PR TITLE
Allow importing keras_nlp without tensorflow

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -45,6 +45,16 @@ jobs:
         KERAS_BACKEND: ${{ matrix.backend }}
       run: |
         pytest keras_nlp/
+    - name: Run integration tests
+      env:
+        KERAS_BACKEND: ${{ matrix.backend }}
+      run: |
+        python pip_build.py --install
+        cd integration_tests && pytest . -k "not NoTensorflow"
+    - name: Run no tensorflow integration test
+      run: |
+        pip uninstall -y tensorflow-text tensorflow
+        cd integration_tests && pytest . -k "NoTensorflow"
   check_format:
     name: Check the code format
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,6 +18,8 @@ jobs:
       matrix:
         backend: [tensorflow, jax, torch]
     runs-on: ubuntu-latest
+    env:
+      KERAS_BACKEND: ${{ matrix.backend }}
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.9
@@ -41,17 +43,14 @@ jobs:
           pip install -r requirements.txt --progress-bar off
           pip install --no-deps -e "." --progress-bar off
     - name: Test with pytest
-      env:
-        KERAS_BACKEND: ${{ matrix.backend }}
       run: |
         pytest keras_nlp/
     - name: Run integration tests
-      env:
-        KERAS_BACKEND: ${{ matrix.backend }}
       run: |
         python pip_build.py --install
         cd integration_tests && pytest . -k "not NoTensorflow"
     - name: Run no tensorflow integration test
+      if: ${{ matrix.backend != 'tensorflow'}}
       run: |
         pip uninstall -y tensorflow-text tensorflow
         cd integration_tests && pytest . -k "NoTensorflow"

--- a/conftest.py
+++ b/conftest.py
@@ -14,17 +14,8 @@
 
 import os
 
-import pytest
-
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-
 import keras
+import pytest
 
 
 def pytest_addoption(parser):
@@ -67,6 +58,8 @@ def pytest_configure(config):
             except RuntimeError:
                 found_gpu = False
         elif backend == "tensorflow":
+            import tensorflow as tf
+
             found_gpu = bool(tf.config.list_logical_devices("GPU"))
         elif backend == "torch":
             import torch

--- a/integration_tests/import_test.py
+++ b/integration_tests/import_test.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+import unittest
 
 import keras_nlp
 
 
-class ImportTest(tf.test.TestCase):
+class ImportTest(unittest.TestCase):
     def test_version(self):
         self.assertIsNotNone(keras_nlp.__version__)

--- a/integration_tests/no_tensorflow_test.py
+++ b/integration_tests/no_tensorflow_test.py
@@ -1,0 +1,40 @@
+# Copyright 2021 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import keras_nlp
+
+
+class NoTensorflow(unittest.TestCase):
+    def test_backbone_works(self):
+        backbone = keras_nlp.models.BertBackbone.from_preset(
+            "bert_tiny_en_uncased",
+        )
+        backbone.predict(
+            {
+                "token_ids": np.ones((4, 128)),
+                "padding_mask": np.ones((4, 128)),
+                "segment_ids": np.ones((4, 128)),
+            }
+        )
+
+    def test_tokenizer_errors(self):
+        with self.assertRaises(Exception) as e:
+            keras_nlp.models.BertTokenizer.from_preset(
+                "bert_tiny_en_uncased",
+            )
+            self.assertTrue("pip install tensorflow-text" in e.exception)

--- a/keras_nlp/src/layers/preprocessing/masked_lm_mask_generator.py
+++ b/keras_nlp/src/layers/preprocessing/masked_lm_mask_generator.py
@@ -12,24 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
 
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.layers.preprocessing.preprocessing_layer import (
     PreprocessingLayer,
 )
-from keras_nlp.src.utils.tensor_utils import assert_tf_text_installed
 from keras_nlp.src.utils.tensor_utils import convert_to_ragged_batch
 
 try:
+    import tensorflow as tf
     import tensorflow_text as tf_text
 except ImportError:
+    tf = None
     tf_text = None
 
 
@@ -139,8 +133,6 @@ class MaskedLMMaskGenerator(PreprocessingLayer):
         random_token_rate=0.1,
         **kwargs,
     ):
-        assert_tf_text_installed(self.__class__.__name__)
-
         super().__init__(**kwargs)
 
         self.vocabulary_size = vocabulary_size

--- a/keras_nlp/src/layers/preprocessing/masked_lm_mask_generator_test.py
+++ b/keras_nlp/src/layers/preprocessing/masked_lm_mask_generator_test.py
@@ -12,14 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-
+import tensorflow as tf
 from keras import ops
 
 from keras_nlp.src.layers.preprocessing.masked_lm_mask_generator import (

--- a/keras_nlp/src/layers/preprocessing/multi_segment_packer.py
+++ b/keras_nlp/src/layers/preprocessing/multi_segment_packer.py
@@ -12,24 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.layers.preprocessing.preprocessing_layer import (
     PreprocessingLayer,
 )
-from keras_nlp.src.utils.tensor_utils import assert_tf_text_installed
 from keras_nlp.src.utils.tensor_utils import convert_to_ragged_batch
 
 try:
+    import tensorflow as tf
     import tensorflow_text as tf_text
 except ImportError:
+    tf = None
     tf_text = None
 
 
@@ -146,8 +139,6 @@ class MultiSegmentPacker(PreprocessingLayer):
         truncate="round_robin",
         **kwargs,
     ):
-        assert_tf_text_installed(self.__class__.__name__)
-
         super().__init__(**kwargs)
 
         self.sequence_length = sequence_length

--- a/keras_nlp/src/layers/preprocessing/preprocessing_layer.py
+++ b/keras_nlp/src/layers/preprocessing/preprocessing_layer.py
@@ -12,25 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
 import keras
 from keras import tree
 
+from keras_nlp.src.utils.tensor_utils import assert_tf_libs_installed
 from keras_nlp.src.utils.tensor_utils import (
     convert_to_backend_tensor_or_python_list,
 )
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
 
 
 class PreprocessingLayer(keras.layers.Layer):
     """Preprocessing layer base class."""
 
     def __init__(self, **kwargs):
+        assert_tf_libs_installed(self.__class__.__name__)
+
         super().__init__(**kwargs)
         self._convert_input_args = False
         self._allow_non_tensor_positional_args = True

--- a/keras_nlp/src/layers/preprocessing/random_deletion.py
+++ b/keras_nlp/src/layers/preprocessing/random_deletion.py
@@ -14,14 +14,6 @@
 
 import random
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.layers.preprocessing.preprocessing_layer import (
     PreprocessingLayer,
@@ -29,6 +21,11 @@ from keras_nlp.src.layers.preprocessing.preprocessing_layer import (
 from keras_nlp.src.utils.tensor_utils import convert_to_ragged_batch
 from keras_nlp.src.utils.tensor_utils import is_int_dtype
 from keras_nlp.src.utils.tensor_utils import is_string_dtype
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
 
 
 @keras_nlp_export("keras_nlp.layers.RandomDeletion")

--- a/keras_nlp/src/layers/preprocessing/random_deletion_test.py
+++ b/keras_nlp/src/layers/preprocessing/random_deletion_test.py
@@ -12,15 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-
 import keras
+import tensorflow as tf
 
 from keras_nlp.src.layers.preprocessing.random_deletion import RandomDeletion
 from keras_nlp.src.tests.test_case import TestCase

--- a/keras_nlp/src/layers/preprocessing/random_swap.py
+++ b/keras_nlp/src/layers/preprocessing/random_swap.py
@@ -14,14 +14,6 @@
 
 import random
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.layers.preprocessing.preprocessing_layer import (
     PreprocessingLayer,
@@ -29,6 +21,11 @@ from keras_nlp.src.layers.preprocessing.preprocessing_layer import (
 from keras_nlp.src.utils.tensor_utils import convert_to_ragged_batch
 from keras_nlp.src.utils.tensor_utils import is_int_dtype
 from keras_nlp.src.utils.tensor_utils import is_string_dtype
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
 
 
 @keras_nlp_export("keras_nlp.layers.RandomSwap")

--- a/keras_nlp/src/layers/preprocessing/random_swap_test.py
+++ b/keras_nlp/src/layers/preprocessing/random_swap_test.py
@@ -12,15 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-
 import keras
+import tensorflow as tf
 
 from keras_nlp.src.layers.preprocessing.random_swap import RandomSwap
 from keras_nlp.src.tests.test_case import TestCase

--- a/keras_nlp/src/layers/preprocessing/start_end_packer.py
+++ b/keras_nlp/src/layers/preprocessing/start_end_packer.py
@@ -12,19 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
 
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.layers.preprocessing.preprocessing_layer import (
     PreprocessingLayer,
 )
 from keras_nlp.src.utils.tensor_utils import convert_to_ragged_batch
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
 
 
 @keras_nlp_export("keras_nlp.layers.StartEndPacker")

--- a/keras_nlp/src/layers/preprocessing/start_end_packer_test.py
+++ b/keras_nlp/src/layers/preprocessing/start_end_packer_test.py
@@ -13,14 +13,7 @@
 # limitations under the License.
 
 import keras
-
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
+import tensorflow as tf
 
 from keras_nlp.src.layers.preprocessing.start_end_packer import StartEndPacker
 from keras_nlp.src.tests.test_case import TestCase

--- a/keras_nlp/src/metrics/bleu.py
+++ b/keras_nlp/src/metrics/bleu.py
@@ -15,20 +15,18 @@
 import collections
 import math
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-
 import keras
 from keras import ops
 
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.utils.tensor_utils import is_float_dtype
 from keras_nlp.src.utils.tensor_utils import tensor_to_list
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
+
 
 REPLACE_SUBSTRINGS = [
     ("<skipped>", ""),

--- a/keras_nlp/src/metrics/bleu_test.py
+++ b/keras_nlp/src/metrics/bleu_test.py
@@ -12,17 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-
 import keras
+import pytest
+import tensorflow as tf
 
 from keras_nlp.src.metrics.bleu import Bleu
 from keras_nlp.src.tests.test_case import TestCase

--- a/keras_nlp/src/metrics/edit_distance.py
+++ b/keras_nlp/src/metrics/edit_distance.py
@@ -12,18 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-
 import keras
 
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.utils.tensor_utils import is_float_dtype
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
 
 
 @keras_nlp_export("keras_nlp.metrics.EditDistance")

--- a/keras_nlp/src/metrics/edit_distance_test.py
+++ b/keras_nlp/src/metrics/edit_distance_test.py
@@ -12,17 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-
 import keras
+import pytest
+import tensorflow as tf
 
 from keras_nlp.src.metrics.edit_distance import EditDistance
 from keras_nlp.src.tests.test_case import TestCase

--- a/keras_nlp/src/metrics/rouge_base.py
+++ b/keras_nlp/src/metrics/rouge_base.py
@@ -12,19 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-
 import keras
 from keras import ops
 
 from keras_nlp.src.utils.tensor_utils import is_float_dtype
 from keras_nlp.src.utils.tensor_utils import tensor_to_list
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
 
 try:
     from rouge_score import rouge_scorer

--- a/keras_nlp/src/metrics/rouge_l_test.py
+++ b/keras_nlp/src/metrics/rouge_l_test.py
@@ -12,13 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
+import tensorflow as tf
 
 from keras_nlp.src.metrics.rouge_l import RougeL
 from keras_nlp.src.tests.test_case import TestCase

--- a/keras_nlp/src/metrics/rouge_n_test.py
+++ b/keras_nlp/src/metrics/rouge_n_test.py
@@ -12,17 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-
 import keras
+import pytest
+import tensorflow as tf
 
 from keras_nlp.src.metrics.rouge_n import RougeN
 from keras_nlp.src.tests.test_case import TestCase

--- a/keras_nlp/src/models/bart/bart_preprocessor_test.py
+++ b/keras_nlp/src/models/bart/bart_preprocessor_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import pytest
-from keras import ops
 
 from keras_nlp.src.models.bart.bart_preprocessor import BartPreprocessor
 from keras_nlp.src.models.bart.bart_tokenizer import BartTokenizer
@@ -67,12 +66,12 @@ class BartPreprocessorTest(TestCase):
         preprocessor = BartPreprocessor(**self.init_kwargs)
         input_data = {
             "encoder_text": (
-                ops.array([" airplane at airport"] * 2),
-                ops.array([" airplane"] * 2),
+                [" airplane at airport"] * 2,
+                [" airplane"] * 2,
             ),
             "decoder_text": (
-                ops.array([" kohli is the best"] * 2),
-                ops.array([" kohli"] * 2),
+                [" kohli is the best"] * 2,
+                [" kohli"] * 2,
             ),
         }
         with self.assertRaises(ValueError):

--- a/keras_nlp/src/models/bart/bart_preprocessor_test.py
+++ b/keras_nlp/src/models/bart/bart_preprocessor_test.py
@@ -13,14 +13,7 @@
 # limitations under the License.
 
 import pytest
-
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
+from keras import ops
 
 from keras_nlp.src.models.bart.bart_preprocessor import BartPreprocessor
 from keras_nlp.src.models.bart.bart_tokenizer import BartTokenizer
@@ -74,12 +67,12 @@ class BartPreprocessorTest(TestCase):
         preprocessor = BartPreprocessor(**self.init_kwargs)
         input_data = {
             "encoder_text": (
-                tf.constant([" airplane at airport"] * 2),
-                tf.constant([" airplane"] * 2),
+                ops.array([" airplane at airport"] * 2),
+                ops.array([" airplane"] * 2),
             ),
             "decoder_text": (
-                tf.constant([" kohli is the best"] * 2),
-                tf.constant([" kohli"] * 2),
+                ops.array([" kohli is the best"] * 2),
+                ops.array([" kohli"] * 2),
             ),
         }
         with self.assertRaises(ValueError):

--- a/keras_nlp/src/models/bloom/bloom_causal_lm_preprocessor.py
+++ b/keras_nlp/src/models/bloom/bloom_causal_lm_preprocessor.py
@@ -12,22 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
 import keras
 from absl import logging
-from keras import ops
 
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.models.bloom.bloom_preprocessor import BloomPreprocessor
 from keras_nlp.src.utils.keras_utils import (
     convert_inputs_to_list_of_tensor_segments,
 )
+from keras_nlp.src.utils.tensor_utils import strip_to_ragged
 
 
 @keras_nlp_export("keras_nlp.models.BloomCausalLMPreprocessor")
@@ -175,14 +168,9 @@ class BloomCausalLMPreprocessor(BloomPreprocessor):
             self.build(None)
 
         token_ids, padding_mask = x["token_ids"], x["padding_mask"]
-        token_ids = ops.convert_to_numpy(token_ids)
-        padding_mask = ops.convert_to_numpy(padding_mask)
-        # Strip any special tokens during detokenization (e.g. the start and
-        # end markers). In the future we could make this configurable.
-        padding_mask = (
-            padding_mask
-            & (token_ids != self.tokenizer.start_token_id)
-            & (token_ids != self.tokenizer.end_token_id)
+        ids_to_strip = (
+            self.tokenizer.start_token_id,
+            self.tokenizer.end_token_id,
         )
-        token_ids = tf.ragged.boolean_mask(token_ids, padding_mask)
+        token_ids = strip_to_ragged(token_ids, padding_mask, ids_to_strip)
         return self.tokenizer.detokenize(token_ids)

--- a/keras_nlp/src/models/causal_lm.py
+++ b/keras_nlp/src/models/causal_lm.py
@@ -15,13 +15,6 @@
 import itertools
 from functools import partial
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
 import keras
 from keras import ops
 from keras import tree
@@ -30,6 +23,11 @@ from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.models.task import Task
 from keras_nlp.src.samplers.serialization import get as get_sampler
 from keras_nlp.src.utils.tensor_utils import tensor_to_list
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
 
 
 @keras_nlp_export("keras_nlp.models.CausalLM")

--- a/keras_nlp/src/models/deberta_v3/deberta_v3_tokenizer.py
+++ b/keras_nlp/src/models/deberta_v3/deberta_v3_tokenizer.py
@@ -13,18 +13,15 @@
 # limitations under the License.
 
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.tokenizers.sentence_piece_tokenizer import (
     SentencePieceTokenizer,
 )
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
 
 
 @keras_nlp_export("keras_nlp.models.DebertaV3Tokenizer")

--- a/keras_nlp/src/models/falcon/falcon_causal_lm_preprocessor.py
+++ b/keras_nlp/src/models/falcon/falcon_causal_lm_preprocessor.py
@@ -12,22 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
 import keras
 from absl import logging
-from keras import ops
 
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.models.falcon.falcon_preprocessor import FalconPreprocessor
 from keras_nlp.src.utils.keras_utils import (
     convert_inputs_to_list_of_tensor_segments,
 )
+from keras_nlp.src.utils.tensor_utils import strip_to_ragged
 
 
 @keras_nlp_export("keras_nlp.models.FalconCausalLMPreprocessor")
@@ -175,10 +168,6 @@ class FalconCausalLMPreprocessor(FalconPreprocessor):
             self.build(None)
 
         token_ids, padding_mask = x["token_ids"], x["padding_mask"]
-        token_ids = ops.convert_to_numpy(token_ids)
-        padding_mask = ops.convert_to_numpy(padding_mask)
-        # Strip any special tokens during detokenization (e.g. the start and
-        # end markers). In the future we could make this configurable.
-        padding_mask = padding_mask & (token_ids != self.tokenizer.end_token_id)
-        token_ids = tf.ragged.boolean_mask(token_ids, padding_mask)
+        ids_to_strip = (self.tokenizer.end_token_id,)
+        token_ids = strip_to_ragged(token_ids, padding_mask, ids_to_strip)
         return self.tokenizer.detokenize(token_ids)

--- a/keras_nlp/src/models/gemma/gemma_causal_lm_preprocessor.py
+++ b/keras_nlp/src/models/gemma/gemma_causal_lm_preprocessor.py
@@ -12,22 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
 import keras
 from absl import logging
-from keras import ops
 
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.models.gemma.gemma_preprocessor import GemmaPreprocessor
 from keras_nlp.src.utils.keras_utils import (
     convert_inputs_to_list_of_tensor_segments,
 )
+from keras_nlp.src.utils.tensor_utils import strip_to_ragged
 
 
 @keras_nlp_export("keras_nlp.models.GemmaCausalLMPreprocessor")
@@ -165,12 +158,10 @@ class GemmaCausalLMPreprocessor(GemmaPreprocessor):
             self.build(None)
 
         token_ids, padding_mask = x["token_ids"], x["padding_mask"]
-        token_ids = ops.convert_to_numpy(token_ids)
-        mask = ops.convert_to_numpy(padding_mask)
-        # Also strip any special tokens during detokenization (e.g. the start
-        # and end markers). In the future we could make this configurable.
-        mask = mask & (token_ids != self.tokenizer.start_token_id)
-        mask = mask & (token_ids != self.tokenizer.pad_token_id)
-        mask = mask & (token_ids != self.tokenizer.end_token_id)
-        token_ids = tf.ragged.boolean_mask(token_ids, mask)
+        ids_to_strip = (
+            self.tokenizer.start_token_id,
+            self.tokenizer.end_token_id,
+            self.tokenizer.pad_token_id,
+        )
+        token_ids = strip_to_ragged(token_ids, padding_mask, ids_to_strip)
         return self.tokenizer.detokenize(token_ids)

--- a/keras_nlp/src/models/gpt2/gpt2_causal_lm_preprocessor.py
+++ b/keras_nlp/src/models/gpt2/gpt2_causal_lm_preprocessor.py
@@ -12,22 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
 import keras
 from absl import logging
-from keras import ops
 
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.models.gpt2.gpt2_preprocessor import GPT2Preprocessor
 from keras_nlp.src.utils.keras_utils import (
     convert_inputs_to_list_of_tensor_segments,
 )
+from keras_nlp.src.utils.tensor_utils import strip_to_ragged
 
 
 @keras_nlp_export("keras_nlp.models.GPT2CausalLMPreprocessor")
@@ -175,10 +168,6 @@ class GPT2CausalLMPreprocessor(GPT2Preprocessor):
             self.build(None)
 
         token_ids, padding_mask = x["token_ids"], x["padding_mask"]
-        token_ids = ops.convert_to_numpy(token_ids)
-        padding_mask = ops.convert_to_numpy(padding_mask)
-        # Strip any special tokens during detokenization (e.g. the start and
-        # end markers). In the future we could make this configurable.
-        padding_mask = padding_mask & (token_ids != self.tokenizer.end_token_id)
-        token_ids = tf.ragged.boolean_mask(token_ids, padding_mask)
+        ids_to_strip = (self.tokenizer.end_token_id,)
+        token_ids = strip_to_ragged(token_ids, padding_mask, ids_to_strip)
         return self.tokenizer.detokenize(token_ids)

--- a/keras_nlp/src/models/gpt_neo_x/gpt_neo_x_causal_lm_preprocessor.py
+++ b/keras_nlp/src/models/gpt_neo_x/gpt_neo_x_causal_lm_preprocessor.py
@@ -12,16 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
 import keras
 from absl import logging
-from keras import ops
 
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.models.gpt_neo_x.gpt_neo_x_preprocessor import (
@@ -30,6 +22,7 @@ from keras_nlp.src.models.gpt_neo_x.gpt_neo_x_preprocessor import (
 from keras_nlp.src.utils.keras_utils import (
     convert_inputs_to_list_of_tensor_segments,
 )
+from keras_nlp.src.utils.tensor_utils import strip_to_ragged
 
 
 @keras_nlp_export("keras_nlp.models.GPTNeoXCausalLMPreprocessor")
@@ -143,12 +136,6 @@ class GPTNeoXCausalLMPreprocessor(GPTNeoXPreprocessor):
             self.build(None)
 
         token_ids, padding_mask = x["token_ids"], x["padding_mask"]
-        if not isinstance(token_ids, tf.Tensor):
-            token_ids = ops.convert_to_numpy(token_ids)
-        if not isinstance(padding_mask, tf.Tensor):
-            padding_mask = ops.convert_to_numpy(padding_mask)
-        # Strip any special tokens during detokenization (e.g. the start and
-        # end markers). In the future we could make this configurable.
-        padding_mask = padding_mask & (token_ids != self.tokenizer.end_token_id)
-        token_ids = tf.ragged.boolean_mask(token_ids, padding_mask)
+        ids_to_strip = (self.tokenizer.end_token_id,)
+        token_ids = strip_to_ragged(token_ids, padding_mask, ids_to_strip)
         return self.tokenizer.detokenize(token_ids)

--- a/keras_nlp/src/models/gpt_neo_x/gpt_neo_x_causal_lm_preprocessor_test.py
+++ b/keras_nlp/src/models/gpt_neo_x/gpt_neo_x_causal_lm_preprocessor_test.py
@@ -12,13 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
+from keras import ops
 
 from keras_nlp.src.models.gpt_neo_x.gpt_neo_x_causal_lm_preprocessor import (
     GPTNeoXCausalLMPreprocessor,
@@ -83,8 +77,8 @@ class GPTNeoXCausalLMPreprocessorTest(TestCase):
 
     def test_generate_postprocess(self):
         input_data = {
-            "token_ids": tf.constant([6, 1, 3, 4, 2, 5, 0, 0]),
-            "padding_mask": tf.cast([1, 1, 1, 1, 1, 1, 0, 0], dtype="bool"),
+            "token_ids": ops.array([6, 1, 3, 4, 2, 5, 0, 0]),
+            "padding_mask": ops.array([1, 1, 1, 1, 1, 1, 0, 0], dtype="bool"),
         }
         preprocessor = GPTNeoXCausalLMPreprocessor(**self.init_kwargs)
         x = preprocessor.generate_postprocess(input_data)

--- a/keras_nlp/src/models/llama/llama_causal_lm_preprocessor.py
+++ b/keras_nlp/src/models/llama/llama_causal_lm_preprocessor.py
@@ -12,22 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
 import keras
 from absl import logging
-from keras import ops
 
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.models.llama.llama_preprocessor import LlamaPreprocessor
 from keras_nlp.src.utils.keras_utils import (
     convert_inputs_to_list_of_tensor_segments,
 )
+from keras_nlp.src.utils.tensor_utils import strip_to_ragged
 
 
 @keras_nlp_export("keras_nlp.models.LlamaCausalLMPreprocessor")
@@ -172,20 +165,6 @@ class LlamaCausalLMPreprocessor(LlamaPreprocessor):
         back to a string.
         """
         token_ids, padding_mask = x["token_ids"], x["padding_mask"]
-        # Convert the inputs to numpy arrays if they aren't a tensor already.
-        if not isinstance(token_ids, tf.Tensor):
-            token_ids = ops.convert_to_numpy(token_ids)
-            # Make sure the numpy array has type `int32` since
-            # `SentencePieceProcessor.detokenize` only accepts `int32` arrays.
-            token_ids = token_ids.astype("int32")
-        if not isinstance(padding_mask, tf.Tensor):
-            padding_mask = ops.convert_to_numpy(padding_mask)
-            padding_mask = padding_mask.astype("bool")
-        # Strip any special tokens during detokenization (e.g. the start and
-        # end markers). In the future we could make this configurable.
-        padding_mask = padding_mask & (token_ids != self.tokenizer.end_token_id)
-        padding_mask = padding_mask & (
-            token_ids != self.tokenizer.start_token_id
-        )
-        token_ids = tf.ragged.boolean_mask(token_ids, padding_mask)
+        ids_to_strip = (self.tokenizer.end_token_id,)
+        token_ids = strip_to_ragged(token_ids, padding_mask, ids_to_strip)
         return self.tokenizer.detokenize(token_ids)

--- a/keras_nlp/src/models/mistral/mistral_causal_lm_preprocessor.py
+++ b/keras_nlp/src/models/mistral/mistral_causal_lm_preprocessor.py
@@ -12,16 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
 import keras
 from absl import logging
-from keras import ops
 
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.models.mistral.mistral_preprocessor import (
@@ -30,6 +22,7 @@ from keras_nlp.src.models.mistral.mistral_preprocessor import (
 from keras_nlp.src.utils.keras_utils import (
     convert_inputs_to_list_of_tensor_segments,
 )
+from keras_nlp.src.utils.tensor_utils import strip_to_ragged
 
 
 @keras_nlp_export("keras_nlp.models.MistralCausalLMPreprocessor")
@@ -174,20 +167,9 @@ class MistralCausalLMPreprocessor(MistralPreprocessor):
         back to a string.
         """
         token_ids, padding_mask = x["token_ids"], x["padding_mask"]
-        # Convert the inputs to numpy arrays if they aren't a tensor already.
-        if not isinstance(token_ids, tf.Tensor):
-            token_ids = ops.convert_to_numpy(token_ids)
-            # Make sure the numpy array has type `int32` since
-            # `SentencePieceProcessor.detokenize` only accepts `int32` arrays.
-            token_ids = token_ids.astype("int32")
-        if not isinstance(padding_mask, tf.Tensor):
-            padding_mask = ops.convert_to_numpy(padding_mask)
-            padding_mask = padding_mask.astype("bool")
-        # Strip any special tokens during detokenization (e.g. the start and
-        # end markers). In the future we could make this configurable.
-        padding_mask = padding_mask & (token_ids != self.tokenizer.end_token_id)
-        padding_mask = padding_mask & (
-            token_ids != self.tokenizer.start_token_id
+        ids_to_strip = (
+            self.tokenizer.start_token_id,
+            self.tokenizer.end_token_id,
         )
-        token_ids = tf.ragged.boolean_mask(token_ids, padding_mask)
+        token_ids = strip_to_ragged(token_ids, padding_mask, ids_to_strip)
         return self.tokenizer.detokenize(token_ids)

--- a/keras_nlp/src/models/opt/opt_causal_lm_preprocessor.py
+++ b/keras_nlp/src/models/opt/opt_causal_lm_preprocessor.py
@@ -12,22 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
 import keras
 from absl import logging
-from keras import ops
 
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.models.opt.opt_preprocessor import OPTPreprocessor
 from keras_nlp.src.utils.keras_utils import (
     convert_inputs_to_list_of_tensor_segments,
 )
+from keras_nlp.src.utils.tensor_utils import strip_to_ragged
 
 
 @keras_nlp_export("keras_nlp.models.OPTCausalLMPreprocessor")
@@ -176,11 +169,9 @@ class OPTCausalLMPreprocessor(OPTPreprocessor):
             self.build(None)
 
         token_ids, padding_mask = x["token_ids"], x["padding_mask"]
-        token_ids = ops.convert_to_numpy(token_ids)
-        padding_mask = ops.convert_to_numpy(padding_mask)
-        # Strip any special tokens during detokenization (e.g. the start and
-        # end markers). In the future we could make this configurable.
-        padding_mask = padding_mask & (token_ids != self.tokenizer.end_token_id)
-        padding_mask = padding_mask & (token_ids != self.tokenizer.pad_token_id)
-        token_ids = tf.ragged.boolean_mask(token_ids, padding_mask)
+        ids_to_strip = (
+            self.tokenizer.end_token_id,
+            self.tokenizer.pad_token_id,
+        )
+        token_ids = strip_to_ragged(token_ids, padding_mask, ids_to_strip)
         return self.tokenizer.detokenize(token_ids)

--- a/keras_nlp/src/models/pali_gemma/pali_gemma_causal_lm_preprocessor.py
+++ b/keras_nlp/src/models/pali_gemma/pali_gemma_causal_lm_preprocessor.py
@@ -13,14 +13,7 @@
 # limitations under the License.
 import keras
 from absl import logging
-
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
+from keras import ops
 
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.layers.preprocessing.multi_segment_packer import (
@@ -84,7 +77,7 @@ class PaliGemmaCausalLMPreprocessor(GemmaCausalLMPreprocessor):
         images, prompts, responses = x["images"], x["prompts"], x["responses"]
         if keras.config.backend() == "tensorflow":
             # Tensorflow backend needs uniform ouput types.
-            images = tf.convert_to_tensor(images)
+            images = ops.convert_to_tensor(images)
         prompts = convert_inputs_to_list_of_tensor_segments(prompts)[0]
         prompts = self.tokenizer(prompts)
         responses = convert_inputs_to_list_of_tensor_segments(responses)[0]

--- a/keras_nlp/src/models/phi3/phi3_causal_lm_preprocessor.py
+++ b/keras_nlp/src/models/phi3/phi3_causal_lm_preprocessor.py
@@ -12,22 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
 import keras
 from absl import logging
-from keras import ops
 
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.models.phi3.phi3_preprocessor import Phi3Preprocessor
 from keras_nlp.src.utils.keras_utils import (
     convert_inputs_to_list_of_tensor_segments,
 )
+from keras_nlp.src.utils.tensor_utils import strip_to_ragged
 
 
 @keras_nlp_export("keras_nlp.models.Phi3CausalLMPreprocessor")
@@ -172,20 +165,9 @@ class Phi3CausalLMPreprocessor(Phi3Preprocessor):
         back to a string.
         """
         token_ids, padding_mask = x["token_ids"], x["padding_mask"]
-        # Convert the inputs to numpy arrays if they aren't a tensor already.
-        if not isinstance(token_ids, tf.Tensor):
-            token_ids = ops.convert_to_numpy(token_ids)
-            # Make sure the numpy array has type `int32` since
-            # `SentencePieceProcessor.detokenize` only accepts `int32` arrays.
-            token_ids = token_ids.astype("int32")
-        if not isinstance(padding_mask, tf.Tensor):
-            padding_mask = ops.convert_to_numpy(padding_mask)
-            padding_mask = padding_mask.astype("bool")
-        # Strip any special tokens during detokenization (e.g. the start and
-        # end markers). In the future we could make this configurable.
-        padding_mask = padding_mask & (token_ids != self.tokenizer.end_token_id)
-        padding_mask = padding_mask & (
-            token_ids != self.tokenizer.start_token_id
+        ids_to_strip = (
+            self.tokenizer.start_token_id,
+            self.tokenizer.end_token_id,
         )
-        token_ids = tf.ragged.boolean_mask(token_ids, padding_mask)
+        token_ids = strip_to_ragged(token_ids, padding_mask, ids_to_strip)
         return self.tokenizer.detokenize(token_ids)

--- a/keras_nlp/src/models/whisper/whisper_audio_feature_extractor_test.py
+++ b/keras_nlp/src/models/whisper/whisper_audio_feature_extractor_test.py
@@ -12,13 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
+import tensorflow as tf
 
 from keras_nlp.src.models.whisper.whisper_audio_feature_extractor import (
     WhisperAudioFeatureExtractor,

--- a/keras_nlp/src/models/xlm_roberta/xlm_roberta_tokenizer.py
+++ b/keras_nlp/src/models/xlm_roberta/xlm_roberta_tokenizer.py
@@ -13,19 +13,16 @@
 # limitations under the License.
 
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.tokenizers.sentence_piece_tokenizer import (
     SentencePieceTokenizer,
 )
 from keras_nlp.src.utils.tensor_utils import tensor_to_list
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
 
 
 @keras_nlp_export("keras_nlp.models.XLMRobertaTokenizer")

--- a/keras_nlp/src/samplers/beam_sampler.py
+++ b/keras_nlp/src/samplers/beam_sampler.py
@@ -12,13 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
+import keras
 from keras import ops
 from keras import tree
 
@@ -142,8 +136,10 @@ class BeamSampler(Sampler):
             next_token = flatten_beams(indices % vocab_size)
             # We need `ensure_shape` as `top_k` will change the static shape.
             next_log_probs = flatten_beams(next_log_probs)
-            # Work around for top_k output shape on tf backend.
-            if isinstance(log_probs, tf.Tensor):
+            if keras.config.backend() == "tensorflow":
+                # Work around for bug in top_k output shape on tf backend.
+                import tensorflow as tf
+
                 log_probs = tf.ensure_shape(next_log_probs, log_probs.shape)
             else:
                 log_probs = next_log_probs

--- a/keras_nlp/src/samplers/beam_sampler_test.py
+++ b/keras_nlp/src/samplers/beam_sampler_test.py
@@ -12,16 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-from absl.testing import parameterized
 from keras import ops
 
 from keras_nlp.src.samplers.beam_sampler import BeamSampler
@@ -120,19 +110,3 @@ class BeamSamplerTest(TestCase):
             stop_token_ids=[self.char_lookup["t"]],
         )
         self.assertEqual(self.join_as_string(output), ["sequentzzzzz"])
-
-    @parameterized.named_parameters(
-        ("jit_compile_false", False), ("jit_compile_true", True)
-    )
-    @pytest.mark.tf_only
-    def test_compilation(self, jit_compile):
-        cache_chars = list("sequentially")
-        cache = ops.array([[self.char_lookup[c] for c in cache_chars]])
-        prompt = ops.full((self.batch_size, self.length), self.char_lookup["z"])
-
-        @tf.function(jit_compile=jit_compile)
-        def generate(prompt, cache):
-            return self.sampler(self.next, prompt=prompt, cache=cache)
-
-        output = generate(prompt, cache)
-        self.assertEqual(self.join_as_string(output), ["sequentially"])

--- a/keras_nlp/src/samplers/contrastive_sampler_test.py
+++ b/keras_nlp/src/samplers/contrastive_sampler_test.py
@@ -13,16 +13,6 @@
 # limitations under the License.
 
 import numpy as np
-import pytest
-
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-from absl.testing import parameterized
 from keras import ops
 
 from keras_nlp.src.samplers.contrastive_sampler import ContrastiveSampler
@@ -176,25 +166,3 @@ class ContrastiveSamplerTest(TestCase):
             hidden_states=hidden_states,
         )
         self.assertTrue("h" not in self.join_as_string(output))
-
-    @parameterized.named_parameters(
-        ("jit_compile_false", False), ("jit_compile_true", True)
-    )
-    @pytest.mark.tf_only
-    def test_compilation(self, jit_compile):
-        cache_chars = list("sequentiallyy")
-        cache = ops.array([[self.char_lookup[c] for c in cache_chars]])
-        prompt = ops.full((self.batch_size, self.length), self.char_lookup["s"])
-
-        @tf.function(jit_compile=jit_compile)
-        def generate(prompt, cache):
-            return self.sampler(
-                self.next,
-                prompt=prompt,
-                cache=cache,
-                index=1,
-                hidden_states=self.hidden_states,
-            )
-
-        output = generate(prompt, cache)
-        self.assertEqual(self.join_as_string(output), ["sequentially"])

--- a/keras_nlp/src/samplers/greedy_sampler_test.py
+++ b/keras_nlp/src/samplers/greedy_sampler_test.py
@@ -12,16 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-from absl.testing import parameterized
 from keras import ops
 
 from keras_nlp.src.samplers.greedy_sampler import GreedySampler
@@ -125,19 +115,3 @@ class GreedySamplerTest(TestCase):
         )
         output_ids = set(ops.convert_to_numpy(output[0]))
         self.assertContainsSubset(output_ids, [0])
-
-    @parameterized.named_parameters(
-        ("jit_compile_false", False), ("jit_compile_true", True)
-    )
-    @pytest.mark.tf_only
-    def test_compilation(self, jit_compile):
-        cache_chars = list("sequentially")
-        cache = ops.array([[self.char_lookup[c] for c in cache_chars]])
-        prompt = ops.full((self.batch_size, self.length), self.char_lookup["z"])
-
-        @tf.function(jit_compile=jit_compile)
-        def generate(prompt, cache):
-            return self.sampler(self.next, prompt=prompt, cache=cache)
-
-        output = generate(prompt, cache)
-        self.assertEqual(self.join_as_string(output), ["sequentially"])

--- a/keras_nlp/src/samplers/random_sampler_test.py
+++ b/keras_nlp/src/samplers/random_sampler_test.py
@@ -13,16 +13,6 @@
 # limitations under the License.
 
 import numpy as np
-import pytest
-
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-from absl.testing import parameterized
 from keras import ops
 
 from keras_nlp.src.samplers.random_sampler import RandomSampler
@@ -108,19 +98,3 @@ class RandomSamplerTest(TestCase):
             stop_token_ids=[self.char_lookup["t"]],
         )
         self.assertEqual(self.join_as_string(output), ["sequentzzzzz"])
-
-    @parameterized.named_parameters(
-        ("jit_compile_false", False), ("jit_compile_true", True)
-    )
-    @pytest.mark.tf_only
-    def test_compilation(self, jit_compile):
-        cache_chars = list("sequentially")
-        cache = ops.array([[self.char_lookup[c] for c in cache_chars]])
-        prompt = ops.full((self.batch_size, self.length), self.char_lookup["z"])
-
-        @tf.function(jit_compile=jit_compile)
-        def generate(prompt, cache):
-            return self.sampler(self.next, prompt=prompt, cache=cache)
-
-        output = generate(prompt, cache)
-        self.assertEqual(self.join_as_string(output), ["sequentially"])

--- a/keras_nlp/src/samplers/top_k_sampler_test.py
+++ b/keras_nlp/src/samplers/top_k_sampler_test.py
@@ -12,16 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-from absl.testing import parameterized
 from keras import ops
 
 from keras_nlp.src.samplers.top_k_sampler import TopKSampler
@@ -113,19 +103,3 @@ class TopKSamplerTest(TestCase):
         )
         output_ids = set(ops.convert_to_numpy(output[0]))
         self.assertContainsSubset(output_ids, range(5))
-
-    @parameterized.named_parameters(
-        ("jit_compile_false", False), ("jit_compile_true", True)
-    )
-    @pytest.mark.tf_only
-    def test_compilation(self, jit_compile):
-        cache_chars = list("sequentially")
-        cache = ops.array([[self.char_lookup[c] for c in cache_chars]])
-        prompt = ops.full((self.batch_size, self.length), self.char_lookup["z"])
-
-        @tf.function(jit_compile=jit_compile)
-        def generate(prompt, cache):
-            return self.sampler(self.next, prompt=prompt, cache=cache)
-
-        output = generate(prompt, cache)
-        self.assertEqual(self.join_as_string(output), ["sequentially"])

--- a/keras_nlp/src/samplers/top_p_sampler_test.py
+++ b/keras_nlp/src/samplers/top_p_sampler_test.py
@@ -13,16 +13,6 @@
 # limitations under the License.
 
 import numpy as np
-import pytest
-
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-from absl.testing import parameterized
 from keras import ops
 
 from keras_nlp.src.samplers.top_p_sampler import TopPSampler
@@ -148,19 +138,3 @@ class TopPSamplerTest(TestCase):
             prompt=prompt,
         )
         self.assertAllEqual(output, ops.zeros_like(output))
-
-    @parameterized.named_parameters(
-        ("jit_compile_false", False), ("jit_compile_true", True)
-    )
-    @pytest.mark.tf_only
-    def test_compilation(self, jit_compile):
-        cache_chars = list("sequentially")
-        cache = ops.array([[self.char_lookup[c] for c in cache_chars]])
-        prompt = ops.full((self.batch_size, self.length), self.char_lookup["z"])
-
-        @tf.function(jit_compile=jit_compile)
-        def generate(prompt, cache):
-            return self.sampler(self.next, prompt=prompt, cache=cache)
-
-        output = generate(prompt, cache)
-        self.assertEqual(self.join_as_string(output), ["sequentially"])

--- a/keras_nlp/src/tests/doc_tests/docstring_test.py
+++ b/keras_nlp/src/tests/doc_tests/docstring_test.py
@@ -18,19 +18,11 @@ import os
 import sys
 import unittest
 
+import keras
 import numpy as np
 import pytest
 import sentencepiece
-
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-
-import keras
+import tensorflow as tf
 
 import keras_nlp
 from keras_nlp.src.tests.doc_tests import docstring_lib

--- a/keras_nlp/src/tests/test_case.py
+++ b/keras_nlp/src/tests/test_case.py
@@ -17,14 +17,8 @@ import os
 import pathlib
 import re
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
 import keras
+import tensorflow as tf
 from absl.testing import parameterized
 from keras import ops
 from keras import tree

--- a/keras_nlp/src/tokenizers/byte_tokenizer.py
+++ b/keras_nlp/src/tokenizers/byte_tokenizer.py
@@ -24,7 +24,6 @@ except ImportError:
 
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.tokenizers import tokenizer
-from keras_nlp.src.utils.tensor_utils import assert_tf_text_installed
 from keras_nlp.src.utils.tensor_utils import convert_to_ragged_batch
 from keras_nlp.src.utils.tensor_utils import is_int_dtype
 
@@ -170,8 +169,6 @@ class ByteTokenizer(tokenizer.Tokenizer):
         dtype="int32",
         **kwargs,
     ):
-        assert_tf_text_installed(self.__class__.__name__)
-
         if not is_int_dtype(dtype):
             raise ValueError(
                 "Output dtype must be an integer type. "

--- a/keras_nlp/src/tokenizers/byte_tokenizer_test.py
+++ b/keras_nlp/src/tokenizers/byte_tokenizer_test.py
@@ -12,13 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
+import tensorflow as tf
 
 from keras_nlp.src.tests.test_case import TestCase
 from keras_nlp.src.tokenizers.byte_tokenizer import ByteTokenizer

--- a/keras_nlp/src/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_nlp/src/tokenizers/sentence_piece_tokenizer.py
@@ -28,7 +28,6 @@ except ImportError:
 
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.tokenizers import tokenizer
-from keras_nlp.src.utils.tensor_utils import assert_tf_text_installed
 from keras_nlp.src.utils.tensor_utils import convert_to_ragged_batch
 from keras_nlp.src.utils.tensor_utils import is_int_dtype
 from keras_nlp.src.utils.tensor_utils import is_string_dtype
@@ -118,8 +117,6 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
         dtype="int32",
         **kwargs,
     ) -> None:
-        assert_tf_text_installed(self.__class__.__name__)
-
         if not is_int_dtype(dtype) and not is_string_dtype(dtype):
             raise ValueError(
                 "Output dtype must be an integer type or a string. "

--- a/keras_nlp/src/tokenizers/sentence_piece_tokenizer_test.py
+++ b/keras_nlp/src/tokenizers/sentence_piece_tokenizer_test.py
@@ -14,13 +14,7 @@
 
 import os
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
+import tensorflow as tf
 
 from keras_nlp.src.tests.test_case import TestCase
 from keras_nlp.src.tokenizers.sentence_piece_tokenizer import (

--- a/keras_nlp/src/tokenizers/sentence_piece_tokenizer_trainer_test.py
+++ b/keras_nlp/src/tokenizers/sentence_piece_tokenizer_trainer_test.py
@@ -15,13 +15,7 @@
 import os
 import re
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
+import tensorflow as tf
 
 from keras_nlp.src.tests.test_case import TestCase
 from keras_nlp.src.tokenizers.sentence_piece_tokenizer import (

--- a/keras_nlp/src/tokenizers/tokenizer_test.py
+++ b/keras_nlp/src/tokenizers/tokenizer_test.py
@@ -15,14 +15,7 @@
 import os
 
 import pytest
-
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
+import tensorflow as tf
 from absl.testing import parameterized
 
 from keras_nlp.src.models.albert.albert_tokenizer import AlbertTokenizer

--- a/keras_nlp/src/tokenizers/unicode_codepoint_tokenizer.py
+++ b/keras_nlp/src/tokenizers/unicode_codepoint_tokenizer.py
@@ -12,17 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
 
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.tokenizers import tokenizer
-from keras_nlp.src.utils.tensor_utils import assert_tf_text_installed
 from keras_nlp.src.utils.tensor_utils import convert_to_ragged_batch
 from keras_nlp.src.utils.tensor_utils import is_int_dtype
 
 try:
+    import tensorflow as tf
     import tensorflow_text as tf_text
 except ImportError:
+    tf = None
     tf_text = None
 
 
@@ -217,8 +217,6 @@ class UnicodeCodepointTokenizer(tokenizer.Tokenizer):
         dtype="int32",
         **kwargs,
     ) -> None:
-        assert_tf_text_installed(self.__class__.__name__)
-
         if not is_int_dtype(dtype):
             raise ValueError(
                 "Output dtype must be an integer type. "

--- a/keras_nlp/src/tokenizers/unicode_codepoint_tokenizer_test.py
+++ b/keras_nlp/src/tokenizers/unicode_codepoint_tokenizer_test.py
@@ -12,13 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
+import tensorflow as tf
 
 from keras_nlp.src.tests.test_case import TestCase
 from keras_nlp.src.tokenizers.unicode_codepoint_tokenizer import (

--- a/keras_nlp/src/tokenizers/word_piece_tokenizer.py
+++ b/keras_nlp/src/tokenizers/word_piece_tokenizer.py
@@ -18,24 +18,17 @@ from typing import Iterable
 
 import keras
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.tokenizers import tokenizer
-from keras_nlp.src.utils.tensor_utils import assert_tf_text_installed
 from keras_nlp.src.utils.tensor_utils import convert_to_ragged_batch
 from keras_nlp.src.utils.tensor_utils import is_int_dtype
 from keras_nlp.src.utils.tensor_utils import is_string_dtype
 
 try:
+    import tensorflow as tf
     import tensorflow_text as tf_text
 except ImportError:
+    tf = None
     tf_text = None
 
 VOCAB_FILENAME = "vocabulary.txt"
@@ -362,8 +355,6 @@ class WordPieceTokenizer(tokenizer.Tokenizer):
         dtype="int32",
         **kwargs,
     ) -> None:
-        assert_tf_text_installed(self.__class__.__name__)
-
         if not is_int_dtype(dtype) and not is_string_dtype(dtype):
             raise ValueError(
                 "Output dtype must be an integer type or a string. "

--- a/keras_nlp/src/tokenizers/word_piece_tokenizer_test.py
+++ b/keras_nlp/src/tokenizers/word_piece_tokenizer_test.py
@@ -14,13 +14,7 @@
 
 import os
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
+import tensorflow as tf
 
 from keras_nlp.src.tests.test_case import TestCase
 from keras_nlp.src.tokenizers.word_piece_tokenizer import WordPieceTokenizer

--- a/keras_nlp/src/tokenizers/word_piece_tokenizer_trainer.py
+++ b/keras_nlp/src/tokenizers/word_piece_tokenizer_trainer.py
@@ -12,23 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
 
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.tokenizers.word_piece_tokenizer import pretokenize
-from keras_nlp.src.utils.tensor_utils import assert_tf_text_installed
 
 try:
+    import tensorflow as tf
     from tensorflow_text.tools.wordpiece_vocab import (
         wordpiece_tokenizer_learner_lib as learner,
     )
 except ImportError:
+    tf = None
     learner = None
 
 
@@ -134,8 +128,6 @@ def compute_word_piece_vocabulary(
     inputs.map(tokenizer.tokenize)
     ```
     """
-    assert_tf_text_installed(compute_word_piece_vocabulary.__name__)
-
     # Read data files.
     if not isinstance(data, (list, tf.data.Dataset)):
         raise ValueError(

--- a/keras_nlp/src/tokenizers/word_piece_tokenizer_trainer_test.py
+++ b/keras_nlp/src/tokenizers/word_piece_tokenizer_trainer_test.py
@@ -14,13 +14,7 @@
 
 import os
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
+import tensorflow as tf
 
 from keras_nlp.src.tests.test_case import TestCase
 from keras_nlp.src.tokenizers.word_piece_tokenizer_trainer import (

--- a/keras_nlp/src/utils/keras_utils.py
+++ b/keras_nlp/src/utils/keras_utils.py
@@ -14,17 +14,15 @@
 
 import sys
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
 import keras
 from absl import logging
 
 from keras_nlp.src.utils.tensor_utils import is_tensor_type
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
 
 
 def clone_initializer(initializer):

--- a/keras_nlp/src/utils/pipeline_model.py
+++ b/keras_nlp/src/utils/pipeline_model.py
@@ -15,18 +15,16 @@
 import functools
 import math
 
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
 import keras
 from keras import ops
 from keras import tree
 
 from keras_nlp.src.utils.tensor_utils import is_tensor_type
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
 
 
 def _convert_inputs_to_dataset(

--- a/keras_nlp/src/utils/pipeline_model_test.py
+++ b/keras_nlp/src/utils/pipeline_model_test.py
@@ -14,17 +14,9 @@
 
 import os
 
-import numpy as np
-
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-
 import keras
+import numpy as np
+import tensorflow as tf
 
 from keras_nlp.src.tests.test_case import TestCase
 from keras_nlp.src.utils.pipeline_model import PipelineModel

--- a/keras_nlp/src/utils/tensor_utils_test.py
+++ b/keras_nlp/src/utils/tensor_utils_test.py
@@ -13,15 +13,7 @@
 # limitations under the License.
 
 import numpy as np
-
-try:
-    import tensorflow as tf
-except ImportError:
-    raise ImportError(
-        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
-        "The TensorFlow package is required for data preprocessing with any backend."
-    )
-
+import tensorflow as tf
 from keras import ops
 
 from keras_nlp.src.tests.test_case import TestCase

--- a/shell/format.sh
+++ b/shell/format.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 base_dir=$(dirname $(dirname $0))
-targets="${base_dir}/*.py ${base_dir}/examples/ ${base_dir}/keras_nlp/ ${base_dir}/tools/"
+targets="${base_dir}/*.py ${base_dir}/examples/ ${base_dir}/keras_nlp/ ${base_dir}/integration_tests/ ${base_dir}/tools/"
 
 isort --sp "${base_dir}/pyproject.toml" ${targets}
 black --config "${base_dir}/pyproject.toml" ${targets}


### PR DESCRIPTION
This change **does not** break the dependency of tensorflow for all text
preprocessing, so most real world workflows will still require a
tensorflow install.

But this would allow running some modeling in Jax with all preprocessing
done with a separately library.

And most important, this will give friendly, actionable install
instructions the first time something is used that requires a
tensorflow install.