### PR TITLE
Dynamic int8 quantization for Llama2 and Llama3

### DIFF
--- a/tools/quantize_checkpoints.py
+++ b/tools/quantize_checkpoints.py
@@ -1,0 +1,84 @@
+# Copyright 2023 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Quantize preset checkpoints with dynamic int8 and optionally upload the quantized preset.
+
+Usage:
+export KERAS_BACKEND=jax CUDA_VISIBLE_DEVICES=
+python tools/quantize_checkpoints.py --preset llama3_8b_en
+python tools/quantize_checkpoints.py --preset llama3_8b_en --upload_uri kaggle://keras/llama3/keras/llama3_8b_en_int8
+"""
+
+import keras
+from absl import app
+from absl import flags
+
+import keras_nlp
+
+FLAGS = flags.FLAGS
+
+
+flags.DEFINE_string(
+    "preset",
+    None,
+    "Must be a valid `CausalLM` preset from KerasNLP",
+    required=True,
+)
+flags.DEFINE_string(
+    "upload_uri",
+    None,
+    'Could be "kaggle://keras/{variant}/keras/{preset}_int8"',
+    required=False,
+)
+
+
+def validate_output(causal_lm):
+    input_str = "What is Keras?"
+    length = 32
+
+    keras_output = causal_lm.generate([input_str], max_length=length)
+    keras_output = keras_output[0]
+    print("🔶 KerasNLP output:", keras_output)
+
+
+def main(_):
+    preset = FLAGS.preset
+    upload_uri = FLAGS.upload_uri
+    print(f"🏃 Quantizing {preset}")
+
+    keras.config.set_floatx("bfloat16")
+
+    causal_lm = keras_nlp.models.CausalLM.from_preset(preset, dtype="bfloat16")
+    backbone = causal_lm.backbone
+    tokenizer = causal_lm.preprocessor.tokenizer
+
+    backbone.quantize("int8")
+    print("✅ Weights quantized")
+
+    causal_lm.backbone = backbone
+    validate_output(causal_lm)
+    print("✅ Output validated")
+
+    quantized_preset = f"{preset}_int8"
+    backbone.save_to_preset(quantized_preset)
+    tokenizer.save_to_preset(quantized_preset)
+    print(f"🏁 Preset saved to ./{quantized_preset}")
+
+    if upload_uri:
+        keras_nlp.upload_preset(uri=upload_uri, preset=quantized_preset)
+        print(f"🏁 Preset uploaded to {upload_uri}")
+
+
+if __name__ == "__main__":
+    app.run(main)


### PR DESCRIPTION
I think it would be better to add the quantization scripts for KerasNLP

|Model|Validation Outputs|File Size|
|-|-|-|
|`llama2_7b_en_int8`|What is Keras?\n Hinweis: Diese Seite wurde zuletzt am 27. April 2017 aktualisiert.|6.3G|
|`llama2_instruct_7b_en_int8`|What is Keras?\n Unterscheidung between Keras und TensorFlow\n Keras is a high-level neural networks API written in Python, capable of|6.3G|
|`llama3_8b_en_int8`|What is Keras? Keras is a high-level neural networks API, written in Python and capable of running on top of either TensorFlow , an industry-st|7.5G|
|`llama3_instruct_8b_en_int8`|What is Keras? - A High-Level Neural Networks API\n\nKeras is a high-level neural networks API that is written in Python and capable of running|7.5G|

`llama2_7b_en_int8` produced some unusual outputs, but based on my past experience, it should generate meaningful results using CUDA and XLA.

Please let me know if these models are ready to be pushed to Kaggle.

cc @mattdangerw 

EDITED:
Note that I have only verified these results using the master branch of Keras and KerasNLP.