### PR TITLE
Lower the default learning rate for albert

### DIFF
--- a/keras_nlp/src/models/albert/albert_classifier.py
+++ b/keras_nlp/src/models/albert/albert_classifier.py
@@ -189,6 +189,23 @@ class AlbertClassifier(Classifier):
         self.activation = keras.activations.get(activation)
         self.dropout = dropout
 
+    def compile(
+        self,
+        optimizer="auto",
+        loss="auto",
+        *,
+        metrics="auto",
+        **kwargs,
+    ):
+        if optimizer == "auto":
+            optimizer = keras.optimizers.Adam(1e-5)
+        super().compile(
+            optimizer=optimizer,
+            loss=loss,
+            metrics=metrics,
+            **kwargs,
+        )
+
     def get_config(self):
         config = super().get_config()
         config.update(


### PR DESCRIPTION
Just noticed while porting https://github.com/keras-team/keras-nlp/pull/1767 that the default learning rate for our classifier does not work for albert pretrained checkpoints. Let's lower it for this model

Fixes #831 