### PR TITLE
fix GemmaBackbone.get_layout_map + test

### DIFF
--- a/keras_nlp/src/models/gemma/gemma_backbone.py
+++ b/keras_nlp/src/models/gemma/gemma_backbone.py
@@ -266,6 +266,7 @@ class GemmaBackbone(Backbone):
             data_dim,
         )
         layout_map["decoder_block.*ffw_gating.kernel"] = (data_dim, model_dim)
+        layout_map["decoder_block.*ffw_gating_2.kernel"] = (data_dim, model_dim)
         layout_map["decoder_block.*ffw_linear.kernel"] = (model_dim, data_dim)
 
         return layout_map

--- a/keras_nlp/src/models/gemma/gemma_backbone.py
+++ b/keras_nlp/src/models/gemma/gemma_backbone.py
@@ -255,17 +255,17 @@ class GemmaBackbone(Backbone):
         # See https://arxiv.org/abs/2403.08295
         layout_map = keras.distribution.LayoutMap(device_mesh)
         layout_map["token_embedding/embeddings"] = (model_dim, data_dim)
-        layout_map["decoder_block.*attention.*(query|key|value).*kernel"] = (
+        layout_map["decoder_block.*attention.*(query|key|value).kernel"] = (
             model_dim,
             data_dim,
             None,
         )
-        layout_map["decoder_block.*attention_output.*kernel"] = (
+        layout_map["decoder_block.*attention_output.kernel"] = (
             model_dim,
             None,
             data_dim,
         )
-        layout_map["decoder_block.*ffw_gating.*kernel"] = (data_dim, model_dim)
-        layout_map["decoder_block.*ffw_linear.*kernel"] = (model_dim, data_dim)
+        layout_map["decoder_block.*ffw_gating.kernel"] = (data_dim, model_dim)
+        layout_map["decoder_block.*ffw_linear.kernel"] = (model_dim, data_dim)
 
         return layout_map

--- a/keras_nlp/src/models/gemma/gemma_backbone_test.py
+++ b/keras_nlp/src/models/gemma/gemma_backbone_test.py
@@ -139,11 +139,11 @@ class GemmaBackboneTest(TestCase):
 
     def test_distribution_with_lora(self):
         if keras.backend.backend() != "jax":
-            return
+            self.skipTest("`ModelParallel` testing requires the Jax backend.")
         devices = keras.distribution.list_devices("CPU")
         if len(devices) == 1:
             # Need more than 1 device for distribution testing.
-            return
+            self.skipTest("`ModelParallel` testing requires multiple devices.")
         device_mesh = keras.distribution.DeviceMesh(
             shape=(1, len(devices)),
             axis_names=("batch", "model"),

--- a/keras_nlp/src/models/gemma/gemma_backbone_test.py
+++ b/keras_nlp/src/models/gemma/gemma_backbone_test.py
@@ -132,7 +132,7 @@ class GemmaBackboneTest(TestCase):
                 self.assertEqual(
                     tuple(w.value.sharding.spec), ("batch", "model")
                 )
-            if "ffw_linearl" in w.path:
+            if "ffw_linear" in w.path:
                 self.assertEqual(
                     tuple(w.value.sharding.spec), ("model", "batch")
                 )

--- a/keras_nlp/src/models/gemma/gemma_backbone_test.py
+++ b/keras_nlp/src/models/gemma/gemma_backbone_test.py
@@ -24,8 +24,8 @@ class GemmaBackboneTest(TestCase):
         self.init_kwargs = {
             "vocabulary_size": 256128,
             "num_layers": 2,
-            "num_query_heads": 4,
-            "num_key_value_heads": 4,
+            "num_query_heads": 8,
+            "num_key_value_heads": 8,
             "hidden_dim": 128,
             "intermediate_dim": 256,
             "head_dim": 128,
@@ -157,27 +157,19 @@ class GemmaBackboneTest(TestCase):
             model.enable_lora(rank=4)
 
         for w in model.weights:
-            if "attention/query/lora_kernel" in w.path:
+            if "attention/query/lora_kernel_a" in w.path:
                 self.assertEqual(
                     tuple(w.value.sharding.spec), (None, None, None)
                 )
-            if "attention/key/lora_kernel" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec), (None, None, None)
-                )
-            if "attention/value/lora_kernel" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec), (None, None, None)
-                )
-            if "attention/attention_output/lora_kernel" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec), (None, None, None)
-                )
-            if "ffw_gating/lora_kernel" in w.path:
+            if "attention/query/lora_kernel_b" in w.path:
                 self.assertEqual(
                     tuple(w.value.sharding.spec), (None, None)
                 )
-            if "ffw_gating_2/lora_kernel" in w.path:
+            if "attention/value/lora_kernel_a" in w.path:
+                self.assertEqual(
+                    tuple(w.value.sharding.spec), (None, None, None)
+                )
+            if "attention/value/lora_kernel_b" in w.path:
                 self.assertEqual(
                     tuple(w.value.sharding.spec), (None, None)
                 )

--- a/keras_nlp/src/models/gemma/gemma_backbone_test.py
+++ b/keras_nlp/src/models/gemma/gemma_backbone_test.py
@@ -82,7 +82,7 @@ class GemmaBackboneTest(TestCase):
 
     def test_architecture_characteristics(self):
         model = GemmaBackbone(**self.init_kwargs)
-        self.assertEqual(model.count_params(), 33407616)
+        self.assertEqual(model.count_params(), 33931904)
         self.assertEqual(len(model.layers), 6)
 
     def test_distribution(self):
@@ -162,14 +162,10 @@ class GemmaBackboneTest(TestCase):
                     tuple(w.value.sharding.spec), (None, None, None)
                 )
             if "attention/query/lora_kernel_b" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec), (None, None)
-                )
+                self.assertEqual(tuple(w.value.sharding.spec), (None, None))
             if "attention/value/lora_kernel_a" in w.path:
                 self.assertEqual(
                     tuple(w.value.sharding.spec), (None, None, None)
                 )
             if "attention/value/lora_kernel_b" in w.path:
-                self.assertEqual(
-                    tuple(w.value.sharding.spec), (None, None)
-                )
+                self.assertEqual(tuple(w.value.sharding.spec), (None, None))


### PR DESCRIPTION
This PR fixes several issues:

1. The default Gemma layout map was still missing the fixes from [issue 19496](https://github.com/keras-team/keras/issues/19496#issuecomment-2089424525).
2. The PR also adds a test for Gemma + get_layout_map + LoRA. This test fails without the get_layout_map fix in 1).
3. The PR also adds a layout map for ffw_gating_2, which was apparently forgotten (but there was a test for it!). The value chosen has been tested to be the one offering the fastest training on TPU_v3_8.
4. The PR also fixes a typo in the tests "ffw_linearl" => "ffw_linear"
5. Finally, the PR changes the number of heads in the test Gemma config from 4 to 8, otherwise the tests won't pass on TPU

Both tests `test_distribution` and `test_distribution_with_lora` now pass on TPU_v3_8.
However, I had to manually change device detection from 'CPU' to 'TPU' in file `gemma_backbone_test.py`, or the distribution tests would be skipped. I suspect these tests are NOT run nightly and I kindly ask a team member to check this.