### PR TITLE
Changed from_preset file downloading to use GFile when able

### DIFF
--- a/keras_nlp/src/utils/preset_utils.py
+++ b/keras_nlp/src/utils/preset_utils.py
@@ -114,7 +114,10 @@ def get_file(preset, path):
     if preset in BUILTIN_PRESETS:
         preset = BUILTIN_PRESETS[preset]["kaggle_handle"]
 
-    scheme = preset.split("://")[0].lower()
+    scheme = None
+    if "://" in preset:
+        scheme = preset.split("://")[0].lower()
+
     if scheme == KAGGLE_SCHEME:
         if kagglehub is None:
             raise ImportError(

--- a/keras_nlp/src/utils/preset_utils.py
+++ b/keras_nlp/src/utils/preset_utils.py
@@ -210,12 +210,6 @@ def get_file(preset, path):
 
 def copy_gfile_to_cache(fname, url, cache_subdir):
     """Much of this is adapted from get_file of keras core."""
-    if url is None:
-        raise ValueError(
-            'Please specify the "url" argument (URL of the file '
-            "to download)."
-        )
-
     if cache_subdir is None:
         cache_dir = config.keras_home()
 
@@ -225,17 +219,7 @@ def copy_gfile_to_cache(fname, url, cache_subdir):
     datadir = os.path.join(datadir_base, cache_subdir)
     os.makedirs(datadir, exist_ok=True)
 
-    fname = path_to_string(fname)
-    if not fname:
-        fname = os.path.basename(urllib.parse.urlsplit(url).path)
-        if not fname:
-            raise ValueError(
-                "Can't parse the file name from the origin provided: "
-                f"'{url}'."
-                "Please specify the `fname` as the input param."
-            )
     fpath = os.path.join(datadir, fname)
-
     if not os.path.exists(fpath):
         io_utils.print_msg(f"Downloading data from {url}")
         tf.io.gfile.copy(url, fpath)

--- a/keras_nlp/src/utils/preset_utils.py
+++ b/keras_nlp/src/utils/preset_utils.py
@@ -20,7 +20,6 @@ import os
 import re
 import urllib
 
-import tensorflow as tf
 from absl import logging
 from keras.src.utils import io_utils
 from keras.src.utils.file_utils import path_to_string
@@ -30,6 +29,14 @@ from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.backend import config
 from keras_nlp.src.backend import config as backend_config
 from keras_nlp.src.backend import keras
+
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "To use `keras_nlp`, please install Tensorflow: `pip install tensorflow`. "
+        "The TensorFlow package is required for data preprocessing with any backend."
+    )
 
 try:
     import kagglehub

--- a/keras_nlp/src/utils/preset_utils.py
+++ b/keras_nlp/src/utils/preset_utils.py
@@ -22,14 +22,14 @@ import shutil
 import urllib
 
 import tensorflow as tf
-
 from absl import logging
 from keras.src.utils import io_utils
 from keras.src.utils.file_utils import path_to_string
 from packaging.version import parse
 
 from keras_nlp.src.api_export import keras_nlp_export
-from keras_nlp.src.backend import config as backend_config, config
+from keras_nlp.src.backend import config
+from keras_nlp.src.backend import config as backend_config
 from keras_nlp.src.backend import keras
 
 try:
@@ -140,11 +140,14 @@ def get_file(preset, path):
             else:
                 raise ValueError(message)
 
-    elif any(preset.lower().startswith(scheme + "://") for scheme in tf.io.gfile.get_registered_schemes()):
+    elif any(
+        preset.lower().startswith(scheme + "://")
+        for scheme in tf.io.gfile.get_registered_schemes()
+    ):
         url = os.path.join(preset, path)
         subdir = preset
         for scheme in tf.io.gfile.get_registered_schemes():
-            if (subdir.lower().startswith(scheme + "://")):
+            if subdir.lower().startswith(scheme + "://"):
                 subdir = subdir.replace(scheme + "://", scheme + "_")
         subdir = subdir.replace("/", "_").replace("-", "_")
         filename = os.path.basename(path)
@@ -288,10 +291,10 @@ def save_tokenizer_assets(tokenizer, preset):
 
 
 def save_serialized_object(
-        layer,
-        preset,
-        config_file=CONFIG_FILE,
-        config_to_skip=[],
+    layer,
+    preset,
+    config_file=CONFIG_FILE,
+    config_to_skip=[],
 ):
     check_keras_3()
     make_preset_dir(preset)
@@ -457,9 +460,9 @@ def delete_model_card(preset):
 
 @keras_nlp_export("keras_nlp.upload_preset")
 def upload_preset(
-        uri,
-        preset,
-        allow_incomplete=False,
+    uri,
+    preset,
+    allow_incomplete=False,
 ):
     """Upload a preset directory to a model hub.
 
@@ -561,9 +564,9 @@ def validate_metadata(preset):
 
 
 def load_serialized_object(
-        preset,
-        config_file=CONFIG_FILE,
-        config_overrides={},
+    preset,
+    config_file=CONFIG_FILE,
+    config_overrides={},
 ):
     config = load_config(preset, config_file)
     config["config"] = {**config["config"], **config_overrides}
@@ -571,8 +574,8 @@ def load_serialized_object(
 
 
 def check_config_class(
-        preset,
-        config_file=CONFIG_FILE,
+    preset,
+    config_file=CONFIG_FILE,
 ):
     """Validate a preset is being loaded on the correct class."""
     config_path = get_file(preset, config_file)

--- a/keras_nlp/src/utils/preset_utils.py
+++ b/keras_nlp/src/utils/preset_utils.py
@@ -18,17 +18,15 @@ import inspect
 import json
 import os
 import re
-import urllib
 
 from absl import logging
-from keras.src.utils import io_utils
-from keras.src.utils.file_utils import path_to_string
 from packaging.version import parse
 
 from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.backend import config
 from keras_nlp.src.backend import config as backend_config
 from keras_nlp.src.backend import keras
+from keras_nlp.src.utils.keras_utils import print_msg
 
 try:
     import tensorflow as tf
@@ -208,7 +206,7 @@ def get_file(preset, path):
         )
 
 
-def copy_gfile_to_cache(fname, url, cache_subdir):
+def copy_gfile_to_cache(filename, url, cache_subdir):
     """Much of this is adapted from get_file of keras core."""
     if cache_subdir is None:
         cache_dir = config.keras_home()
@@ -219,9 +217,9 @@ def copy_gfile_to_cache(fname, url, cache_subdir):
     datadir = os.path.join(datadir_base, cache_subdir)
     os.makedirs(datadir, exist_ok=True)
 
-    fpath = os.path.join(datadir, fname)
+    fpath = os.path.join(datadir, filename)
     if not os.path.exists(fpath):
-        io_utils.print_msg(f"Downloading data from {url}")
+        print_msg(f"Downloading data from {url}")
         tf.io.gfile.copy(url, fpath)
 
     return fpath


### PR DESCRIPTION
To better support Google product usage when there are authentication barriers, we will use GFile-based processes. 

As a result, `gcloud auth` should function as expected.