### PR TITLE
Gemma: Add logit soft-capping to score function.

### DIFF
--- a/keras_nlp/src/models/gemma/gemma_causal_lm.py
+++ b/keras_nlp/src/models/gemma/gemma_causal_lm.py
@@ -445,6 +445,12 @@ class GemmaCausalLM(CausalLM):
         x = self.backbone.layer_norm(x)
         logits = self.backbone.token_embedding(x, reverse=True)
 
+        if self.backbone.final_logit_soft_cap is not None:
+            logits = ops.divide(logits, self.backbone.final_logit_soft_cap)
+            logits = ops.multiply(
+                ops.tanh(logits), self.backbone.final_logit_soft_cap
+            )
+
         if scoring_mode == "logits":
             return logits
 


### PR DESCRIPTION
Gemma 2 added logit soft-capping to `.call_with_cache()` in #1673 but this was not paralleled in the `.score()` function, so the logits/loss and derived attributes (e.g., gradients) will differ from those returned by `.generate()`. This PR brings these back into parity.