### PR TITLE
One more small Gemma conversion fix

### DIFF
--- a/keras_nlp/src/utils/transformers/convert_gemma.py
+++ b/keras_nlp/src/utils/transformers/convert_gemma.py
@@ -55,7 +55,7 @@ def convert_backbone_config(transformers_config):
             "attention_logit_soft_cap": transformers_config[
                 "attn_logit_softcapping"
             ],
-            "sliding_window_size": transformers_config["sliding_window_size"],
+            "sliding_window_size": transformers_config["sliding_window"],
             "use_sliding_window_attention": True,
         }
     return backbone_config


### PR DESCRIPTION
sliding_window_size appears to be deprecated in favour of sliding_window

https://github.com/huggingface/transformers/blob/0fdea8607d7e01eb0e38a1ebeb7feee30a22f0cf/src/transformers/models/gemma2/configuration_gemma2.py#L151