### PR TITLE
Add a HF BERT converter, improve safetensor loading

### DIFF
--- a/keras_nlp/src/utils/preset_utils.py
+++ b/keras_nlp/src/utils/preset_utils.py
@@ -59,18 +59,20 @@ TOKENIZER_ASSET_DIR = "assets/tokenizer"
 
 # Config file names.
 CONFIG_FILE = "config.json"
-HF_CONFIG_FILE = "config.json"
 TOKENIZER_CONFIG_FILE = "tokenizer.json"
 TASK_CONFIG_FILE = "task.json"
 PREPROCESSOR_CONFIG_FILE = "preprocessor.json"
 METADATA_FILE = "metadata.json"
-SAFETENSOR_CONFIG_FILE = "model.safetensors.index.json"
-
-README_FILE = "README.md"
 
 # Weight file names.
 MODEL_WEIGHTS_FILE = "model.weights.h5"
 TASK_WEIGHTS_FILE = "task.weights.h5"
+
+# HuggingFace filenames.
+README_FILE = "README.md"
+HF_CONFIG_FILE = "config.json"
+HF_TOKENIZER_CONFIG_FILE = "tokenizer_config.json"
+SAFETENSOR_CONFIG_FILE = "model.safetensors.index.json"
 SAFETENSOR_FILE = "model.safetensors"
 
 # Global state for preset registry.

--- a/keras_nlp/src/utils/transformers/convert.py
+++ b/keras_nlp/src/utils/transformers/convert.py
@@ -14,6 +14,8 @@
 """Convert huggingface models to KerasNLP."""
 
 
+from keras_nlp.src.utils.transformers.convert_bert import load_bert_backbone
+from keras_nlp.src.utils.transformers.convert_bert import load_bert_tokenizer
 from keras_nlp.src.utils.transformers.convert_gemma import load_gemma_backbone
 from keras_nlp.src.utils.transformers.convert_gemma import load_gemma_tokenizer
 from keras_nlp.src.utils.transformers.convert_llama3 import load_llama3_backbone
@@ -29,8 +31,21 @@ from keras_nlp.src.utils.transformers.convert_pali_gemma import (
 
 
 def load_transformers_backbone(cls, preset, load_weights):
+    """
+    Load HuggingFace model config as weights as a KerasNLP backbone.
+
+    Args:
+        cls (class): Keras model class.
+        preset (str): Preset configuration name.
+        load_weights (bool): Whether to load the weights.
+
+    Returns:
+        backbone: Initialized Keras model backbone.
+    """
     if cls is None:
         raise ValueError("Backbone class is None")
+    if cls.__name__ == "BertBackbone":
+        return load_bert_backbone(cls, preset, load_weights)
     if cls.__name__ == "GemmaBackbone":
         return load_gemma_backbone(cls, preset, load_weights)
     if cls.__name__ == "Llama3Backbone":
@@ -44,8 +59,20 @@ def load_transformers_backbone(cls, preset, load_weights):
 
 
 def load_transformers_tokenizer(cls, preset):
+    """
+    Load HuggingFace tokenizer assets as a KerasNLP tokenizer.
+
+    Args:
+        cls (class): Tokenizer class.
+        preset (str): Preset configuration name.
+
+    Returns:
+        tokenizer: Initialized tokenizer.
+    """
     if cls is None:
         raise ValueError("Tokenizer class is None")
+    if cls.__name__ == "BertTokenizer":
+        return load_bert_tokenizer(cls, preset)
     if cls.__name__ == "GemmaTokenizer":
         return load_gemma_tokenizer(cls, preset)
     if cls.__name__ == "Llama3Tokenizer":

--- a/keras_nlp/src/utils/transformers/convert.py
+++ b/keras_nlp/src/utils/transformers/convert.py
@@ -32,7 +32,7 @@ from keras_nlp.src.utils.transformers.convert_pali_gemma import (
 
 def load_transformers_backbone(cls, preset, load_weights):
     """
-    Load HuggingFace model config as weights as a KerasNLP backbone.
+    Load a Transformer model config and weights as a KerasNLP backbone.
 
     Args:
         cls (class): Keras model class.
@@ -60,7 +60,7 @@ def load_transformers_backbone(cls, preset, load_weights):
 
 def load_transformers_tokenizer(cls, preset):
     """
-    Load HuggingFace tokenizer assets as a KerasNLP tokenizer.
+    Load a Transformer tokenizer assets as a KerasNLP tokenizer.
 
     Args:
         cls (class): Tokenizer class.

--- a/keras_nlp/src/utils/transformers/convert_bert.py
+++ b/keras_nlp/src/utils/transformers/convert_bert.py
@@ -1,0 +1,173 @@
+# Copyright 2024 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import numpy as np
+
+from keras_nlp.src.utils.preset_utils import HF_CONFIG_FILE
+from keras_nlp.src.utils.preset_utils import HF_TOKENIZER_CONFIG_FILE
+from keras_nlp.src.utils.preset_utils import get_file
+from keras_nlp.src.utils.preset_utils import jax_memory_cleanup
+from keras_nlp.src.utils.preset_utils import load_config
+from keras_nlp.src.utils.transformers.safetensor_utils import SafetensorLoader
+
+
+def convert_backbone_config(transformers_config):
+    return {
+        "vocabulary_size": transformers_config["vocab_size"],
+        "num_layers": transformers_config["num_hidden_layers"],
+        "num_heads": transformers_config["num_attention_heads"],
+        "hidden_dim": transformers_config["hidden_size"],
+        "intermediate_dim": transformers_config["intermediate_size"],
+    }
+
+
+def convert_weights(backbone, loader, transformers_config):
+    # Embedding layer
+    loader.port_weight(
+        keras_variable=backbone.get_layer("token_embedding").embeddings,
+        hf_weight_key="bert.embeddings.word_embeddings.weight",
+    )
+    loader.port_weight(
+        keras_variable=backbone.get_layer(
+            "position_embedding"
+        ).position_embeddings,
+        hf_weight_key="bert.embeddings.position_embeddings.weight",
+    )
+    loader.port_weight(
+        keras_variable=backbone.get_layer("segment_embedding").embeddings,
+        hf_weight_key="bert.embeddings.token_type_embeddings.weight",
+    )
+    loader.port_weight(
+        keras_variable=backbone.get_layer("embeddings_layer_norm").beta,
+        hf_weight_key="bert.embeddings.LayerNorm.beta",
+    )
+    loader.port_weight(
+        keras_variable=backbone.get_layer("embeddings_layer_norm").gamma,
+        hf_weight_key="bert.embeddings.LayerNorm.gamma",
+    )
+
+    def transpose_and_reshape(x, shape):
+        return np.reshape(np.transpose(x), shape)
+
+    # Attention blocks
+    for i in range(backbone.num_layers):
+        block = backbone.get_layer(f"transformer_layer_{i}")
+        attn = block._self_attention_layer
+        hf_prefix = "bert.encoder.layer."
+        # Attention layers
+        loader.port_weight(
+            keras_variable=attn.query_dense.kernel,
+            hf_weight_key=f"{hf_prefix}{i}.attention.self.query.weight",
+            hook_fn=transpose_and_reshape,
+        )
+        loader.port_weight(
+            keras_variable=attn.query_dense.bias,
+            hf_weight_key=f"{hf_prefix}{i}.attention.self.query.bias",
+            hook_fn=lambda hf_tensor, shape: np.reshape(hf_tensor, shape),
+        )
+        loader.port_weight(
+            keras_variable=attn.key_dense.kernel,
+            hf_weight_key=f"{hf_prefix}{i}.attention.self.key.weight",
+            hook_fn=transpose_and_reshape,
+        )
+        loader.port_weight(
+            keras_variable=attn.key_dense.bias,
+            hf_weight_key=f"{hf_prefix}{i}.attention.self.key.bias",
+            hook_fn=lambda hf_tensor, shape: np.reshape(hf_tensor, shape),
+        )
+        loader.port_weight(
+            keras_variable=attn.value_dense.kernel,
+            hf_weight_key=f"{hf_prefix}{i}.attention.self.value.weight",
+            hook_fn=transpose_and_reshape,
+        )
+        loader.port_weight(
+            keras_variable=attn.value_dense.bias,
+            hf_weight_key=f"{hf_prefix}{i}.attention.self.value.bias",
+            hook_fn=lambda hf_tensor, shape: np.reshape(hf_tensor, shape),
+        )
+        loader.port_weight(
+            keras_variable=attn.output_dense.kernel,
+            hf_weight_key=f"{hf_prefix}{i}.attention.output.dense.weight",
+            hook_fn=transpose_and_reshape,
+        )
+        loader.port_weight(
+            keras_variable=attn.output_dense.bias,
+            hf_weight_key=f"{hf_prefix}{i}.attention.output.dense.bias",
+            hook_fn=lambda hf_tensor, shape: np.reshape(hf_tensor, shape),
+        )
+        # Attention layer norm.
+        loader.port_weight(
+            keras_variable=block._self_attention_layer_norm.beta,
+            hf_weight_key=f"{hf_prefix}{i}.attention.output.LayerNorm.beta",
+        )
+        loader.port_weight(
+            keras_variable=block._self_attention_layer_norm.gamma,
+            hf_weight_key=f"{hf_prefix}{i}.attention.output.LayerNorm.gamma",
+        )
+        # MLP layers
+        loader.port_weight(
+            keras_variable=block._feedforward_intermediate_dense.kernel,
+            hf_weight_key=f"{hf_prefix}{i}.intermediate.dense.weight",
+            hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
+        )
+        loader.port_weight(
+            keras_variable=block._feedforward_intermediate_dense.bias,
+            hf_weight_key=f"{hf_prefix}{i}.intermediate.dense.bias",
+        )
+        loader.port_weight(
+            keras_variable=block._feedforward_output_dense.kernel,
+            hf_weight_key=f"{hf_prefix}{i}.output.dense.weight",
+            hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
+        )
+        loader.port_weight(
+            keras_variable=block._feedforward_output_dense.bias,
+            hf_weight_key=f"{hf_prefix}{i}.output.dense.bias",
+        )
+        # Output layer norm.
+        loader.port_weight(
+            keras_variable=block._feedforward_layer_norm.beta,
+            hf_weight_key=f"{hf_prefix}{i}.output.LayerNorm.beta",
+        )
+        loader.port_weight(
+            keras_variable=block._feedforward_layer_norm.gamma,
+            hf_weight_key=f"{hf_prefix}{i}.output.LayerNorm.gamma",
+        )
+
+    loader.port_weight(
+        keras_variable=backbone.get_layer("pooled_dense").kernel,
+        hf_weight_key="bert.pooler.dense.weight",
+        hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
+    )
+    loader.port_weight(
+        keras_variable=backbone.get_layer("pooled_dense").bias,
+        hf_weight_key="bert.pooler.dense.bias",
+    )
+
+
+def load_bert_backbone(cls, preset, load_weights):
+    transformers_config = load_config(preset, HF_CONFIG_FILE)
+    keras_config = convert_backbone_config(transformers_config)
+    backbone = cls(**keras_config)
+    if load_weights:
+        jax_memory_cleanup(backbone)
+        with SafetensorLoader(preset) as loader:
+            convert_weights(backbone, loader, transformers_config)
+    return backbone
+
+
+def load_bert_tokenizer(cls, preset):
+    transformers_config = load_config(preset, HF_TOKENIZER_CONFIG_FILE)
+    return cls(
+        get_file(preset, "vocab.txt"),
+        lowercase=transformers_config["do_lower_case"],
+    )

--- a/keras_nlp/src/utils/transformers/convert_bert_test.py
+++ b/keras_nlp/src/utils/transformers/convert_bert_test.py
@@ -1,0 +1,29 @@
+# Copyright 2023 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+from keras_nlp.src.models.bert.bert_classifier import BertClassifier
+from keras_nlp.src.tests.test_case import TestCase
+
+
+class TestTask(TestCase):
+    @pytest.mark.large
+    def test_convert_tiny_preset(self):
+        model = BertClassifier.from_preset(
+            "hf://google-bert/bert-base-uncased", num_classes=2
+        )
+        prompt = "That movies was terrible."
+        model.predict([prompt])
+
+    # TODO: compare numerics with huggingface model

--- a/keras_nlp/src/utils/transformers/convert_gemma.py
+++ b/keras_nlp/src/utils/transformers/convert_gemma.py
@@ -11,32 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from functools import partial
-
 import numpy as np
 
 from keras_nlp.src.utils.preset_utils import HF_CONFIG_FILE
-from keras_nlp.src.utils.preset_utils import SAFETENSOR_CONFIG_FILE
 from keras_nlp.src.utils.preset_utils import get_file
 from keras_nlp.src.utils.preset_utils import jax_memory_cleanup
 from keras_nlp.src.utils.preset_utils import load_config
-from keras_nlp.src.utils.transformers.safetensor_utils import set_keras_weight
+from keras_nlp.src.utils.transformers.safetensor_utils import SafetensorLoader
 
 
-def load_gemma_backbone(cls, preset, load_weights):
-    """
-    Load and initialize the Gemma backbone model.
-
-    Args:
-        cls (class): Keras model class.
-        preset (str): Preset configuration name.
-        load_weights (bool): Whether to load the weights.
-
-    Returns:
-        backbone: Initialized Keras model backbone.
-    """
-    transformers_config = load_config(preset, HF_CONFIG_FILE)
-
+def convert_backbone_config(transformers_config):
     backbone_config = dict()
     if transformers_config["model_type"] == "gemma":
         # Build Gemma backbone configuration
@@ -71,154 +55,109 @@ def load_gemma_backbone(cls, preset, load_weights):
             "sliding_window_size": transformers_config["sliding_window_size"],
             "use_sliding_window_attention": True,
         }
+    return backbone_config
 
-    backbone = cls(**backbone_config)
-    if not load_weights:
-        return backbone
 
-    jax_memory_cleanup(backbone)
-    # Code to port the weights from safetensors into the keras nlp model
-    safetensor_config = load_config(preset, SAFETENSOR_CONFIG_FILE)
-    safetensor_files = {
-        fname: get_file(preset, fname)
-        for fname in set(safetensor_config["weight_map"].values())
-    }
-    port_weight = partial(
-        set_keras_weight,
-        safetensor_files=safetensor_files,
-        safetensor_config=safetensor_config,
-    )
-
+def convert_weights(backbone, loader, transformers_config):
     # Embedding layer
-    port_weight(
-        keras_variable=backbone.get_layer("token_embedding").variables[0],
+    loader.port_weight(
+        keras_variable=backbone.get_layer("token_embedding").embeddings,
         hf_weight_key="model.embed_tokens.weight",
     )
+
+    def transpose_and_reshape(x, shape):
+        return np.reshape(np.transpose(x), shape)
 
     # Attention blocks
     for i in range(backbone.num_layers):
         decoder_layer = backbone.get_layer(f"decoder_block_{i}")
         # Norm layers
-        port_weight(
-            keras_variable=decoder_layer.pre_attention_norm.variables[0],
+        loader.port_weight(
+            keras_variable=decoder_layer.pre_attention_norm.scale,
             hf_weight_key=f"model.layers.{i}.input_layernorm.weight",
         )
 
         if decoder_layer.use_post_attention_norm:
-            port_weight(
-                keras_variable=decoder_layer.post_attention_norm.variables[0],
+            loader.port_weight(
+                keras_variable=decoder_layer.post_attention_norm.scale,
                 hf_weight_key=f"model.layers.{i}.post_attention_layernorm.weight",
             )
 
         if transformers_config["model_type"] == "gemma":
-            port_weight(
-                keras_variable=decoder_layer.pre_ffw_norm.variables[0],
+            loader.port_weight(
+                keras_variable=decoder_layer.pre_ffw_norm.scale,
                 hf_weight_key=f"model.layers.{i}.post_attention_layernorm.weight",
             )
         elif transformers_config["model_type"] == "gemma2":
-            port_weight(
-                keras_variable=decoder_layer.pre_ffw_norm.variables[0],
+            loader.port_weight(
+                keras_variable=decoder_layer.pre_ffw_norm.scale,
                 hf_weight_key=f"model.layers.{i}.pre_feedforward_layernorm.weight",
             )
 
         if decoder_layer.use_post_ffw_norm:
-            port_weight(
-                keras_variable=decoder_layer.post_ffw_norm.variables[0],
+            loader.port_weight(
+                keras_variable=decoder_layer.post_ffw_norm.scale,
                 hf_weight_key=f"model.layers.{i}.post_feedforward_layernorm.weight",
             )
 
         # Attention layers
-        port_weight(
-            keras_variable=decoder_layer.attention.query_dense.variables[0],
+        loader.port_weight(
+            keras_variable=decoder_layer.attention.query_dense.kernel,
             hf_weight_key=f"model.layers.{i}.self_attn.q_proj.weight",
-            # rearrange_patterns="(a c) b -> a b c",
-            # rearrange_dims={"a": backbone.num_query_heads},
-            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
-                np.reshape(
-                    hf_tensor,
-                    (keras_shape[0], keras_shape[2], keras_shape[1]),
-                ),
-                axes=(0, 2, 1),
-            ),
+            hook_fn=transpose_and_reshape,
         )
-        port_weight(
-            keras_variable=decoder_layer.attention.key_dense.variables[0],
+        loader.port_weight(
+            keras_variable=decoder_layer.attention.key_dense.kernel,
             hf_weight_key=f"model.layers.{i}.self_attn.k_proj.weight",
-            # rearrange_patterns="(a c) b -> a b c",
-            # rearrange_dims={"a": backbone.num_key_value_heads},
-            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
-                np.reshape(
-                    hf_tensor,
-                    (keras_shape[0], keras_shape[2], keras_shape[1]),
-                ),
-                axes=(0, 2, 1),
-            ),
+            hook_fn=transpose_and_reshape,
         )
-        port_weight(
-            keras_variable=decoder_layer.attention.value_dense.variables[0],
+        loader.port_weight(
+            keras_variable=decoder_layer.attention.value_dense.kernel,
             hf_weight_key=f"model.layers.{i}.self_attn.v_proj.weight",
-            # rearrange_patterns="(a c) b -> a b c",
-            # rearrange_dims={"a": backbone.num_key_value_heads},
-            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
-                np.reshape(
-                    hf_tensor,
-                    (keras_shape[0], keras_shape[2], keras_shape[1]),
-                ),
-                axes=(0, 2, 1),
-            ),
+            hook_fn=transpose_and_reshape,
         )
-        port_weight(
-            keras_variable=decoder_layer.attention.output_dense.variables[0],
+        loader.port_weight(
+            keras_variable=decoder_layer.attention.output_dense.kernel,
             hf_weight_key=f"model.layers.{i}.self_attn.o_proj.weight",
-            # rearrange_patterns="c (a b) -> a b c",
-            # rearrange_dims={"a": backbone.num_query_heads},
-            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
-                np.reshape(
-                    hf_tensor,
-                    (keras_shape[2], keras_shape[0], keras_shape[1]),
-                ),
-                axes=(1, 2, 0),
-            ),
+            hook_fn=transpose_and_reshape,
         )
 
         # MLP layers
-        port_weight(
-            keras_variable=decoder_layer.gating_ffw.variables[0],
+        loader.port_weight(
+            keras_variable=decoder_layer.gating_ffw.kernel,
             hf_weight_key=f"model.layers.{i}.mlp.gate_proj.weight",
-            # rearrange_patterns="b a -> a b",
             hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
         )
-        port_weight(
-            keras_variable=decoder_layer.gating_ffw_2.variables[0],
+        loader.port_weight(
+            keras_variable=decoder_layer.gating_ffw_2.kernel,
             hf_weight_key=f"model.layers.{i}.mlp.up_proj.weight",
-            # rearrange_patterns="b a -> a b",
             hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
         )
-        port_weight(
-            keras_variable=decoder_layer.ffw_linear.variables[0],
+        loader.port_weight(
+            keras_variable=decoder_layer.ffw_linear.kernel,
             hf_weight_key=f"model.layers.{i}.mlp.down_proj.weight",
-            # rearrange_patterns="b a -> a b",
             hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
         )
 
     # Final normalization layer
-    port_weight(
-        keras_variable=backbone.get_layer("final_normalization").variables[0],
+    loader.port_weight(
+        keras_variable=backbone.get_layer("final_normalization").scale,
         hf_weight_key="model.norm.weight",
     )
 
     return backbone
 
 
+def load_gemma_backbone(cls, preset, load_weights):
+    transformers_config = load_config(preset, HF_CONFIG_FILE)
+    keras_config = convert_backbone_config(transformers_config)
+    backbone = cls(**keras_config)
+    if load_weights:
+        jax_memory_cleanup(backbone)
+        with SafetensorLoader(preset) as loader:
+            convert_weights(backbone, loader, transformers_config)
+    return backbone
+
+
 def load_gemma_tokenizer(cls, preset):
-    """
-    Load the Gemma tokenizer.
-
-    Args:
-        cls (class): Tokenizer class.
-        preset (str): Preset configuration name.
-
-    Returns:
-        tokenizer: Initialized tokenizer.
-    """
     return cls(get_file(preset, "tokenizer.model"))

--- a/keras_nlp/src/utils/transformers/convert_gemma.py
+++ b/keras_nlp/src/utils/transformers/convert_gemma.py
@@ -65,9 +65,6 @@ def convert_weights(backbone, loader, transformers_config):
         hf_weight_key="model.embed_tokens.weight",
     )
 
-    def transpose_and_reshape(x, shape):
-        return np.reshape(np.transpose(x), shape)
-
     # Attention blocks
     for i in range(backbone.num_layers):
         decoder_layer = backbone.get_layer(f"decoder_block_{i}")
@@ -104,22 +101,46 @@ def convert_weights(backbone, loader, transformers_config):
         loader.port_weight(
             keras_variable=decoder_layer.attention.query_dense.kernel,
             hf_weight_key=f"model.layers.{i}.self_attn.q_proj.weight",
-            hook_fn=transpose_and_reshape,
+            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
+                np.reshape(
+                    hf_tensor,
+                    (keras_shape[0], keras_shape[2], keras_shape[1]),
+                ),
+                axes=(0, 2, 1),
+            ),
         )
         loader.port_weight(
             keras_variable=decoder_layer.attention.key_dense.kernel,
             hf_weight_key=f"model.layers.{i}.self_attn.k_proj.weight",
-            hook_fn=transpose_and_reshape,
+            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
+                np.reshape(
+                    hf_tensor,
+                    (keras_shape[0], keras_shape[2], keras_shape[1]),
+                ),
+                axes=(0, 2, 1),
+            ),
         )
         loader.port_weight(
             keras_variable=decoder_layer.attention.value_dense.kernel,
             hf_weight_key=f"model.layers.{i}.self_attn.v_proj.weight",
-            hook_fn=transpose_and_reshape,
+            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
+                np.reshape(
+                    hf_tensor,
+                    (keras_shape[0], keras_shape[2], keras_shape[1]),
+                ),
+                axes=(0, 2, 1),
+            ),
         )
         loader.port_weight(
             keras_variable=decoder_layer.attention.output_dense.kernel,
             hf_weight_key=f"model.layers.{i}.self_attn.o_proj.weight",
-            hook_fn=transpose_and_reshape,
+            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
+                np.reshape(
+                    hf_tensor,
+                    (keras_shape[2], keras_shape[0], keras_shape[1]),
+                ),
+                axes=(1, 2, 0),
+            ),
         )
 
         # MLP layers

--- a/keras_nlp/src/utils/transformers/convert_llama3.py
+++ b/keras_nlp/src/utils/transformers/convert_llama3.py
@@ -11,188 +11,118 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from functools import partial
-
 import numpy as np
 
 from keras_nlp.src.utils.preset_utils import HF_CONFIG_FILE
-from keras_nlp.src.utils.preset_utils import SAFETENSOR_CONFIG_FILE
-from keras_nlp.src.utils.preset_utils import get_file
 from keras_nlp.src.utils.preset_utils import jax_memory_cleanup
 from keras_nlp.src.utils.preset_utils import load_config
-from keras_nlp.src.utils.transformers.safetensor_utils import set_keras_weight
+from keras_nlp.src.utils.transformers.safetensor_utils import SafetensorLoader
 
 
-def load_llama3_backbone(cls, preset, load_weights):
-    """
-    Load and initialize the Llama3 backbone model.
-
-    Args:
-        cls (class): Keras model class.
-        preset (str): Preset configuration name.
-        load_weights (bool): Whether to load the weights.
-
-    Returns:
-        backbone: Initialized Keras model backbone.
-    """
-    transformers_config = load_config(preset, HF_CONFIG_FILE)
-
-    backbone = cls(
-        vocabulary_size=transformers_config["vocab_size"],
-        num_layers=transformers_config["num_hidden_layers"],
-        num_query_heads=transformers_config["num_attention_heads"],
-        hidden_dim=transformers_config["hidden_size"],
-        intermediate_dim=transformers_config["intermediate_size"],
-        num_key_value_heads=transformers_config["num_key_value_heads"],
-    )
-
-    if not load_weights:
-        return backbone
-
-    jax_memory_cleanup(backbone)
-    # Code to port the weights from safetensors into the keras nlp model
-    safetensor_config = load_config(preset, SAFETENSOR_CONFIG_FILE)
-    safetensor_files = {
-        fname: get_file(preset, fname)
-        for fname in set(safetensor_config["weight_map"].values())
+def convert_backbone_config(transformers_config):
+    return {
+        "vocabulary_size": transformers_config["vocab_size"],
+        "num_layers": transformers_config["num_hidden_layers"],
+        "num_query_heads": transformers_config["num_attention_heads"],
+        "hidden_dim": transformers_config["hidden_size"],
+        "intermediate_dim": transformers_config["intermediate_size"],
+        "num_key_value_heads": transformers_config["num_key_value_heads"],
     }
-    port_weight = partial(
-        set_keras_weight,
-        safetensor_files=safetensor_files,
-        safetensor_config=safetensor_config,
-    )
 
-    # Embedding layers
-    port_weight(
-        keras_variable=backbone.get_layer("token_embedding").variables[0],
+
+def convert_weights(backbone, loader, transformers_config):
+    loader.port_weight(
+        keras_variable=backbone.get_layer("token_embedding").embeddings,
         hf_weight_key="model.embed_tokens.weight",
     )
-    port_weight(
-        keras_variable=backbone.get_layer("token_embedding").variables[1],
+    loader.port_weight(
+        keras_variable=backbone.get_layer("token_embedding").reverse_embeddings,
         hf_weight_key="lm_head.weight",
         # rearrange_pattern="b a -> a b",
         hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
     )
 
+    def transpose_and_reshape(x, shape):
+        return np.reshape(np.transpose(x), shape)
+
     # Attention blocks
     for i in range(backbone.num_layers):
         decoder_layer = backbone.get_layer(f"transformer_layer_{i}")
         # Norm layers
-        port_weight(
-            keras_variable=decoder_layer._self_attention_layernorm.variables[0],
+        loader.port_weight(
+            keras_variable=decoder_layer._self_attention_layernorm.scale,
             hf_weight_key=f"model.layers.{i}.input_layernorm.weight",
         )
-        port_weight(
-            keras_variable=decoder_layer._feedforward_layernorm.variables[0],
+        loader.port_weight(
+            keras_variable=decoder_layer._feedforward_layernorm.scale,
             hf_weight_key=f"model.layers.{i}.post_attention_layernorm.weight",
         )
 
         # Attention layers
-        port_weight(
-            keras_variable=decoder_layer._self_attention_layer._query_dense.variables[
-                0
-            ],
+        loader.port_weight(
+            keras_variable=decoder_layer._self_attention_layer._query_dense.kernel,
             hf_weight_key=f"model.layers.{i}.self_attn.q_proj.weight",
-            # rearrange_patterns="(b c) a -> a b c,
-            # rearrange_dims={"b": backbone.num_query_heads},
-            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
-                np.reshape(
-                    hf_tensor,
-                    (keras_shape[1], keras_shape[2], keras_shape[0]),
-                ),
-                axes=(2, 0, 1),
-            ),
+            hook_fn=transpose_and_reshape,
         )
-        port_weight(
-            keras_variable=decoder_layer._self_attention_layer._key_dense.variables[
-                0
-            ],
+        loader.port_weight(
+            keras_variable=decoder_layer._self_attention_layer._key_dense.kernel,
             hf_weight_key=f"model.layers.{i}.self_attn.k_proj.weight",
-            # rearrange_patterns="(b c) a -> a b c",
-            # rearrange_dims={"b": backbone.num_key_value_heads},
-            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
-                np.reshape(
-                    hf_tensor,
-                    (keras_shape[1], keras_shape[2], keras_shape[0]),
-                ),
-                axes=(2, 0, 1),
-            ),
+            hook_fn=transpose_and_reshape,
         )
-        port_weight(
-            keras_variable=decoder_layer._self_attention_layer._value_dense.variables[
-                0
-            ],
+        loader.port_weight(
+            keras_variable=decoder_layer._self_attention_layer._value_dense.kernel,
             hf_weight_key=f"model.layers.{i}.self_attn.v_proj.weight",
-            # rearrange_patterns="(b c) a -> a b c",
-            # rearrange_dims={"b": backbone.num_key_value_heads},
-            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
-                np.reshape(
-                    hf_tensor,
-                    (keras_shape[1], keras_shape[2], keras_shape[0]),
-                ),
-                axes=(2, 0, 1),
-            ),
+            hook_fn=transpose_and_reshape,
         )
-        port_weight(
-            keras_variable=decoder_layer._self_attention_layer._output_dense.variables[
-                0
-            ],
+        loader.port_weight(
+            keras_variable=decoder_layer._self_attention_layer._output_dense.kernel,
             hf_weight_key=f"model.layers.{i}.self_attn.o_proj.weight",
             # rearrange_patterns="c (a b) -> a b c",
             # rearrange_dims={"a": backbone.num_query_heads},
-            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
-                np.reshape(
-                    hf_tensor,
-                    (keras_shape[2], keras_shape[0], keras_shape[1]),
-                ),
-                axes=(1, 2, 0),
-            ),
+            hook_fn=transpose_and_reshape,
         )
 
         # MLP layers
-        port_weight(
-            keras_variable=decoder_layer._feedforward_gate_dense.variables[0],
+        loader.port_weight(
+            keras_variable=decoder_layer._feedforward_gate_dense.kernel,
             hf_weight_key=f"model.layers.{i}.mlp.gate_proj.weight",
             # rearrange_patterns="b a -> a b",
             hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
         )
-        port_weight(
-            keras_variable=decoder_layer._feedforward_intermediate_dense.variables[
-                0
-            ],
+        loader.port_weight(
+            keras_variable=decoder_layer._feedforward_intermediate_dense.kernel,
             hf_weight_key=f"model.layers.{i}.mlp.up_proj.weight",
             # rearrange_patterns="b a -> a b",
             hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
         )
-        port_weight(
-            keras_variable=decoder_layer._feedforward_output_dense.variables[0],
+        loader.port_weight(
+            keras_variable=decoder_layer._feedforward_output_dense.kernel,
             hf_weight_key=f"model.layers.{i}.mlp.down_proj.weight",
             # rearrange_patterns="b a -> a b",
             hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
         )
 
     # Final normalization layer
-    port_weight(
-        keras_variable=backbone.get_layer(
-            "sequence_output_layernorm"
-        ).variables[0],
+    loader.port_weight(
+        keras_variable=backbone.get_layer("sequence_output_layernorm").scale,
         hf_weight_key="model.norm.weight",
     )
 
     return backbone
 
 
+def load_llama3_backbone(cls, preset, load_weights):
+    transformers_config = load_config(preset, HF_CONFIG_FILE)
+    keras_config = convert_backbone_config(transformers_config)
+    backbone = cls(**keras_config)
+    if load_weights:
+        jax_memory_cleanup(backbone)
+        with SafetensorLoader(preset) as loader:
+            convert_weights(backbone, loader, transformers_config)
+    return backbone
+
+
 def load_llama3_tokenizer(cls, preset):
-    """
-    Load the Llama3 tokenizer.
-
-    Args:
-        cls (class): Tokenizer class.
-        preset (str): Preset configuration name.
-
-    Returns:
-        tokenizer: Initialized tokenizer.
-    """
     tokenizer_config = load_config(preset, "tokenizer.json")
     vocab = tokenizer_config["model"]["vocab"]
     merges = tokenizer_config["model"]["merges"]

--- a/keras_nlp/src/utils/transformers/convert_pali_gemma.py
+++ b/keras_nlp/src/utils/transformers/convert_pali_gemma.py
@@ -183,9 +183,6 @@ def convert_weights(backbone, loader, transformers_config):
         hf_weight_key="multi_modal_projector.linear.bias",
     )
 
-    def transpose_and_reshape(x, shape):
-        return np.reshape(np.transpose(x), shape)
-
     ############################################################################
     # Language Tower
     ############################################################################
@@ -206,22 +203,46 @@ def convert_weights(backbone, loader, transformers_config):
         loader.port_weight(
             keras_variable=decoder_layer.attention.query_dense.kernel,
             hf_weight_key=f"language_model.model.layers.{index}.self_attn.q_proj.weight",
-            hook_fn=transpose_and_reshape,
+            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
+                np.reshape(
+                    hf_tensor,
+                    (keras_shape[0], keras_shape[2], keras_shape[1]),
+                ),
+                axes=(0, 2, 1),
+            ),
         )
         loader.port_weight(
             keras_variable=decoder_layer.attention.key_dense.kernel,
             hf_weight_key=f"language_model.model.layers.{index}.self_attn.k_proj.weight",
-            hook_fn=transpose_and_reshape,
+            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
+                np.reshape(
+                    hf_tensor,
+                    (keras_shape[0], keras_shape[2], keras_shape[1]),
+                ),
+                axes=(0, 2, 1),
+            ),
         )
         loader.port_weight(
             keras_variable=decoder_layer.attention.value_dense.kernel,
             hf_weight_key=f"language_model.model.layers.{index}.self_attn.v_proj.weight",
-            hook_fn=transpose_and_reshape,
+            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
+                np.reshape(
+                    hf_tensor,
+                    (keras_shape[0], keras_shape[2], keras_shape[1]),
+                ),
+                axes=(0, 2, 1),
+            ),
         )
         loader.port_weight(
             keras_variable=decoder_layer.attention.output_dense.kernel,
             hf_weight_key=f"language_model.model.layers.{index}.self_attn.o_proj.weight",
-            hook_fn=transpose_and_reshape,
+            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
+                np.reshape(
+                    hf_tensor,
+                    (keras_shape[2], keras_shape[0], keras_shape[1]),
+                ),
+                axes=(1, 2, 0),
+            ),
         )
 
         # MLP layers

--- a/keras_nlp/src/utils/transformers/convert_pali_gemma.py
+++ b/keras_nlp/src/utils/transformers/convert_pali_gemma.py
@@ -11,102 +11,70 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from functools import partial
-
 import numpy as np
 
 from keras_nlp.src.utils.preset_utils import HF_CONFIG_FILE
-from keras_nlp.src.utils.preset_utils import SAFETENSOR_CONFIG_FILE
 from keras_nlp.src.utils.preset_utils import get_file
 from keras_nlp.src.utils.preset_utils import jax_memory_cleanup
 from keras_nlp.src.utils.preset_utils import load_config
-from keras_nlp.src.utils.transformers.safetensor_utils import set_keras_weight
+from keras_nlp.src.utils.transformers.safetensor_utils import SafetensorLoader
 
 
-def load_pali_gemma_backbone(cls, preset, load_weights):
-    """
-    Load and initialize the PaliGemma backbone model.
-
-    Args:
-        cls (class): Keras model class.
-        preset (str): Preset configuration name.
-        load_weights (bool): Whether to load the weights.
-
-    Returns:
-        backbone: Initialized Keras model backbone.
-    """
-    transformers_config = load_config(preset, HF_CONFIG_FILE)
+def convert_backbone_config(transformers_config):
     text_config = transformers_config["text_config"]
     vision_config = transformers_config["vision_config"]
-    backbone = cls(
-        vocabulary_size=transformers_config["image_token_index"],
-        image_size=(
+    return {
+        "vocabulary_size": transformers_config["image_token_index"],
+        "image_size": (
             vision_config["image_size"]
             if "image_size" in vision_config.keys()
             else 224
         ),
-        num_layers=text_config["num_hidden_layers"],
-        num_query_heads=text_config["num_attention_heads"],
-        num_key_value_heads=text_config["num_key_value_heads"],
-        hidden_dim=text_config["hidden_size"],
-        intermediate_dim=text_config["intermediate_size"] * 2,
-        head_dim=text_config["num_image_tokens"],
-        vit_patch_size=vision_config["patch_size"],
-        vit_num_heads=vision_config["num_attention_heads"],
-        vit_hidden_dim=vision_config["hidden_size"],
-        vit_num_layers=vision_config["num_hidden_layers"],
-        vit_intermediate_dim=vision_config["intermediate_size"],
-    )
-
-    if not load_weights:
-        return backbone
-
-    jax_memory_cleanup(backbone)
-    # Code to port the weights from safetensors into the keras nlp model
-    safetensor_config = load_config(preset, SAFETENSOR_CONFIG_FILE)
-    safetensor_files = {
-        fname: get_file(preset, fname)
-        for fname in set(safetensor_config["weight_map"].values())
+        "num_layers": text_config["num_hidden_layers"],
+        "num_query_heads": text_config["num_attention_heads"],
+        "num_key_value_heads": text_config["num_key_value_heads"],
+        "hidden_dim": text_config["hidden_size"],
+        "intermediate_dim": text_config["intermediate_size"] * 2,
+        "head_dim": text_config["num_image_tokens"],
+        "vit_patch_size": vision_config["patch_size"],
+        "vit_num_heads": vision_config["num_attention_heads"],
+        "vit_hidden_dim": vision_config["hidden_size"],
+        "vit_num_layers": vision_config["num_hidden_layers"],
+        "vit_intermediate_dim": vision_config["intermediate_size"],
     }
-    port_weight = partial(
-        set_keras_weight,
-        safetensor_files=safetensor_files,
-        safetensor_config=safetensor_config,
-    )
 
+
+def convert_weights(backbone, loader, transformers_config):
     ############################################################################
     # Image Tower
     ############################################################################
     image_encoder = backbone.vit_encoder.get_layer("image_encoder")
 
     # Embedding
-    port_weight(
+    loader.port_weight(
         keras_variable=image_encoder.vision_embeddings.patch_embedding.bias,
         hf_weight_key="vision_tower.vision_model.embeddings.patch_embedding.bias",
     )
 
-    port_weight(
+    loader.port_weight(
         keras_variable=image_encoder.vision_embeddings.patch_embedding.kernel,
         hf_weight_key="vision_tower.vision_model.embeddings.patch_embedding.weight",
-        hook_fn=lambda hf_tensor, keras_shape: np.transpose(
-            hf_tensor,
-            axes=(2, 3, 1, 0),
-        ),
+        hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(2, 3, 1, 0)),
     )
 
     # Positional Embedding
-    port_weight(
+    loader.port_weight(
         keras_variable=image_encoder.vision_embeddings.position_embedding.embeddings,
         hf_weight_key="vision_tower.vision_model.embeddings.position_embedding.weight",
     )
 
     # Normalization
-    port_weight(
+    loader.port_weight(
         keras_variable=image_encoder.encoder_layer_norm.gamma,
         hf_weight_key="vision_tower.vision_model.post_layernorm.weight",
     )
 
-    port_weight(
+    loader.port_weight(
         keras_variable=image_encoder.encoder_layer_norm.beta,
         hf_weight_key="vision_tower.vision_model.post_layernorm.bias",
     )
@@ -115,126 +83,108 @@ def load_pali_gemma_backbone(cls, preset, load_weights):
     for index in range(image_encoder.num_layers):
         block = image_encoder.resblocks[index]
 
-        port_weight(
+        loader.port_weight(
             keras_variable=block.layer_norm_1.beta,
             hf_weight_key=f"vision_tower.vision_model.encoder.layers.{index}.layer_norm1.bias",
         )
 
-        port_weight(
+        loader.port_weight(
             keras_variable=block.layer_norm_1.gamma,
             hf_weight_key=f"vision_tower.vision_model.encoder.layers.{index}.layer_norm1.weight",
         )
 
-        port_weight(
+        loader.port_weight(
             keras_variable=block.layer_norm_2.beta,
             hf_weight_key=f"vision_tower.vision_model.encoder.layers.{index}.layer_norm2.bias",
         )
 
-        port_weight(
+        loader.port_weight(
             keras_variable=block.layer_norm_2.gamma,
             hf_weight_key=f"vision_tower.vision_model.encoder.layers.{index}.layer_norm2.weight",
         )
 
-        port_weight(
+        loader.port_weight(
             keras_variable=block.mlp_dense_1.kernel,
             hf_weight_key=f"vision_tower.vision_model.encoder.layers.{index}.mlp.fc1.weight",
-            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
-                hf_tensor,
-                axes=(1, 0),
-            ),
+            hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
         )
 
-        port_weight(
+        loader.port_weight(
             keras_variable=block.mlp_dense_1.bias,
             hf_weight_key=f"vision_tower.vision_model.encoder.layers.{index}.mlp.fc1.bias",
         )
 
-        port_weight(
+        loader.port_weight(
             keras_variable=block.mlp_dense_2.kernel,
             hf_weight_key=f"vision_tower.vision_model.encoder.layers.{index}.mlp.fc2.weight",
-            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
-                hf_tensor,
-                axes=(1, 0),
-            ),
+            hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
         )
 
-        port_weight(
+        loader.port_weight(
             keras_variable=block.mlp_dense_2.bias,
             hf_weight_key=f"vision_tower.vision_model.encoder.layers.{index}.mlp.fc2.bias",
         )
 
-        port_weight(
+        loader.port_weight(
             keras_variable=block.attn.key_proj.bias,
             hf_weight_key=f"vision_tower.vision_model.encoder.layers.{index}.self_attn.k_proj.bias",
         )
 
-        port_weight(
+        loader.port_weight(
             keras_variable=block.attn.key_proj.kernel,
             hf_weight_key=f"vision_tower.vision_model.encoder.layers.{index}.self_attn.k_proj.weight",
-            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
-                hf_tensor,
-                axes=(1, 0),
-            ),
+            hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
         )
 
-        port_weight(
+        loader.port_weight(
             keras_variable=block.attn.out_proj.bias,
             hf_weight_key=f"vision_tower.vision_model.encoder.layers.{index}.self_attn.out_proj.bias",
         )
 
-        port_weight(
+        loader.port_weight(
             keras_variable=block.attn.out_proj.kernel,
             hf_weight_key=f"vision_tower.vision_model.encoder.layers.{index}.self_attn.out_proj.weight",
-            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
-                hf_tensor,
-                axes=(1, 0),
-            ),
+            hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
         )
 
-        port_weight(
+        loader.port_weight(
             keras_variable=block.attn.query_proj.bias,
             hf_weight_key=f"vision_tower.vision_model.encoder.layers.{index}.self_attn.q_proj.bias",
         )
 
-        port_weight(
+        loader.port_weight(
             keras_variable=block.attn.query_proj.kernel,
             hf_weight_key=f"vision_tower.vision_model.encoder.layers.{index}.self_attn.q_proj.weight",
-            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
-                hf_tensor,
-                axes=(1, 0),
-            ),
+            hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
         )
 
-        port_weight(
+        loader.port_weight(
             keras_variable=block.attn.value_proj.bias,
             hf_weight_key=f"vision_tower.vision_model.encoder.layers.{index}.self_attn.v_proj.bias",
         )
 
-        port_weight(
+        loader.port_weight(
             keras_variable=block.attn.value_proj.kernel,
             hf_weight_key=f"vision_tower.vision_model.encoder.layers.{index}.self_attn.v_proj.weight",
-            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
-                hf_tensor,
-                axes=(1, 0),
-            ),
+            hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
         )
 
     # Multi Modal Projection
-    port_weight(
+    loader.port_weight(
         keras_variable=backbone.vit_encoder.get_layer(
             "image_classifier"
         ).kernel,
         hf_weight_key="multi_modal_projector.linear.weight",
-        hook_fn=lambda hf_tensor, keras_shape: np.transpose(
-            hf_tensor,
-            axes=(1, 0),
-        ),
+        hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
     )
 
-    port_weight(
+    loader.port_weight(
         keras_variable=backbone.vit_encoder.get_layer("image_classifier").bias,
         hf_weight_key="multi_modal_projector.linear.bias",
     )
+
+    def transpose_and_reshape(x, shape):
+        return np.reshape(np.transpose(x), shape)
 
     ############################################################################
     # Language Tower
@@ -243,91 +193,78 @@ def load_pali_gemma_backbone(cls, preset, load_weights):
         decoder_layer = backbone.transformer_layers[index]
 
         # Norm layers
-        port_weight(
+        loader.port_weight(
             keras_variable=decoder_layer.pre_attention_norm.scale,
             hf_weight_key=f"language_model.model.layers.{index}.input_layernorm.weight",
         )
-        port_weight(
+        loader.port_weight(
             keras_variable=decoder_layer.pre_ffw_norm.scale,
             hf_weight_key=f"language_model.model.layers.{index}.post_attention_layernorm.weight",
         )
 
         # Attention layers
-        port_weight(
+        loader.port_weight(
             keras_variable=decoder_layer.attention.query_dense.kernel,
             hf_weight_key=f"language_model.model.layers.{index}.self_attn.q_proj.weight",
-            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
-                np.reshape(
-                    hf_tensor,
-                    (keras_shape[0], keras_shape[2], keras_shape[1]),
-                ),
-                axes=(0, 2, 1),
-            ),
+            hook_fn=transpose_and_reshape,
         )
-        port_weight(
+        loader.port_weight(
             keras_variable=decoder_layer.attention.key_dense.kernel,
             hf_weight_key=f"language_model.model.layers.{index}.self_attn.k_proj.weight",
-            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
-                np.reshape(
-                    hf_tensor,
-                    (keras_shape[0], keras_shape[2], keras_shape[1]),
-                ),
-                axes=(0, 2, 1),
-            ),
+            hook_fn=transpose_and_reshape,
         )
-        port_weight(
+        loader.port_weight(
             keras_variable=decoder_layer.attention.value_dense.kernel,
             hf_weight_key=f"language_model.model.layers.{index}.self_attn.v_proj.weight",
-            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
-                np.reshape(
-                    hf_tensor,
-                    (keras_shape[0], keras_shape[2], keras_shape[1]),
-                ),
-                axes=(0, 2, 1),
-            ),
+            hook_fn=transpose_and_reshape,
         )
-        port_weight(
+        loader.port_weight(
             keras_variable=decoder_layer.attention.output_dense.kernel,
             hf_weight_key=f"language_model.model.layers.{index}.self_attn.o_proj.weight",
-            hook_fn=lambda hf_tensor, keras_shape: np.transpose(
-                np.reshape(
-                    hf_tensor,
-                    (keras_shape[2], keras_shape[0], keras_shape[1]),
-                ),
-                axes=(1, 2, 0),
-            ),
+            hook_fn=transpose_and_reshape,
         )
 
         # MLP layers
-        port_weight(
-            keras_variable=decoder_layer.gating_ffw.variables[0],
+        loader.port_weight(
+            keras_variable=decoder_layer.gating_ffw.kernel,
             hf_weight_key=f"language_model.model.layers.{index}.mlp.gate_proj.weight",
             hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
         )
-        port_weight(
-            keras_variable=decoder_layer.gating_ffw_2.variables[0],
+        loader.port_weight(
+            keras_variable=decoder_layer.gating_ffw_2.kernel,
             hf_weight_key=f"language_model.model.layers.{index}.mlp.up_proj.weight",
             hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
         )
-        port_weight(
-            keras_variable=decoder_layer.ffw_linear.variables[0],
+        loader.port_weight(
+            keras_variable=decoder_layer.ffw_linear.kernel,
             hf_weight_key=f"language_model.model.layers.{index}.mlp.down_proj.weight",
             hook_fn=lambda hf_tensor, _: np.transpose(hf_tensor, axes=(1, 0)),
         )
 
     # Normalization
-    port_weight(
+    loader.port_weight(
         keras_variable=backbone.layer_norm.scale,
         hf_weight_key="language_model.model.norm.weight",
     )
 
     # Embedding
-    port_weight(
+    loader.port_weight(
         keras_variable=backbone.token_embedding.embeddings,
         hf_weight_key="language_model.model.embed_tokens.weight",
         hook_fn=lambda hf_tensor, keras_shape: hf_tensor[: keras_shape[0]],
     )
 
+    return backbone
+
+
+def load_pali_gemma_backbone(cls, preset, load_weights):
+    transformers_config = load_config(preset, HF_CONFIG_FILE)
+    keras_config = convert_backbone_config(transformers_config)
+    backbone = cls(**keras_config)
+    if load_weights:
+        jax_memory_cleanup(backbone)
+        with SafetensorLoader(preset) as loader:
+            convert_weights(backbone, loader, transformers_config)
     return backbone
 
 

--- a/keras_nlp/src/utils/transformers/safetensor_utils.py
+++ b/keras_nlp/src/utils/transformers/safetensor_utils.py
@@ -11,34 +11,61 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import contextlib
+
+from keras_nlp.src.utils.preset_utils import SAFETENSOR_CONFIG_FILE
+from keras_nlp.src.utils.preset_utils import SAFETENSOR_FILE
+from keras_nlp.src.utils.preset_utils import check_file_exists
+from keras_nlp.src.utils.preset_utils import get_file
+from keras_nlp.src.utils.preset_utils import load_config
+
 try:
     import safetensors
 except ImportError:
     safetensors = None
 
 
-def set_keras_weight(
-    safetensor_files,
-    safetensor_config,
-    keras_variable,
-    hf_weight_key,
-    hook_fn=None,
-):
-    if safetensors is None:
-        raise ImportError(
-            "Converting from the huggingface/transformers model format"
-            "requires the safetensors package."
-            "Please install with `pip install safetensors`."
-        )
-    else:
-        from safetensors import safe_open
+class SafetensorLoader(contextlib.ExitStack):
+    def __init__(self, preset):
+        super().__init__()
 
-    safetensor_file = safetensor_files[
-        safetensor_config["weight_map"][hf_weight_key]
-    ]
-    with safe_open(safetensor_file, framework="np") as f:
-        hf_tensor = f.get_tensor(hf_weight_key)
+        if safetensors is None:
+            raise ImportError(
+                "Converting from the huggingface/transformers model format"
+                "requires the safetensors package."
+                "Please install with `pip install safetensors`."
+            )
 
+        self.preset = preset
+        if check_file_exists(preset, SAFETENSOR_CONFIG_FILE):
+            self.safetensor_config = load_config(preset, SAFETENSOR_CONFIG_FILE)
+        else:
+            self.safetensor_config = None
+        self.safetensor_files = {}
+
+    def get_tensor(self, hf_weight_key):
+        if self.safetensor_config is None:
+            fname = SAFETENSOR_FILE
+        else:
+            fname = self.safetensor_config["weight_map"][hf_weight_key]
+
+        if fname in self.safetensor_files:
+            file = self.safetensor_files[fname]
+        else:
+            path = get_file(self.preset, fname)
+            file = self.enter_context(
+                safetensors.safe_open(path, framework="np")
+            )
+            self.safetensor_files[fname] = file
+
+        return file.get_tensor(hf_weight_key)
+
+    def port_weight(self, keras_variable, hf_weight_key, hook_fn=None):
+        hf_tensor = self.get_tensor(hf_weight_key)
         if hook_fn:
             hf_tensor = hook_fn(hf_tensor, list(keras_variable.shape))
         keras_variable.assign(hf_tensor)
+
+
+def set_keras_weight():
+    pass

--- a/keras_nlp/src/utils/transformers/safetensor_utils.py
+++ b/keras_nlp/src/utils/transformers/safetensor_utils.py
@@ -65,7 +65,3 @@ class SafetensorLoader(contextlib.ExitStack):
         if hook_fn:
             hf_tensor = hook_fn(hf_tensor, list(keras_variable.shape))
         keras_variable.assign(hf_tensor)
-
-
-def set_keras_weight():
-    pass


### PR DESCRIPTION
- Handle the case where we only have a single safetensors file and no `model.safetensors.index.json`.
- Only open each safetensors file once during conversion. This required a bit of refactoring to handle all the python contexts correctly, but speeds up our tests by over a factor of two. For smaller models this should be a major speedup.