### PR TITLE
Fix compatibility for earlier versions of Keras

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -17,6 +17,10 @@ jobs:
       fail-fast: false
       matrix:
         backend: [tensorflow, jax, torch]
+        version: [latest]
+        include:
+          - backend: torch
+            version: 3.1
     runs-on: ubuntu-latest
     env:
       KERAS_BACKEND: ${{ matrix.backend }}
@@ -42,51 +46,11 @@ jobs:
       run: |
           pip install -r requirements.txt --progress-bar off
           pip install --no-deps -e "." --progress-bar off
-    - name: Test with pytest
+    - name: Pin Keras version
+      if: ${{ matrix.version == '3.1'}}
       run: |
-        pytest keras_nlp/
-    - name: Run integration tests
-      run: |
-        python pip_build.py --install
-        cd integration_tests && pytest . -k "not NoTensorflow"
-    - name: Run no tensorflow integration test
-      if: ${{ matrix.backend != 'tensorflow'}}
-      run: |
-        pip uninstall -y tensorflow-text tensorflow
-        cd integration_tests && pytest . -k "NoTensorflow"
-  run_tests_with_keras_3_1_0:
-    name: Test the code with Keras 3.1.0
-    strategy:
-      fail-fast: false
-      matrix:
-        backend: [tensorflow, jax, torch]
-    runs-on: ubuntu-latest
-    env:
-      KERAS_BACKEND: ${{ matrix.backend }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.9
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        python -m pip install --upgrade pip setuptools
-        echo "::set-output name=dir::$(pip cache dir)"
-    - name: pip cache
-      uses: actions/cache@v4
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-    - name: Install dependencies with Keras 3.1.0
-      run: |
-          pip install -r requirements.txt --progress-bar off
-          pip install --no-deps -e "." --progress-bar off
-          pip uninstall -y keras
-          pip install keras==3.1.0 --progress-bar off
+        pip uninstall -y keras
+        pip install keras==3.1.0 --progress-bar off
     - name: Test with pytest
       run: |
         pytest keras_nlp/

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -54,6 +54,51 @@ jobs:
       run: |
         pip uninstall -y tensorflow-text tensorflow
         cd integration_tests && pytest . -k "NoTensorflow"
+  run_tests_with_keras_3_1_0:
+    name: Test the code with Keras 3.1.0
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [tensorflow, jax, torch]
+    runs-on: ubuntu-latest
+    env:
+      KERAS_BACKEND: ${{ matrix.backend }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.9
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        python -m pip install --upgrade pip setuptools
+        echo "::set-output name=dir::$(pip cache dir)"
+    - name: pip cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Install dependencies with Keras 3.1.0
+      run: |
+          pip install -r requirements.txt --progress-bar off
+          pip install --no-deps -e "." --progress-bar off
+          pip uninstall -y keras
+          pip install keras==3.1.0 --progress-bar off
+    - name: Test with pytest
+      run: |
+        pytest keras_nlp/
+    - name: Run integration tests
+      run: |
+        python pip_build.py --install
+        cd integration_tests && pytest . -k "not NoTensorflow"
+    - name: Run no tensorflow integration test
+      if: ${{ matrix.backend != 'tensorflow'}}
+      run: |
+        pip uninstall -y tensorflow-text tensorflow
+        cd integration_tests && pytest . -k "NoTensorflow"
   check_format:
     name: Check the code format
     runs-on: ubuntu-latest

--- a/keras_nlp/src/layers/modeling/reversible_embedding.py
+++ b/keras_nlp/src/layers/modeling/reversible_embedding.py
@@ -17,6 +17,7 @@ from keras import ops
 from packaging.version import parse
 
 from keras_nlp.src.api_export import keras_nlp_export
+from keras_nlp.src.utils.keras_utils import assert_quantization_support
 
 
 @keras_nlp_export("keras_nlp.layers.ReversibleEmbedding")
@@ -237,11 +238,7 @@ class ReversibleEmbedding(keras.layers.Embedding):
     def quantize(self, mode, type_check=True):
         import gc
 
-        if parse(keras.version()) < parse("3.4.0"):
-            raise ValueError(
-                "`quantize` in KerasNLP requires Keras >= 3.4.0 to function "
-                f"correctly. Received: '{keras.version()}'"
-            )
+        assert_quantization_support()
         if type_check and type(self) is not ReversibleEmbedding:
             raise NotImplementedError(
                 f"Layer {self.__class__.__name__} does not have a `quantize()` "

--- a/keras_nlp/src/layers/modeling/reversible_embedding_test.py
+++ b/keras_nlp/src/layers/modeling/reversible_embedding_test.py
@@ -19,12 +19,12 @@ import numpy as np
 from absl.testing import parameterized
 from keras import ops
 from keras import random
-from packaging.version import parse
 
 from keras_nlp.src.layers.modeling.reversible_embedding import (
     ReversibleEmbedding,
 )
 from keras_nlp.src.tests.test_case import TestCase
+from keras_nlp.src.utils.keras_utils import has_quantization_support
 
 
 class ReversibleEmbeddingTest(TestCase):
@@ -104,8 +104,8 @@ class ReversibleEmbeddingTest(TestCase):
         ("tie_weights", True), ("untie_weights", False)
     )
     def test_quantize_int8(self, tie_weights):
-        if parse(keras.version()) < parse("3.4.0"):
-            self.skipTest("This test needs keras>=3.4.0.")
+        if not has_quantization_support():
+            self.skipTest("This version of Keras doesn't support quantization.")
 
         layer_config = dict(
             input_dim=100, output_dim=32, tie_weights=tie_weights
@@ -155,8 +155,8 @@ class ReversibleEmbeddingTest(TestCase):
         ("untie_weights", False),
     )
     def test_quantize_dtype_argument(self, tie_weights):
-        if parse(keras.version()) < parse("3.4.0"):
-            self.skipTest("This test needs keras>=3.4.0.")
+        if not has_quantization_support():
+            self.skipTest("This version of Keras doesn't support quantization.")
 
         self.run_layer_test(
             cls=ReversibleEmbedding,

--- a/keras_nlp/src/layers/modeling/reversible_embedding_test.py
+++ b/keras_nlp/src/layers/modeling/reversible_embedding_test.py
@@ -19,6 +19,7 @@ import numpy as np
 from absl.testing import parameterized
 from keras import ops
 from keras import random
+from packaging.version import parse
 
 from keras_nlp.src.layers.modeling.reversible_embedding import (
     ReversibleEmbedding,
@@ -103,6 +104,9 @@ class ReversibleEmbeddingTest(TestCase):
         ("tie_weights", True), ("untie_weights", False)
     )
     def test_quantize_int8(self, tie_weights):
+        if parse(keras.version()) < parse("3.4.0"):
+            self.skipTest("This test needs keras>=3.4.0.")
+
         layer_config = dict(
             input_dim=100, output_dim=32, tie_weights=tie_weights
         )
@@ -151,6 +155,9 @@ class ReversibleEmbeddingTest(TestCase):
         ("untie_weights", False),
     )
     def test_quantize_dtype_argument(self, tie_weights):
+        if parse(keras.version()) < parse("3.4.0"):
+            self.skipTest("This test needs keras>=3.4.0.")
+
         self.run_layer_test(
             cls=ReversibleEmbedding,
             init_kwargs={

--- a/keras_nlp/src/models/backbone.py
+++ b/keras_nlp/src/models/backbone.py
@@ -15,9 +15,9 @@
 import os
 
 import keras
-from packaging.version import parse
 
 from keras_nlp.src.api_export import keras_nlp_export
+from keras_nlp.src.utils.keras_utils import assert_quantization_support
 from keras_nlp.src.utils.preset_utils import CONFIG_FILE
 from keras_nlp.src.utils.preset_utils import MODEL_WEIGHTS_FILE
 from keras_nlp.src.utils.preset_utils import check_config_class
@@ -109,11 +109,7 @@ class Backbone(keras.Model):
         self._token_embedding = value
 
     def quantize(self, mode, **kwargs):
-        if parse(keras.version()) < parse("3.4.0"):
-            raise ValueError(
-                "`quantize` in KerasNLP requires Keras >= 3.4.0 to function "
-                f"correctly. Received: keras.version()={keras.version()}"
-            )
+        assert_quantization_support()
         return super().quantize(mode, **kwargs)
 
     def get_config(self):

--- a/keras_nlp/src/models/pali_gemma/pali_gemma_vit.py
+++ b/keras_nlp/src/models/pali_gemma/pali_gemma_vit.py
@@ -536,7 +536,14 @@ class PaliGemmaVit(keras.Model):
             classifier_activation
         )
         self.image_sequence_length = int((image_size / patch_size) ** 2)
-        self.dtype_policy = keras.dtype_policies.get(dtype)
+        # Before Keras 3.2, there is no `keras.dtype_policies.get`.
+        if hasattr(keras.dtype_policies, "get"):
+            self.dtype_policy = keras.dtype_policies.get(dtype)
+        else:
+            if isinstance(dtype, keras.dtype_policies.DTypePolicy):
+                dtype = dtype.name
+            dtype = dtype or keras.config.dtype_policy().name
+            self.dtype_policy = keras.dtype_policies.DTypePolicy(dtype)
 
     def get_config(self):
         config = super().get_config()

--- a/keras_nlp/src/tests/test_case.py
+++ b/keras_nlp/src/tests/test_case.py
@@ -22,6 +22,7 @@ import tensorflow as tf
 from absl.testing import parameterized
 from keras import ops
 from keras import tree
+from packaging.version import parse
 
 from keras_nlp.src import layers as keras_nlp_layers
 from keras_nlp.src.tokenizers.tokenizer import Tokenizer
@@ -445,7 +446,7 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             self.run_precision_test(cls, init_kwargs, input_data)
 
         # Check quantization.
-        if run_quantization_check:
+        if run_quantization_check and parse(keras.version()) >= parse("3.4.0"):
             self.run_quantization_test(backbone, cls, init_kwargs, input_data)
 
     def run_task_test(

--- a/keras_nlp/src/tests/test_case.py
+++ b/keras_nlp/src/tests/test_case.py
@@ -22,10 +22,10 @@ import tensorflow as tf
 from absl.testing import parameterized
 from keras import ops
 from keras import tree
-from packaging.version import parse
 
 from keras_nlp.src import layers as keras_nlp_layers
 from keras_nlp.src.tokenizers.tokenizer import Tokenizer
+from keras_nlp.src.utils.keras_utils import has_quantization_support
 from keras_nlp.src.utils.tensor_utils import is_float_dtype
 
 
@@ -446,7 +446,7 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             self.run_precision_test(cls, init_kwargs, input_data)
 
         # Check quantization.
-        if run_quantization_check and parse(keras.version()) >= parse("3.4.0"):
+        if run_quantization_check and has_quantization_support():
             self.run_quantization_test(backbone, cls, init_kwargs, input_data)
 
     def run_task_test(

--- a/keras_nlp/src/utils/keras_utils.py
+++ b/keras_nlp/src/utils/keras_utils.py
@@ -16,6 +16,7 @@ import sys
 
 import keras
 from absl import logging
+from packaging.version import parse
 
 from keras_nlp.src.utils.tensor_utils import is_tensor_type
 
@@ -102,3 +103,15 @@ def print_msg(message, line_break=True):
 @keras.saving.register_keras_serializable(package="keras_nlp")
 def gelu_approximate(x):
     return keras.activations.gelu(x, approximate=True)
+
+
+def has_quantization_support():
+    return False if parse(keras.version()) < parse("3.4.0") else True
+
+
+def assert_quantization_support():
+    if not has_quantization_support():
+        raise ValueError(
+            "Quantization API requires Keras >= 3.4.0 to function "
+            f"correctly. Received: '{keras.version()}'"
+        )


### PR DESCRIPTION
I have added a new matrix of runners to test KerasNLP with Keras 3.1.0

Now the code should run flawlessly with Keras 3.1.0
(Keras 3.0.x failed due to the absence of the `keras.tree` API, and it is difficult to make it compatible).

However, quantization only works correctly with Keras >= 3.4.0 using `DTypePolicyMap`. Therefore, version checks have been included as well.

cc @fchollet @mattdangerw 

EDITED:
All tests passed. If users are not using the quantization API, they can use any version of Keras from `3.1.0` to the latest.