### PR TITLE
Temp workflow to publish a keras-hub package

### DIFF
--- a/.github/workflows/publish-hub-to-pypi.yml
+++ b/.github/workflows/publish-hub-to-pypi.yml
@@ -1,0 +1,43 @@
+name: Publish Hub to PyPI
+
+on:
+  push:
+    branches:
+      - keras-hub
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    name: Build and publish Hub to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          python -m pip install --upgrade pip setuptools
+          echo "::set-output name=dir::$(pip cache dir)"
+      - name: pip cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: |
+            pip install -r requirements.txt --progress-bar off
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python pip_build.py
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN_HUB }}

--- a/keras_nlp/src/api_export.py
+++ b/keras_nlp/src/api_export.py
@@ -24,6 +24,11 @@ except ImportError:
 
 def maybe_register_serializable(symbol):
     if isinstance(symbol, types.FunctionType) or hasattr(symbol, "get_config"):
+        # We register twice, first with the old name, second with the new name,
+        # so loading still works under the old name.
+        # TODO replace compat_package_name with keras-nlp after rename.
+        compat_name = "compat_package_name"
+        keras.saving.register_keras_serializable(package=compat_name)(symbol)
         keras.saving.register_keras_serializable(package="keras_nlp")(symbol)
 
 

--- a/keras_nlp/src/utils/preset_utils.py
+++ b/keras_nlp/src/utils/preset_utils.py
@@ -99,7 +99,8 @@ def list_presets(cls):
 
 def list_subclasses(cls):
     """Find all registered subclasses of a class."""
-    custom_objects = keras.saving.get_custom_objects().values()
+    # Deduplicate the lists, since we have to register object twice for compat.
+    custom_objects = set(keras.saving.get_custom_objects().values())
     subclasses = []
     for x in custom_objects:
         if inspect.isclass(x) and x != cls and issubclass(x, cls):

--- a/pip_build.py
+++ b/pip_build.py
@@ -36,7 +36,7 @@ import pathlib
 import re
 import shutil
 
-package = "keras_nlp"
+package = "keras_hub"
 build_directory = "tmp_build_dir"
 dist_directory = "dist"
 to_copy = ["setup.py", "setup.cfg", "README.md"]
@@ -48,15 +48,15 @@ def ignore_files(_, filenames):
 
 def export_version_string(version, is_nightly=False):
     """Export Version and Package Name."""
+    date = datetime.datetime.now()
+    version += f".dev{date.strftime('%Y%m%d%H%M%S')}"
     if is_nightly:
-        date = datetime.datetime.now()
-        version += f".dev{date.strftime('%Y%m%d%H')}"
-        # Replaces `name="keras-nlp"` in `setup.py` with `keras-nlp-nightly`
+        # Replaces `name="keras-hub"` in `setup.py` with `keras-hub-nightly`
         with open("setup.py") as f:
             setup_contents = f.read()
         with open("setup.py", "w") as f:
             setup_contents = setup_contents.replace(
-                'name="keras-nlp"', 'name="keras-nlp-nightly"'
+                'name="keras-hub"', 'name="keras-hub-nightly"'
             )
             f.write(setup_contents)
 
@@ -78,11 +78,18 @@ def copy_source_to_build_directory(root_path):
     os.chdir(root_path)
     os.mkdir(build_directory)
     shutil.copytree(
-        package, os.path.join(build_directory, package), ignore=ignore_files
+        "keras_nlp", os.path.join(build_directory, package), ignore=ignore_files
     )
     for fname in to_copy:
         shutil.copy(fname, os.path.join(f"{build_directory}", fname))
     os.chdir(build_directory)
+    # TODO: remove all of this when our code is actually renamed in the repo.
+    os.system("grep -lR 'keras_nlp' . | xargs sed -i 's/keras_nlp/keras_hub/g'")
+    os.system("grep -lR 'keras-nlp' . | xargs sed -i 's/keras-nlp/keras-hub/g'")
+    os.system("grep -lR 'KerasNLP' . | xargs sed -i 's/KerasNLP/KerasHub/g'")
+    os.system(
+        "grep -lR 'compat_package_name' . | xargs sed -i 's/compat_package_name/keras_nlp/g'"
+    )
 
 
 def build(root_path, is_nightly=False):

--- a/setup.py
+++ b/setup.py
@@ -44,11 +44,8 @@ else:
 
 setup(
     name="keras-nlp",
-    description=(
-        "Industry-strength Natural Language Processing extensions for Keras."
-    ),
-    long_description=README,
-    long_description_content_type="text/markdown",
+    description="🚧🚧🚧 Work in progress. 🚧🚧🚧 More details soon!",
+    long_description="🚧🚧🚧 Work in progress. 🚧🚧🚧 More details soon!",
     version=VERSION,
     url="https://github.com/keras-team/keras-nlp",
     author="Keras team",


### PR DESCRIPTION
This is a temporary way to test out the keras-hub branch.
- Does a global rename of all symbols during package build.
- Registers the "old" name on symbol export for saving compat.
- Adds a github action to publish every commit to keras-hub as a new package.
- Removes our descriptions on PyPI temporarily, until we want to message this more broadly.