### PR TITLE
Add quantization support for `Gemma`, `Gemma2` and `PaliGemma`

### DIFF
--- a/keras_nlp/src/layers/modeling/reversible_embedding.py
+++ b/keras_nlp/src/layers/modeling/reversible_embedding.py
@@ -107,15 +107,13 @@ class ReversibleEmbedding(keras.layers.Embedding):
 
     def build(self, inputs_shape=None):
         super().build(inputs_shape)
-
-        if not self.tie_weights:
-            if self.quantization_mode != "int8":
-                self.reverse_embeddings = self.add_weight(
-                    name="reverse_embeddings",
-                    shape=(self.output_dim, self.input_dim),
-                    initializer=self.embeddings_initializer,
-                    dtype=self.dtype,
-                )
+        if not self.tie_weights and self.quantization_mode != "int8":
+            self.reverse_embeddings = self.add_weight(
+                name="reverse_embeddings",
+                shape=(self.output_dim, self.input_dim),
+                initializer=self.embeddings_initializer,
+                dtype=self.dtype,
+            )
 
     def call(self, inputs, reverse=False):
         if reverse:
@@ -148,11 +146,8 @@ class ReversibleEmbedding(keras.layers.Embedding):
         if not self.tie_weights:
             # Store the reverse embedding weights as the last weights.
             target_variables.append(self.reverse_embeddings)
-            if self.quantization_mode is not None:
-                if self.quantization_mode == "int8":
-                    target_variables.append(self.reverse_embeddings_scale)
-                else:
-                    raise self._quantization_mode_error(self.quantization_mode)
+            if self.quantization_mode == "int8":
+                target_variables.append(self.reverse_embeddings_scale)
             for i, variable in enumerate(target_variables, start=len(store)):
                 store[str(i)] = variable
 
@@ -163,11 +158,8 @@ class ReversibleEmbedding(keras.layers.Embedding):
         if not self.tie_weights:
             # Last weights in the stores are the reverse embedding weights.
             target_variables = [self.reverse_embeddings]
-            if self.quantization_mode is not None:
-                if self.quantization_mode == "int8":
-                    target_variables.append(self.reverse_embeddings_scale)
-                else:
-                    raise self._quantization_mode_error(self.quantization_mode)
+            if self.quantization_mode == "int8":
+                target_variables.append(self.reverse_embeddings_scale)
             for i, variable in enumerate(
                 target_variables, start=len(store) - len(target_variables)
             ):

--- a/keras_nlp/src/layers/modeling/reversible_embedding_test.py
+++ b/keras_nlp/src/layers/modeling/reversible_embedding_test.py
@@ -98,3 +98,71 @@ class ReversibleEmbeddingTest(TestCase):
         output_data = embedding(input_data, reverse=True)
         self.assertEqual(output_data.shape, (4, 10, 100))
         self.assertDTypeEqual(output_data, "float16")
+
+    @parameterized.named_parameters(
+        ("tie_weights", True), ("untie_weights", False)
+    )
+    def test_quantize_int8(self, tie_weights):
+        layer_config = dict(
+            input_dim=100, output_dim=32, tie_weights=tie_weights
+        )
+        layer = ReversibleEmbedding(**layer_config)
+        layer.build()
+        x = random.randint(shape=(64, 100), minval=0, maxval=9)
+        x_reverse = random.uniform(shape=(64, 32))
+        y_float = layer(x)
+        y_reverse_float = layer(x_reverse, reverse=True)
+        layer.quantize("int8")
+
+        # Verify weights dtype
+        if not tie_weights:
+            self.assertEqual(
+                keras.backend.standardize_dtype(layer.reverse_embeddings.dtype),
+                "int8",
+            )
+            self.assertEqual(
+                keras.backend.standardize_dtype(
+                    layer.reverse_embeddings_scale.dtype
+                ),
+                layer.variable_dtype,
+            )
+
+        # Try eager call and verify output correctness
+        y_quantized = layer(x)
+        y_reverse_quantized = layer(x_reverse, reverse=True)
+        mse = ops.mean(ops.square(y_float - y_quantized))
+        mse_reverse = ops.mean(
+            ops.square(y_reverse_float - y_reverse_quantized)
+        )
+        self.assertLess(mse, 1e-3)  # A weak correctness test
+        self.assertLess(mse_reverse, 1e-3)  # A weak correctness test
+
+        # Try saving and reloading the model
+        model = keras.models.Sequential([layer])
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "quantized_model.keras"
+        )
+        model.save(temp_filepath)
+        new_model = keras.models.load_model(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+    @parameterized.named_parameters(
+        ("tie_weights", True),
+        ("untie_weights", False),
+    )
+    def test_quantize_dtype_argument(self, tie_weights):
+        self.run_layer_test(
+            cls=ReversibleEmbedding,
+            init_kwargs={
+                "input_dim": 100,
+                "output_dim": 32,
+                "tie_weights": tie_weights,
+                "embeddings_initializer": "HeNormal",
+                "dtype": "int8_from_float32",
+            },
+            input_data=random.randint(minval=0, maxval=100, shape=(4, 10)),
+            expected_output_shape=(4, 10, 32),
+            expected_num_trainable_weights=0,
+            expected_num_non_trainable_weights=2 if tie_weights else 4,
+            expected_num_non_trainable_variables=2 if tie_weights else 4,
+        )

--- a/keras_nlp/src/models/backbone.py
+++ b/keras_nlp/src/models/backbone.py
@@ -74,11 +74,7 @@ class Backbone(keras.Model):
             id(layer) for layer in self._flatten_layers()
         )
         self._initialized = True
-        if dtype is not None:
-            if isinstance(dtype, keras.DTypePolicy):
-                self.dtype_policy = dtype
-            else:
-                self.dtype_policy = keras.DTypePolicy(dtype)
+        self.dtype_policy = keras.dtype_policies.get(dtype)
 
     def __setattr__(self, name, value):
         # Work around setattr issues for Keras 2 and Keras 3 torch backend.
@@ -106,10 +102,19 @@ class Backbone(keras.Model):
     def get_config(self):
         # Don't chain to super here. `get_config()` for functional models is
         # a nested layer config and cannot be passed to Backbone constructors.
-        return {
+        config = {
             "name": self.name,
             "trainable": self.trainable,
         }
+
+        # Add quantization support by utilizing `DTypePolicyMap`
+        policy_map = keras.dtype_policies.DTypePolicyMap()
+        for layer in self._flatten_layers():
+            if layer.quantization_mode is not None:
+                policy_map[layer.path] = layer.dtype_policy
+        if len(policy_map) > 0:
+            config.update({"dtype": policy_map})
+        return config
 
     @classmethod
     def from_config(cls, config):

--- a/keras_nlp/src/models/bloom/bloom_backbone_test.py
+++ b/keras_nlp/src/models/bloom/bloom_backbone_test.py
@@ -39,6 +39,9 @@ class BloomBackboneTest(TestCase):
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,
             expected_output_shape=(2, 5, 8),
+            # TODO: Set to `True`. Error msg: Layer LayerNormalization does not
+            # have a `quantized_call()` method implemented.
+            run_quantization_check=False,
         )
 
     @pytest.mark.large

--- a/keras_nlp/src/models/gemma/gemma_backbone_test.py
+++ b/keras_nlp/src/models/gemma/gemma_backbone_test.py
@@ -11,11 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-
 import keras
 import pytest
-from absl.testing import parameterized
 from keras import ops
 
 from keras_nlp.src.models.gemma.gemma_backbone import GemmaBackbone
@@ -173,42 +170,6 @@ class GemmaBackboneTest(TestCase):
             if "attention/value/lora_kernel_b" in w.path:
                 self.assertEqual(tuple(w.value.sharding.spec), (None, None))
 
-    @parameterized.named_parameters(("int8", "int8"), ("float8", "float8"))
-    def test_quantize(self, mode):
-        model = GemmaBackbone(**self.init_kwargs)
-        y_float = model(self.input_data)
-        model.quantize(mode)
-
-        # Verify weights dtype
-        selected_layer = model.transformer_layers[0].attention.query_dense
-        if mode == "int8":
-            self.assertDTypeEqual(selected_layer._kernel, "int8")
-        elif mode == "float8":
-            self.assertLen(selected_layer.trainable_weights, 7)
-            self.assertTrue(hasattr(selected_layer, "kernel_amax_history"))
-
-        # Try eager call and verify output correctness
-        y_quantized = model(self.input_data)
-        mse = ops.mean(ops.square(y_float - y_quantized))
-        if mode == "int8":
-            # A weak correctness test
-            self.assertLess(mse, 1e-2)
-        elif mode == "float8":
-            # float8 quantization requires extra calibration, so we skip the
-            # assertion
-            pass
-
-        # Try saving and reloading the model
-        temp_filepath = os.path.join(
-            self.get_temp_dir(), "quantized_model.keras"
-        )
-        model.save(temp_filepath)
-        reloaded_model = keras.models.load_model(temp_filepath)
-        self.assertAllClose(
-            model.predict(self.input_data),
-            reloaded_model.predict(self.input_data),
-        )
-
 
 class Gemma2BackboneTest(TestCase):
     def setUp(self):
@@ -248,40 +209,4 @@ class Gemma2BackboneTest(TestCase):
             cls=GemmaBackbone,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,
-        )
-
-    @parameterized.named_parameters(("int8", "int8"), ("float8", "float8"))
-    def test_quantize(self, mode):
-        model = GemmaBackbone(**self.init_kwargs)
-        y_float = model(self.input_data)
-        model.quantize(mode)
-
-        # Verify weights dtype
-        selected_layer = model.transformer_layers[0].attention.query_dense
-        if mode == "int8":
-            self.assertDTypeEqual(selected_layer._kernel, "int8")
-        elif mode == "float8":
-            self.assertLen(selected_layer.trainable_weights, 7)
-            self.assertTrue(hasattr(selected_layer, "kernel_amax_history"))
-
-        # Try eager call and verify output correctness
-        y_quantized = model(self.input_data)
-        mse = ops.mean(ops.square(y_float - y_quantized))
-        if mode == "int8":
-            # A weak correctness test
-            self.assertLess(mse, 1e-2)
-        elif mode == "float8":
-            # float8 quantization requires extra calibration, so we skip the
-            # assertion
-            pass
-
-        # Try saving and reloading the model
-        temp_filepath = os.path.join(
-            self.get_temp_dir(), "quantized_model.keras"
-        )
-        model.save(temp_filepath)
-        reloaded_model = keras.models.load_model(temp_filepath)
-        self.assertAllClose(
-            model.predict(self.input_data),
-            reloaded_model.predict(self.input_data),
         )

--- a/keras_nlp/src/models/opt/opt_backbone_test.py
+++ b/keras_nlp/src/models/opt/opt_backbone_test.py
@@ -40,6 +40,10 @@ class OPTBackboneTest(TestCase):
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,
             expected_output_shape=(2, 5, 2),
+            # TODO: Set to `True`. Error msg: Layer 'token_embedding' expected 1
+            # variables, but received 0 variables during loading. Expected:
+            # ['embeddings']
+            run_quantization_check=False,
         )
 
     @pytest.mark.large

--- a/keras_nlp/src/models/pali_gemma/pali_gemma_backbone_test.py
+++ b/keras_nlp/src/models/pali_gemma/pali_gemma_backbone_test.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 import os
 
-import keras
 import numpy as np
-from absl.testing import parameterized
 
 from keras_nlp.src.models.pali_gemma.pali_gemma_backbone import (
     PaliGemmaBackbone,
@@ -35,12 +33,7 @@ class PaliGemmaBackboneTest(TestCase):
         self.vocabulary_size = 256
         self.text_sequence_length = 64
         self.image_size = 16
-        self.dummy_text = [
-            "the quick brown fox" for _ in range(self.batch_size)
-        ]
-        self.dummy_images = np.random.uniform(
-            size=(self.batch_size, self.image_size, self.image_size, 3)
-        )
+        self.image_sequence_length = int((self.image_size / 4) ** 2)
 
         proto = "gemma_test_vocab.spm"
         tokenizer = PaliGemmaTokenizer(
@@ -65,64 +58,17 @@ class PaliGemmaBackboneTest(TestCase):
             "vit_hidden_dim": 8,
             "vit_intermediate_dim": 16,
         }
-        self.backbone = PaliGemmaBackbone(**self.init_kwargs)
-        self.dummy_imgs = np.random.rand(
+
+        dummy_images = np.random.rand(
             self.batch_size, self.image_size, self.image_size, 3
         )
-        self.dummy_text_token_ids = np.random.rand(
+        dummy_text_token_ids = np.random.rand(
             self.batch_size, self.text_sequence_length
         )
-        self.dummy_text = [
-            "answer en the quick brown fox" for i in range(self.batch_size)
-        ]
-
-    def test_pali_gemma_backbone(self):
-        output = self.backbone(
-            {
-                "token_ids": self.dummy_text_token_ids,
-                "images": self.dummy_imgs,
-                "padding_mask": np.ones(
-                    (self.batch_size, self.text_sequence_length),
-                    dtype="int32",
-                ),
-                "response_mask": np.zeros(
-                    (self.batch_size, self.text_sequence_length),
-                    dtype="int32",
-                ),
-            }
-        )
-        self.assertEqual(
-            (
-                self.batch_size,
-                self.text_sequence_length + self.backbone.image_sequence_length,
-                8,
-            ),
-            output.shape,
-        )
-
-    def test_pali_gemma_backbone_with_preprocessing(self):
-        x, _, _ = self.preprocessor(
-            {
-                "images": self.dummy_images,
-                "prompts": self.dummy_text,
-                "responses": self.dummy_text,
-            }
-        )
-        output = self.backbone(x)
-        self.assertEqual(
-            (
-                self.batch_size,
-                self.text_sequence_length + self.backbone.image_sequence_length,
-                8,
-            ),
-            output.shape,
-        )
-
-    @parameterized.named_parameters(("int8", "int8"), ("float8", "float8"))
-    def test_quantize(self, mode):
-        input_data = {
-            "token_ids": self.dummy_text_token_ids,
-            "images": self.dummy_imgs,
+        dummy_text = ["answer en the quick brown fox"] * self.batch_size
+        self.input_data = {
+            "token_ids": dummy_text_token_ids,
+            "images": dummy_images,
             "padding_mask": np.ones(
                 (self.batch_size, self.text_sequence_length),
                 dtype="int32",
@@ -132,28 +78,35 @@ class PaliGemmaBackboneTest(TestCase):
                 dtype="int32",
             ),
         }
-        model = PaliGemmaBackbone(**self.init_kwargs)
-        model(input_data)
-        model.quantize(mode)
+        self.raw_input_data = {
+            "images": dummy_images,
+            "prompts": dummy_text,
+            "responses": dummy_text,
+        }
 
-        # Verify weights dtype
-        selected_layer = model.transformer_layers[0].attention.query_dense
-        if mode == "int8":
-            self.assertDTypeEqual(selected_layer._kernel, "int8")
-        elif mode == "float8":
-            self.assertLen(selected_layer.trainable_weights, 7)
-            self.assertTrue(hasattr(selected_layer, "kernel_amax_history"))
-
-        # Try eager call
-        model(input_data)
-
-        # Try saving and reloading the model
-        temp_filepath = os.path.join(
-            self.get_temp_dir(), "quantized_model.keras"
+    def test_backbone_basics(self):
+        self.run_backbone_test(
+            cls=PaliGemmaBackbone,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            expected_output_shape=(
+                self.batch_size,
+                self.text_sequence_length + self.image_sequence_length,
+                8,
+            ),
+            variable_length_data=[self.input_data],
+            run_mixed_precision_check=False,  # TODO: Set to `True`
         )
-        model.save(temp_filepath)
-        reloaded_model = keras.models.load_model(temp_filepath)
-        self.assertAllClose(
-            model.predict(input_data),
-            reloaded_model.predict(input_data),
+
+    def test_pali_gemma_backbone_with_preprocessing(self):
+        model = PaliGemmaBackbone(**self.init_kwargs)
+        x, _, _ = self.preprocessor(self.raw_input_data)
+        output = model(x)
+        self.assertEqual(
+            (
+                self.batch_size,
+                self.text_sequence_length + self.image_sequence_length,
+                8,
+            ),
+            output.shape,
         )

--- a/keras_nlp/src/models/pali_gemma/pali_gemma_vit.py
+++ b/keras_nlp/src/models/pali_gemma/pali_gemma_vit.py
@@ -536,6 +536,7 @@ class PaliGemmaVit(keras.Model):
             classifier_activation
         )
         self.image_sequence_length = int((image_size / patch_size) ** 2)
+        self.dtype_policy = keras.dtype_policies.get(dtype)
 
     def get_config(self):
         config = super().get_config()

--- a/keras_nlp/src/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_nlp/src/tokenizers/sentence_piece_tokenizer.py
@@ -120,7 +120,14 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
     ) -> None:
         assert_tf_text_installed(self.__class__.__name__)
 
-        if not is_int_dtype(dtype) and not is_string_dtype(dtype):
+        if isinstance(dtype, str):
+            compute_dtype = dtype
+        elif isinstance(dtype, keras.DTypePolicy):
+            compute_dtype = dtype.compute_dtype
+
+        if not is_int_dtype(compute_dtype) and not is_string_dtype(
+            compute_dtype
+        ):
             raise ValueError(
                 "Output dtype must be an integer type or a string. "
                 f"Received: dtype={dtype}"

--- a/keras_nlp/src/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_nlp/src/tokenizers/sentence_piece_tokenizer.py
@@ -120,14 +120,7 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
     ) -> None:
         assert_tf_text_installed(self.__class__.__name__)
 
-        if isinstance(dtype, str):
-            compute_dtype = dtype
-        elif isinstance(dtype, keras.DTypePolicy):
-            compute_dtype = dtype.compute_dtype
-
-        if not is_int_dtype(compute_dtype) and not is_string_dtype(
-            compute_dtype
-        ):
+        if not is_int_dtype(dtype) and not is_string_dtype(dtype):
             raise ValueError(
                 "Output dtype must be an integer type or a string. "
                 f"Received: dtype={dtype}"


### PR DESCRIPTION
~~We will need a new release of Keras for this. Currently, I have built the PR based on the master branch of Keras.~~

The implementation is simple and clean after introducing `DTypePolicyMap` and some other fixes.
Thanks to @fchollet and @mattdangerw for their help.

It is worth noting that float8 training & inference are also supported in this PR. You can check `test_quantize` for this.

Some numbers:

|Model|Memory Usage (bfloat16)|Memory Usage (int8)|Weights (kagglehub)|Weights (int8)|Note|
|-|-|-|-|-|-|
|"gemma_1.1_instruct_2b_en"|5.69GB|2.82GB|4.7GB|2.4GB||
|"gemma2_instruct_9b_en"|20.93GB|10.14GB|18GB|8.7GB|Measured on CPU|
|"pali_gemma_3b_mix_224"|6.52GB|3.22GB|5.5GB|2.8GB||

Script:

<details>

<summary>int8_gemma.py</summary>

```python
import argparse
import os
import pathlib
import time
import typing

import keras
import psutil
import tensorflow as tf

import keras_nlp

# Setup kaggle information
os.environ["KAGGLE_USERNAME"] = "xxx"
os.environ["KAGGLE_KEY"] = "xxx"


def get_args():
    parser = argparse.ArgumentParser()
    parser.add_argument(
        "--model",
        default="pali_gemma_3b_mix_224",
        choices=[
            "gemma_1.1_instruct_2b_en",
            "pali_gemma_3b_mix_224",
            "gemma2_instruct_9b_en",
        ],
        help="Which model to demonstrate",
    )
    parser.add_argument(
        "--path",
        default=".",
        help="Path to save and load the model",
    )
    parser.add_argument(
        "--save",
        action="store_true",
        help="Quantize and save the model",
    )
    args = parser.parse_args()
    return args


def get_memory_usage():
    # From CPU or GPU:0
    try:
        memory_stats = tf.config.experimental.get_memory_info("GPU:0")
        peak_usage = memory_stats["peak"] / (2**30)
    except Exception:
        memory_usage = psutil.Process().memory_info().rss
        peak_usage = memory_usage / (2**30)
    return peak_usage


def benchmark_pali_gemma(
    model: keras_nlp.models.PaliGemmaCausalLM, image, prompt: str
):
    # Warmup
    model.generate({"images": image, "prompts": prompt}, max_length=128)

    # Benchmark
    st = time.time()
    result = model.generate(
        {"images": image, "prompts": prompt}, max_length=128
    )
    ed = time.time()
    return result, ed - st


def benchmark_gemma(model: keras_nlp.models.GemmaCausalLM, prompt: str):
    # Warmup
    model.generate(prompt, max_length=128)

    # Benchmark
    st = time.time()
    result = model.generate(prompt, max_length=128)
    ed = time.time()
    return result, ed - st


def save_int8_model(
    preset: str,
    model: typing.Union[
        keras_nlp.models.GemmaCausalLM,
        keras_nlp.models.PaliGemmaCausalLM,
    ],
):
    model.quantize("int8")
    model.summary()
    model.save(f"{preset}_int8.keras")


def load(model_path: pathlib.Path):
    model = keras.saving.load_model(model_path)
    return model


if __name__ == "__main__":
    keras.config.set_dtype_policy("bfloat16")
    x = keras.ops.ones([1]) * keras.ops.ones([1])  # Trigger TF dummy logs

    args = get_args()
    path = pathlib.Path(args.path)
    is_pali_gemma = "pali_gemma" in str(args.model)
    print(f"Peak memory usage (init): {get_memory_usage():.3f} GB")

    # Save
    if args.save:
        if is_pali_gemma:
            model = keras_nlp.models.PaliGemmaCausalLM.from_preset(args.model)
        else:
            model = keras_nlp.models.GemmaCausalLM.from_preset(args.model)
        model.summary()
        print(
            "Peak memory usage (loaded float model): "
            f"{get_memory_usage():.3f} GB"
        )
        save_int8_model(args.model, model)
    # Load
    else:
        model_path = path / f"{args.model}_int8.keras"
        model = load(model_path)
        print(
            "Peak memory usage (loaded int8 model): "
            f"{get_memory_usage():.3f} GB"
        )

        if is_pali_gemma:
            image_path = keras.utils.get_file(
                "cow_beach_1.png",
                "https://storage.googleapis.com/keras-cv/models/paligemma/cow_beach_1.png",
            )
            image = keras.utils.load_img(image_path)
            image = keras.utils.img_to_array(image, "channels_last")
            prompt = "describe en\n"
            result, elapsed_time = benchmark_pali_gemma(model, image, prompt)
        else:
            prompt = "What is Keras3?"
            result, elapsed_time = benchmark_gemma(model, prompt)
        print(result)
        print(
            f"The elapsed time for model inference: {elapsed_time:.3f} seconds"
        )

```

</details>

Usage:

```bash
# Get quantized model
python int8_gemma.py --model "gemma_1.1_instruct_2b_en" --save
python int8_gemma.py --model "gemma2_instruct_9b_en" --save
python int8_gemma.py --model "pali_gemma_3b_mix_224" --save
# Run
python int8_gemma.py --model "gemma_1.1_instruct_2b_en"
python int8_gemma.py --model "gemma2_instruct_9b_en"
python int8_gemma.py --model "pali_gemma_3b_mix_224"
```

Outputs:
```bash
# Gemma
What is Keras3?

Keras3 is a high-level neural network library built on top of Keras 2. It provides a simplified and more efficient way to build and train deep learning models.

**Key features of Keras3:**

- Simplified API with Keras 2 compatibility
- High-level abstractions for common tasks
- Improved performance and efficiency
- Support for modern neural network architectures


**Benefits of using Keras3:**

- Easier to learn and use
- Faster and more accurate models
- Reduced development time
- Improved portability across different hardware platforms


**How to use Keras3:**

- Import

# PaliGemma
describe en
In this image I can see a cow which affor is in brown color and white color. I can see the sand. In the background I can see the water and the sky.
```