### PR TITLE
Limit the default sequence length to 1024 for all models

### DIFF
--- a/keras_nlp/src/models/bloom/bloom_preprocessor.py
+++ b/keras_nlp/src/models/bloom/bloom_preprocessor.py
@@ -110,7 +110,7 @@ class BloomPreprocessor(Preprocessor):
     def __init__(
         self,
         tokenizer,
-        sequence_length=2048,
+        sequence_length=1024,
         add_start_token=True,
         add_end_token=True,
         **kwargs,

--- a/keras_nlp/src/models/falcon/falcon_preprocessor.py
+++ b/keras_nlp/src/models/falcon/falcon_preprocessor.py
@@ -112,7 +112,7 @@ class FalconPreprocessor(Preprocessor):
     def __init__(
         self,
         tokenizer,
-        sequence_length=2048,
+        sequence_length=1024,
         add_start_token=True,
         add_end_token=True,
         **kwargs,

--- a/keras_nlp/src/models/gemma/gemma_preprocessor.py
+++ b/keras_nlp/src/models/gemma/gemma_preprocessor.py
@@ -127,7 +127,7 @@ class GemmaPreprocessor(Preprocessor):
     def __init__(
         self,
         tokenizer,
-        sequence_length=8192,
+        sequence_length=1024,
         add_start_token=True,
         add_end_token=True,
         **kwargs,

--- a/keras_nlp/src/models/opt/opt_preprocessor.py
+++ b/keras_nlp/src/models/opt/opt_preprocessor.py
@@ -112,7 +112,7 @@ class OPTPreprocessor(Preprocessor):
     def __init__(
         self,
         tokenizer,
-        sequence_length=2048,
+        sequence_length=1024,
         add_start_token=True,
         add_end_token=True,
         **kwargs,

--- a/keras_nlp/src/models/phi3/phi3_preprocessor.py
+++ b/keras_nlp/src/models/phi3/phi3_preprocessor.py
@@ -115,7 +115,7 @@ class Phi3Preprocessor(Preprocessor):
     def __init__(
         self,
         tokenizer,
-        sequence_length=4096,
+        sequence_length=1024,
         add_start_token=True,
         add_end_token=False,
         **kwargs,


### PR DESCRIPTION
Pretrained models are supporting larger and larger sequence lengths. In gemma's case this is a particular nasty gotcha, as very few people have the compute resources to actually train on 8000 token long sequences.

I think it might be the more user friendly approach to lower our default sequence length to 1024. This won't prohibit users from setting a longer sequence length, but it will lessen the unpleasant gotcha of suddenly using a ton of VRAM when training.

We should still almost always document setting the sequence length in our code examples, as it's something the user generally should think about when fine-tuning or generating.