### PR TITLE
Add `ResNetBackbone` and `ResNetImageClassifier`

### DIFF
--- a/keras_nlp/api/models/__init__.py
+++ b/keras_nlp/api/models/__init__.py
@@ -181,6 +181,10 @@ from keras_nlp.src.models.phi3.phi3_causal_lm_preprocessor import (
 from keras_nlp.src.models.phi3.phi3_preprocessor import Phi3Preprocessor
 from keras_nlp.src.models.phi3.phi3_tokenizer import Phi3Tokenizer
 from keras_nlp.src.models.preprocessor import Preprocessor
+from keras_nlp.src.models.resnet.resnet_backbone import ResNetBackbone
+from keras_nlp.src.models.resnet.resnet_image_classifier import (
+    ResNetImageClassifier,
+)
 from keras_nlp.src.models.roberta.roberta_backbone import RobertaBackbone
 from keras_nlp.src.models.roberta.roberta_classifier import RobertaClassifier
 from keras_nlp.src.models.roberta.roberta_masked_lm import RobertaMaskedLM

--- a/keras_nlp/src/models/resnet/__init__.py
+++ b/keras_nlp/src/models/resnet/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2024 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/keras_nlp/src/models/resnet/resnet_backbone_test.py
+++ b/keras_nlp/src/models/resnet/resnet_backbone_test.py
@@ -1,0 +1,99 @@
+# Copyright 2024 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from absl.testing import parameterized
+from keras import backend
+from keras import ops
+
+from keras_nlp.src.models.resnet.resnet_backbone import ResNetBackbone
+from keras_nlp.src.tests.test_case import TestCase
+
+
+class ResNetBackboneTest(TestCase):
+    def setUp(self):
+        self.init_kwargs = {
+            "stackwise_num_filters": [64, 64, 64],
+            "stackwise_num_blocks": [2, 2, 2],
+            "stackwise_num_strides": [1, 2, 2],
+            "include_rescaling": False,
+            "pooling": "avg",
+        }
+        self.input_size = (16, 16)
+        self.input_data = ops.ones((2, 16, 16, 3))
+
+    @parameterized.named_parameters(
+        ("v1_basic_channels_last", False, "basic_block", "channels_last"),
+        ("v1_basic_channels_first", False, "basic_block", "channels_first"),
+        ("v1_block_channels_last", False, "block", "channels_last"),
+        ("v2_basic_channels_last", True, "basic_block", "channels_last"),
+        ("v2_basic_channels_first", True, "basic_block", "channels_first"),
+        ("v2_block_channels_last", True, "block", "channels_last"),
+    )
+    def test_backbone_basics(self, preact, block_type, data_format):
+        if (
+            backend.backend() == "tensorflow"
+            and data_format == "channels_first"
+        ):
+            self.skipTest("TensorFlow CPU does not support channels_first")
+
+        if data_format == "channels_last":
+            input_data = self.input_data
+            input_image_shape = self.input_size + (3,)
+        else:
+            input_data = ops.transpose(self.input_data, [0, 3, 1, 2])
+            input_image_shape = (3,) + self.input_size
+
+        init_kwargs = self.init_kwargs.copy()
+        init_kwargs.update(
+            {
+                "block_type": block_type,
+                "preact": preact,
+                "input_image_shape": input_image_shape,
+                "data_format": data_format,
+            }
+        )
+        self.run_backbone_test(
+            cls=ResNetBackbone,
+            init_kwargs=init_kwargs,
+            input_data=input_data,
+            expected_output_shape=(
+                (2, 64) if block_type == "basic_block" else (2, 256)
+            ),
+            run_quantization_check=(
+                True if data_format == "channels_last" else False
+            ),
+        )
+
+    @parameterized.named_parameters(
+        ("v1_basic", False, "basic_block"),
+        ("v1_block", False, "block"),
+        ("v2_basic", True, "basic_block"),
+        ("v2_block", True, "block"),
+    )
+    @pytest.mark.large
+    def test_saved_model(self, preact, block_type):
+        init_kwargs = self.init_kwargs.copy()
+        init_kwargs.update(
+            {
+                "block_type": block_type,
+                "preact": preact,
+                "input_image_shape": (16, 16, 3),
+            }
+        )
+        self.run_model_saving_test(
+            cls=ResNetBackbone,
+            init_kwargs=init_kwargs,
+            input_data=self.input_data,
+        )

--- a/keras_nlp/src/models/resnet/resnet_image_classifier.py
+++ b/keras_nlp/src/models/resnet/resnet_image_classifier.py
@@ -1,0 +1,138 @@
+# Copyright 2024 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import keras
+
+from keras_nlp.src.api_export import keras_nlp_export
+from keras_nlp.src.models.image_classifier import ImageClassifier
+from keras_nlp.src.models.resnet.resnet_backbone import ResNetBackbone
+
+
+@keras_nlp_export("keras_nlp.models.ResNetImageClassifier")
+class ResNetImageClassifier(ImageClassifier):
+    """ResNet image classifier task model.
+
+    Args:
+        backbone: A `keras_nlp.models.ResNetBackbone` instance.
+        num_classes: int. The number of classes to predict.
+        activation: `None`, str or callable. The activation function to use on
+            the `Dense` layer. Set `activation=None` to return the output
+            logits. Defaults to `"softmax"`.
+
+    To fine-tune with `fit()`, pass a dataset containing tuples of `(x, y)`
+    where `x` is a tensor and `y` is a integer from `[0, num_classes)`.
+    All `ImageClassifier` tasks include a `from_preset()` constructor which can
+    be used to load a pre-trained config and weights.
+
+    Examples:
+
+    Call `predict()` to run inference.
+    ```python
+    # Load preset and train
+    images = np.ones((2, 224, 224, 3), dtype="float32")
+    classifier = keras_nlp.models.ResNetImageClassifier.from_preset(
+        'resnet50_imagenet'
+    )
+    classifier.predict(images)
+    ```
+
+    Call `fit()` on a single batch.
+    ```python
+    # Load preset and train
+    images = np.ones((2, 224, 224, 3), dtype="float32")
+    labels = [0, 3]
+    classifier = keras_nlp.models.ResNetImageClassifier.from_preset(
+        'resnet50_imagenet'
+    )
+    classifier.fit(x=images, y=labels, batch_size=2)
+    ```
+
+    Call `fit()` with custom loss, optimizer and backbone.
+    ```python
+    classifier = keras_nlp.models.ResNetImageClassifier.from_preset(
+        'resnet50_imagenet'
+    )
+    classifier.compile(
+        loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+        optimizer=keras.optimizers.Adam(5e-5),
+    )
+    classifier.backbone.trainable = False
+    classifier.fit(x=images, y=labels, batch_size=2)
+    ```
+
+    Custom backbone.
+    ```python
+    images = np.ones((2, 224, 224, 3), dtype="float32")
+    labels = [0, 3]
+    backbone = keras_nlp.models.ResNetBackbone(
+        stackwise_num_filters=[64, 64, 64],
+        stackwise_num_blocks=[2, 2, 2],
+        stackwise_num_strides=[1, 2, 2],
+        block_type="basic_block",
+        preact=True,
+        include_rescaling=False,
+        input_image_shape=(224, 224, 3),
+        pooling="avg",
+    )
+    classifier = keras_nlp.models.ResNetImageClassifier(
+        backbone=backbone,
+        num_classes=4,
+    )
+    classifier.fit(x=images, y=labels, batch_size=2)
+    ```
+    """
+
+    backbone_cls = ResNetBackbone
+
+    def __init__(
+        self,
+        backbone,
+        num_classes,
+        activation="softmax",
+        preprocessor=None,  # adding this dummy arg for saved model test
+        # TODO: once preprocessor flow is figured out, this needs to be updated
+        **kwargs,
+    ):
+        # === Layers ===
+        self.backbone = backbone
+        self.output_dense = keras.layers.Dense(
+            num_classes,
+            activation=activation,
+            dtype=self.backbone.dtype_policy,
+            name="predictions",
+        )
+
+        # === Functional Model ===
+        inputs = self.backbone.input
+        x = self.backbone(inputs)
+        outputs = self.output_dense(x)
+        super().__init__(
+            inputs=inputs,
+            outputs=outputs,
+            **kwargs,
+        )
+
+        # === Config ===
+        self.num_classes = num_classes
+        self.activation = activation
+
+    def get_config(self):
+        # Backbone serialized in `super`
+        config = super().get_config()
+        config.update(
+            {
+                "num_classes": self.num_classes,
+                "activation": self.activation,
+            }
+        )
+        return config

--- a/keras_nlp/src/models/resnet/resnet_image_classifier.py
+++ b/keras_nlp/src/models/resnet/resnet_image_classifier.py
@@ -40,9 +40,7 @@ class ResNetImageClassifier(ImageClassifier):
     ```python
     # Load preset and train
     images = np.ones((2, 224, 224, 3), dtype="float32")
-    classifier = keras_nlp.models.ResNetImageClassifier.from_preset(
-        'resnet50_imagenet'
-    )
+    classifier = keras_nlp.models.ResNetImageClassifier.from_preset("resnet50")
     classifier.predict(images)
     ```
 
@@ -51,17 +49,13 @@ class ResNetImageClassifier(ImageClassifier):
     # Load preset and train
     images = np.ones((2, 224, 224, 3), dtype="float32")
     labels = [0, 3]
-    classifier = keras_nlp.models.ResNetImageClassifier.from_preset(
-        'resnet50_imagenet'
-    )
+    classifier = keras_nlp.models.ResNetImageClassifier.from_preset("resnet50")
     classifier.fit(x=images, y=labels, batch_size=2)
     ```
 
     Call `fit()` with custom loss, optimizer and backbone.
     ```python
-    classifier = keras_nlp.models.ResNetImageClassifier.from_preset(
-        'resnet50_imagenet'
-    )
+    classifier = keras_nlp.models.ResNetImageClassifier.from_preset("resnet50")
     classifier.compile(
         loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
         optimizer=keras.optimizers.Adam(5e-5),
@@ -79,9 +73,8 @@ class ResNetImageClassifier(ImageClassifier):
         stackwise_num_blocks=[2, 2, 2],
         stackwise_num_strides=[1, 2, 2],
         block_type="basic_block",
-        preact=True,
+        use_pre_activation=True,
         include_rescaling=False,
-        input_image_shape=(224, 224, 3),
         pooling="avg",
     )
     classifier = keras_nlp.models.ResNetImageClassifier(

--- a/keras_nlp/src/models/resnet/resnet_image_classifier_test.py
+++ b/keras_nlp/src/models/resnet/resnet_image_classifier_test.py
@@ -30,7 +30,7 @@ class ResNetImageClassifierTest(TestCase):
             stackwise_num_blocks=[2, 2, 2],
             stackwise_num_strides=[1, 2, 2],
             block_type="basic_block",
-            preact=True,
+            use_pre_activation=True,
             input_image_shape=(16, 16, 3),
             include_rescaling=False,
             pooling="avg",

--- a/keras_nlp/src/models/resnet/resnet_image_classifier_test.py
+++ b/keras_nlp/src/models/resnet/resnet_image_classifier_test.py
@@ -1,0 +1,62 @@
+# Copyright 2024 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+from keras import ops
+
+from keras_nlp.src.models.resnet.resnet_backbone import ResNetBackbone
+from keras_nlp.src.models.resnet.resnet_image_classifier import (
+    ResNetImageClassifier,
+)
+from keras_nlp.src.tests.test_case import TestCase
+
+
+class ResNetImageClassifierTest(TestCase):
+    def setUp(self):
+        self.images = ops.ones((2, 16, 16, 3))
+        self.labels = [0, 3]
+        self.backbone = ResNetBackbone(
+            stackwise_num_filters=[64, 64, 64],
+            stackwise_num_blocks=[2, 2, 2],
+            stackwise_num_strides=[1, 2, 2],
+            block_type="basic_block",
+            preact=True,
+            input_image_shape=(16, 16, 3),
+            include_rescaling=False,
+            pooling="avg",
+        )
+        self.init_kwargs = {
+            "backbone": self.backbone,
+            "num_classes": 2,
+            "activation": "softmax",
+        }
+        self.train_data = (self.images, self.labels)
+
+    def test_classifier_basics(self):
+        pytest.skip(
+            reason="TODO: enable after preprocessor flow is figured out"
+        )
+        self.run_task_test(
+            cls=ResNetImageClassifier,
+            init_kwargs=self.init_kwargs,
+            train_data=self.train_data,
+            expected_output_shape=(2, 2),
+        )
+
+    @pytest.mark.large
+    def test_saved_model(self):
+        self.run_model_saving_test(
+            cls=ResNetImageClassifier,
+            init_kwargs=self.init_kwargs,
+            input_data=self.images,
+        )

--- a/keras_nlp/src/utils/keras_utils.py
+++ b/keras_nlp/src/utils/keras_utils.py
@@ -115,3 +115,16 @@ def assert_quantization_support():
             "Quantization API requires Keras >= 3.4.0 to function "
             f"correctly. Received: '{keras.version()}'"
         )
+
+
+def standardize_data_format(data_format):
+    if data_format is None:
+        return keras.config.image_data_format()
+    data_format = str(data_format).lower()
+    if data_format not in {"channels_first", "channels_last"}:
+        raise ValueError(
+            "The `data_format` argument must be one of "
+            "{'channels_first', 'channels_last'}. "
+            f"Received: data_format={data_format}"
+        )
+    return data_format


### PR DESCRIPTION
Closes #1750 

This PR largely follows #1737 but introduces some improvements:
- Supports both `"channels_last"` and `"channels_first"`
- Add support for mixed precision
- Improve the docstrings

The `preact` parameter in `ResNetBackbone` determines whether to instantiate ResNet or ResNetV2 (similar to `keras.applications.ResNet*`)
https://github.com/keras-team/keras/blob/b45be337c6156d90f220beba9f68eeb2e52e2b0d/keras/src/applications/resnet.py#L50

I have a small question regarding model implementation:
When creating a `Dense` layer in `ImageClassifier`, the `dtype_policy` is not configurable. I used `backbone.dtype_policy` as a workaround but it might be fragile.

The implementation has been verified by using the model weights from KerasCV.
Please refer to this colab: https://colab.research.google.com/drive/1HGktF-4TkTdTjlMVv7qr3D_ysspJXDmo?usp=sharing

@mattdangerw @divyashreepathihalli @SamanehSaadat 