### PR TITLE
Sliding window fixes

### DIFF
--- a/keras_nlp/src/models/gemma/gemma_backbone_test.py
+++ b/keras_nlp/src/models/gemma/gemma_backbone_test.py
@@ -203,6 +203,27 @@ class Gemma2BackboneTest(TestCase):
             expected_output_shape=(2, 10, 16),
         )
 
+    def test_sliding_window(self):
+        # Test sliding window correctness by hand.
+        backbone = GemmaBackbone(**self.init_kwargs)
+        attention = backbone.transformer_layers[0].attention
+        mask = attention._mask_sliding_window(ops.ones((1, 10, 10), "bool"))
+        expected = [
+            [
+                [1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
+                [1, 1, 1, 1, 1, 1, 0, 0, 0, 0],
+                [1, 1, 1, 1, 1, 1, 1, 0, 0, 0],
+                [1, 1, 1, 1, 1, 1, 1, 1, 0, 0],
+                [1, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+                [0, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+                [0, 0, 1, 1, 1, 1, 1, 1, 1, 1],
+                [0, 0, 0, 1, 1, 1, 1, 1, 1, 1],
+                [0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
+                [0, 0, 0, 0, 0, 1, 1, 1, 1, 1],
+            ]
+        ]
+        self.assertAllEqual(mask, expected)
+
     @pytest.mark.large
     def test_saved_model(self):
         self.run_model_saving_test(


### PR DESCRIPTION
We have an issue, particularly on the tensorflow backend, when computing the sliding window mask during generation.

- For tf, this would affect any sequence length.
- For jax and torch, this would only affect generations longer 4096.

Before: https://colab.research.google.com/gist/mattdangerw/3d7ab7fd0f2a1169e67d3f4d43d40701/keras-tf-bug.ipynb
After: https://colab.research.google.com/gist/mattdangerw/b48e47107a2513c61d8e70a4652df468/keras-tf-bug-with-fix.ipynb
