### PR TITLE
Add int8 models to Llama2 and Llama3

### DIFF
--- a/keras_nlp/src/models/llama/llama_presets.py
+++ b/keras_nlp/src/models/llama/llama_presets.py
@@ -25,6 +25,16 @@ backbone_presets = {
         },
         "kaggle_handle": "kaggle://keras/llama2/keras/llama2_7b_en/1",
     },
+    "llama2_7b_en_int8": {
+        "metadata": {
+            "description": "LLaMA 2 7B Quantized Base model",
+            "params": 6739839488,
+            "official_name": "LLaMA 2",
+            "path": "llama2",
+            "model_card": "https://github.com/meta-llama/llama",
+        },
+        "kaggle_handle": "kaggle://keras/llama2/keras/llama2_7b_en_int8/1",
+    },
     "llama2_instruct_7b_en": {
         "metadata": {
             "description": "LLaMA 2 7B Chat model",
@@ -34,6 +44,16 @@ backbone_presets = {
             "model_card": "https://github.com/meta-llama/llama",
         },
         "kaggle_handle": "kaggle://keras/llama2/keras/llama2_instruct_7b_en/1",
+    },
+    "llama2_instruct_7b_en_int8": {
+        "metadata": {
+            "description": "LLaMA 2 7B Quantized Chat model",
+            "params": 6739839488,
+            "official_name": "LLaMA 2",
+            "path": "llama2",
+            "model_card": "https://github.com/meta-llama/llama",
+        },
+        "kaggle_handle": "kaggle://keras/llama2/keras/llama2_instruct_7b_en_int8/1",
     },
     "vicuna_1.5_7b_en": {
         "metadata": {

--- a/keras_nlp/src/models/llama/llama_presets.py
+++ b/keras_nlp/src/models/llama/llama_presets.py
@@ -17,7 +17,7 @@
 backbone_presets = {
     "llama2_7b_en": {
         "metadata": {
-            "description": "LLaMA 2 7B Base model",
+            "description": "7 billion parameter, 32-layer, base LLaMA 2 model.",
             "params": 6738415616,
             "official_name": "LLaMA 2",
             "path": "llama2",
@@ -27,7 +27,10 @@ backbone_presets = {
     },
     "llama2_7b_en_int8": {
         "metadata": {
-            "description": "LLaMA 2 7B Quantized Base model",
+            "description": (
+                "7 billion parameter, 32-layer, base LLaMA 2 model with "
+                "activation and weights quantized to int8."
+            ),
             "params": 6739839488,
             "official_name": "LLaMA 2",
             "path": "llama2",
@@ -37,7 +40,10 @@ backbone_presets = {
     },
     "llama2_instruct_7b_en": {
         "metadata": {
-            "description": "LLaMA 2 7B Chat model",
+            "description": (
+                "7 billion parameter, 32-layer, instruction tuned LLaMA 2 "
+                "model."
+            ),
             "params": 6738415616,
             "official_name": "LLaMA 2",
             "path": "llama2",
@@ -47,7 +53,10 @@ backbone_presets = {
     },
     "llama2_instruct_7b_en_int8": {
         "metadata": {
-            "description": "LLaMA 2 7B Quantized Chat model",
+            "description": (
+                "7 billion parameter, 32-layer, instruction tuned LLaMA 2 "
+                "model with activation and weights quantized to int8."
+            ),
             "params": 6739839488,
             "official_name": "LLaMA 2",
             "path": "llama2",
@@ -57,7 +66,10 @@ backbone_presets = {
     },
     "vicuna_1.5_7b_en": {
         "metadata": {
-            "description": "Vicuna v1.5 7B Chat model",
+            "description": (
+                "7 billion parameter, 32-layer, instruction tuned Vicuna v1.5 "
+                "model."
+            ),
             "params": 6738415616,
             "official_name": "Vicuna",
             "path": "vicuna",

--- a/keras_nlp/src/models/llama3/llama3_presets.py
+++ b/keras_nlp/src/models/llama3/llama3_presets.py
@@ -25,6 +25,16 @@ backbone_presets = {
         },
         "kaggle_handle": "kaggle://keras/llama3/keras/llama3_8b_en/3",
     },
+    "llama3_8b_en_int8": {
+        "metadata": {
+            "description": "LLaMA 3 8B Quantized Base model",
+            "params": 8031894016,
+            "official_name": "LLaMA 3",
+            "path": "llama3",
+            "model_card": "https://github.com/meta-llama/llama3",
+        },
+        "kaggle_handle": "kaggle://keras/llama3/keras/llama3_8b_en_int8/1",
+    },
     "llama3_instruct_8b_en": {
         "metadata": {
             "description": "LLaMA 3 8B Instruct model",
@@ -34,5 +44,15 @@ backbone_presets = {
             "model_card": "https://github.com/meta-llama/llama3",
         },
         "kaggle_handle": "kaggle://keras/llama3/keras/llama3_instruct_8b_en/3",
+    },
+    "llama3_instruct_8b_en_int8": {
+        "metadata": {
+            "description": "LLaMA 3 8B Quantized Instruct model",
+            "params": 8031894016,
+            "official_name": "LLaMA 3",
+            "path": "llama3",
+            "model_card": "https://github.com/meta-llama/llama3",
+        },
+        "kaggle_handle": "kaggle://keras/llama3/keras/llama3_instruct_8b_en_int8/1",
     },
 }

--- a/keras_nlp/src/models/llama3/llama3_presets.py
+++ b/keras_nlp/src/models/llama3/llama3_presets.py
@@ -17,7 +17,7 @@
 backbone_presets = {
     "llama3_8b_en": {
         "metadata": {
-            "description": "LLaMA 3 8B Base model",
+            "description": "8 billion parameter, 32-layer, base LLaMA 3 model.",
             "params": 8030261248,
             "official_name": "LLaMA 3",
             "path": "llama3",
@@ -27,7 +27,10 @@ backbone_presets = {
     },
     "llama3_8b_en_int8": {
         "metadata": {
-            "description": "LLaMA 3 8B Quantized Base model",
+            "description": (
+                "8 billion parameter, 32-layer, base LLaMA 3 model with "
+                "activation and weights quantized to int8."
+            ),
             "params": 8031894016,
             "official_name": "LLaMA 3",
             "path": "llama3",
@@ -37,7 +40,10 @@ backbone_presets = {
     },
     "llama3_instruct_8b_en": {
         "metadata": {
-            "description": "LLaMA 3 8B Instruct model",
+            "description": (
+                "8 billion parameter, 32-layer, instruction tuned LLaMA 3 "
+                "model."
+            ),
             "params": 8030261248,
             "official_name": "LLaMA 3",
             "path": "llama3",
@@ -47,12 +53,17 @@ backbone_presets = {
     },
     "llama3_instruct_8b_en_int8": {
         "metadata": {
-            "description": "LLaMA 3 8B Quantized Instruct model",
+            "description": (
+                "8 billion parameter, 32-layer, instruction tuned LLaMA 3 "
+                "model with activation and weights quantized to int8."
+            ),
             "params": 8031894016,
             "official_name": "LLaMA 3",
             "path": "llama3",
             "model_card": "https://github.com/meta-llama/llama3",
         },
-        "kaggle_handle": "kaggle://keras/llama3/keras/llama3_instruct_8b_en_int8/1",
+        "kaggle_handle": (
+            "kaggle://keras/llama3/keras/llama3_instruct_8b_en_int8/1"
+        ),
     },
 }


### PR DESCRIPTION
The `params` is the number reported by `Model.summary()` which should be consistent with other models.
All models can run inference using colab T4.
You can check out the outputs of `llama3_instruct_8b_en_int8` from this colab:
https://colab.research.google.com/drive/1KbUzNsY0906HFcn7FzRiBDtOtO-08msj?usp=sharing
