### PR TITLE
Add pyramid output for densenet, cspDarknet

### DIFF
--- a/keras_nlp/src/models/csp_darknet/csp_darknet_backbone.py
+++ b/keras_nlp/src/models/csp_darknet/csp_darknet_backbone.py
@@ -15,11 +15,11 @@ import keras
 from keras import layers
 
 from keras_nlp.src.api_export import keras_nlp_export
-from keras_nlp.src.models.backbone import Backbone
+from keras_nlp.src.models.feature_pyramid_backbone import FeaturePyramidBackbone
 
 
 @keras_nlp_export("keras_nlp.models.CSPDarkNetBackbone")
-class CSPDarkNetBackbone(Backbone):
+class CSPDarkNetBackbone(FeaturePyramidBackbone):
     """This class represents Keras Backbone of CSPDarkNet model.
 
     This class implements a CSPDarkNet backbone as described in
@@ -39,7 +39,7 @@ class CSPDarkNetBackbone(Backbone):
             `"basic_block"` for basic conv block.
             Defaults to "basic_block".
         image_shape: tuple. The input shape without the batch size.
-            Defaults to `(None, None, 3)`.
+            Defaults to `(224, 224, 3)`.
 
     Examples:
     ```python
@@ -87,6 +87,8 @@ class CSPDarkNetBackbone(Backbone):
         x = apply_darknet_conv_block(
             base_channels, kernel_size=3, strides=1, name="stem_conv"
         )(x)
+
+        pyramid_outputs = {}
         for index, (channels, depth) in enumerate(
             zip(stackwise_num_filters, stackwise_depth)
         ):
@@ -111,6 +113,7 @@ class CSPDarkNetBackbone(Backbone):
                 residual=(index != len(stackwise_depth) - 1),
                 name=f"dark{index + 2}_csp",
             )(x)
+            pyramid_outputs[f"P{index + 2}"] = x
 
         super().__init__(inputs=image_input, outputs=x, **kwargs)
 
@@ -120,6 +123,7 @@ class CSPDarkNetBackbone(Backbone):
         self.include_rescaling = include_rescaling
         self.block_type = block_type
         self.image_shape = image_shape
+        self.pyramid_outputs = pyramid_outputs
 
     def get_config(self):
         config = super().get_config()

--- a/keras_nlp/src/models/csp_darknet/csp_darknet_backbone.py
+++ b/keras_nlp/src/models/csp_darknet/csp_darknet_backbone.py
@@ -39,7 +39,7 @@ class CSPDarkNetBackbone(FeaturePyramidBackbone):
             `"basic_block"` for basic conv block.
             Defaults to "basic_block".
         image_shape: tuple. The input shape without the batch size.
-            Defaults to `(224, 224, 3)`.
+            Defaults to `(None, None, 3)`.
 
     Examples:
     ```python
@@ -67,7 +67,7 @@ class CSPDarkNetBackbone(FeaturePyramidBackbone):
         stackwise_depth,
         include_rescaling,
         block_type="basic_block",
-        image_shape=(224, 224, 3),
+        image_shape=(None, None, 3),
         **kwargs,
     ):
         # === Functional Model ===

--- a/keras_nlp/src/models/csp_darknet/csp_darknet_backbone_test.py
+++ b/keras_nlp/src/models/csp_darknet/csp_darknet_backbone_test.py
@@ -24,21 +24,32 @@ from keras_nlp.src.tests.test_case import TestCase
 class CSPDarkNetBackboneTest(TestCase):
     def setUp(self):
         self.init_kwargs = {
-            "stackwise_num_filters": [32, 64, 128, 256],
+            "stackwise_num_filters": [2, 4, 6, 8],
             "stackwise_depth": [1, 3, 3, 1],
             "include_rescaling": False,
             "block_type": "basic_block",
-            "image_shape": (224, 224, 3),
+            "image_shape": (32, 32, 3),
         }
-        self.input_data = np.ones((2, 224, 224, 3), dtype="float32")
+        self.input_size = 32
+        self.input_data = np.ones(
+            (2, self.input_size, self.input_size, 3), dtype="float32"
+        )
 
     def test_backbone_basics(self):
         self.run_backbone_test(
             cls=CSPDarkNetBackbone,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,
-            expected_output_shape=(2, 7, 7, 256),
+            expected_output_shape=(2, 1, 1, 8),
             run_mixed_precision_check=False,
+        )
+
+    def test_pyramid_output_format(self):
+        self.run_pyramid_output_test(
+            cls=CSPDarkNetBackbone,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            expected_pyramid_output_keys=["P2", "P3", "P4", "P5"],
         )
 
     @pytest.mark.large

--- a/keras_nlp/src/models/csp_darknet/csp_darknet_backbone_test.py
+++ b/keras_nlp/src/models/csp_darknet/csp_darknet_backbone_test.py
@@ -26,7 +26,6 @@ class CSPDarkNetBackboneTest(TestCase):
         self.init_kwargs = {
             "stackwise_num_filters": [2, 4, 6, 8],
             "stackwise_depth": [1, 3, 3, 1],
-            "include_rescaling": False,
             "block_type": "basic_block",
             "image_shape": (32, 32, 3),
         }
@@ -42,7 +41,9 @@ class CSPDarkNetBackboneTest(TestCase):
             input_data=self.input_data,
             expected_output_shape=(2, 1, 1, 8),
             expected_pyramid_output_keys=["P2", "P3", "P4", "P5"],
+            expected_pyramid_image_sizes=[(8, 8), (4, 4), (2, 2), (1, 1)],
             run_mixed_precision_check=False,
+            run_data_format_check=False,
         )
 
     @pytest.mark.large

--- a/keras_nlp/src/models/csp_darknet/csp_darknet_backbone_test.py
+++ b/keras_nlp/src/models/csp_darknet/csp_darknet_backbone_test.py
@@ -36,20 +36,13 @@ class CSPDarkNetBackboneTest(TestCase):
         )
 
     def test_backbone_basics(self):
-        self.run_backbone_test(
+        self.run_vision_backbone_test(
             cls=CSPDarkNetBackbone,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,
             expected_output_shape=(2, 1, 1, 8),
-            run_mixed_precision_check=False,
-        )
-
-    def test_pyramid_output_format(self):
-        self.run_pyramid_output_test(
-            cls=CSPDarkNetBackbone,
-            init_kwargs=self.init_kwargs,
-            input_data=self.input_data,
             expected_pyramid_output_keys=["P2", "P3", "P4", "P5"],
+            run_mixed_precision_check=False,
         )
 
     @pytest.mark.large

--- a/keras_nlp/src/models/densenet/densenet_backbone.py
+++ b/keras_nlp/src/models/densenet/densenet_backbone.py
@@ -14,14 +14,14 @@
 import keras
 
 from keras_nlp.src.api_export import keras_nlp_export
-from keras_nlp.src.models.backbone import Backbone
+from keras_nlp.src.models.feature_pyramid_backbone import FeaturePyramidBackbone
 
 BN_AXIS = 3
 BN_EPSILON = 1.001e-5
 
 
 @keras_nlp_export("keras_nlp.models.DenseNetBackbone")
-class DenseNetBackbone(Backbone):
+class DenseNetBackbone(FeaturePyramidBackbone):
     """Instantiates the DenseNet architecture.
 
     This class implements a DenseNet backbone as described in
@@ -85,6 +85,7 @@ class DenseNetBackbone(Backbone):
             3, strides=2, padding="same", name="pool1"
         )(x)
 
+        pyramid_outputs = {}
         for stack_index in range(len(stackwise_num_repeats) - 1):
             index = stack_index + 2
             x = apply_dense_block(
@@ -103,7 +104,7 @@ class DenseNetBackbone(Backbone):
             growth_rate,
             name=f"conv{len(stackwise_num_repeats) + 1}",
         )
-
+        pyramid_outputs[f"P{stack_index}"] = x
         x = keras.layers.BatchNormalization(
             axis=BN_AXIS, epsilon=BN_EPSILON, name="bn"
         )(x)
@@ -117,6 +118,7 @@ class DenseNetBackbone(Backbone):
         self.compression_ratio = compression_ratio
         self.growth_rate = growth_rate
         self.image_shape = image_shape
+        self.pyramid_outputs = pyramid_outputs
 
     def get_config(self):
         config = super().get_config()

--- a/keras_nlp/src/models/densenet/densenet_backbone.py
+++ b/keras_nlp/src/models/densenet/densenet_backbone.py
@@ -94,6 +94,7 @@ class DenseNetBackbone(FeaturePyramidBackbone):
                 growth_rate,
                 name=f"conv{index}",
             )
+            pyramid_outputs[f"P{index}"] = x
             x = apply_transition_block(
                 x, compression_ratio, name=f"pool{index}"
             )
@@ -104,7 +105,7 @@ class DenseNetBackbone(FeaturePyramidBackbone):
             growth_rate,
             name=f"conv{len(stackwise_num_repeats) + 1}",
         )
-        pyramid_outputs[f"P{stack_index}"] = x
+        pyramid_outputs[f"P{len(stackwise_num_repeats) +1}"] = x
         x = keras.layers.BatchNormalization(
             axis=BN_AXIS, epsilon=BN_EPSILON, name="bn"
         )(x)

--- a/keras_nlp/src/models/densenet/densenet_backbone.py
+++ b/keras_nlp/src/models/densenet/densenet_backbone.py
@@ -35,7 +35,7 @@ class DenseNetBackbone(FeaturePyramidBackbone):
         include_rescaling: bool, whether to rescale the inputs. If set
             to `True`, inputs will be passed through a `Rescaling(1/255.0)`
             layer. Defaults to `True`.
-        image_shape: optional shape tuple, defaults to (224, 224, 3).
+        image_shape: optional shape tuple, defaults to (None, None, 3).
         compression_ratio: float, compression rate at transition layers,
             defaults to 0.5.
         growth_rate: int, number of filters added by each dense block,
@@ -62,7 +62,7 @@ class DenseNetBackbone(FeaturePyramidBackbone):
         self,
         stackwise_num_repeats,
         include_rescaling=True,
-        image_shape=(224, 224, 3),
+        image_shape=(None, None, 3),
         compression_ratio=0.5,
         growth_rate=32,
         **kwargs,

--- a/keras_nlp/src/models/densenet/densenet_backbone_test.py
+++ b/keras_nlp/src/models/densenet/densenet_backbone_test.py
@@ -14,7 +14,6 @@
 
 import numpy as np
 import pytest
-from keras import models
 
 from keras_nlp.src.models.densenet.densenet_backbone import DenseNetBackbone
 from keras_nlp.src.tests.test_case import TestCase
@@ -44,19 +43,12 @@ class DenseNetBackboneTest(TestCase):
         )
 
     def test_pyramid_output_format(self):
-        init_kwargs = self.init_kwargs
-        backbone = DenseNetBackbone(**init_kwargs)
-        model = models.Model(backbone.inputs, backbone.pyramid_outputs)
-        output_data = model(self.input_data)
-
-        self.assertIsInstance(output_data, dict)
-        self.assertEqual(
-            list(output_data.keys()), list(backbone.pyramid_outputs.keys())
+        self.run_pyramid_output_test(
+            cls=DenseNetBackbone,
+            init_kwargs=self.init_kwargs,
+            input_data=self.input_data,
+            expected_pyramid_output_keys=["P2", "P3", "P4", "P5"],
         )
-        self.assertEqual(list(output_data.keys()), ["P2", "P3", "P4", "P5"])
-        for k, v in output_data.items():
-            size = self.input_size // (2 ** int(k[1:]))
-            self.assertEqual(tuple(v.shape[:3]), (2, size, size))
 
     @pytest.mark.large
     def test_saved_model(self):

--- a/keras_nlp/src/models/densenet/densenet_backbone_test.py
+++ b/keras_nlp/src/models/densenet/densenet_backbone_test.py
@@ -51,7 +51,7 @@ class DenseNetBackboneTest(TestCase):
         self.assertEqual(
             list(output_data.keys()), list(backbone.pyramid_outputs.keys())
         )
-        self.assertEqual(list(output_data.keys()), ["P2", "P3", "P4"])
+        self.assertEqual(list(output_data.keys()), ["P2", "P3", "P4", "P5"])
         for k, v in output_data.items():
             size = self.input_size // (2 ** int(k[1:]))
             self.assertEqual(tuple(v.shape[:3]), (2, size, size))

--- a/keras_nlp/src/models/densenet/densenet_backbone_test.py
+++ b/keras_nlp/src/models/densenet/densenet_backbone_test.py
@@ -30,7 +30,9 @@ class DenseNetBackboneTest(TestCase):
             "image_shape": (32, 32, 3),
         }
         self.input_size = 32
-        self.input_data = np.ones((2, self.input_size, self.input_size, 3), dtype="float32")
+        self.input_data = np.ones(
+            (2, self.input_size, self.input_size, 3), dtype="float32"
+        )
 
     def test_backbone_basics(self):
         self.run_backbone_test(
@@ -55,7 +57,7 @@ class DenseNetBackboneTest(TestCase):
         for k, v in output_data.items():
             size = self.input_size // (2 ** int(k[1:]))
             self.assertEqual(tuple(v.shape[:3]), (2, size, size))
-            
+
     @pytest.mark.large
     def test_saved_model(self):
         self.run_model_saving_test(

--- a/keras_nlp/src/models/densenet/densenet_backbone_test.py
+++ b/keras_nlp/src/models/densenet/densenet_backbone_test.py
@@ -34,20 +34,13 @@ class DenseNetBackboneTest(TestCase):
         )
 
     def test_backbone_basics(self):
-        self.run_backbone_test(
+        self.run_vision_backbone_test(
             cls=DenseNetBackbone,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,
             expected_output_shape=(2, 1, 1, 24),
-            run_mixed_precision_check=False,
-        )
-
-    def test_pyramid_output_format(self):
-        self.run_pyramid_output_test(
-            cls=DenseNetBackbone,
-            init_kwargs=self.init_kwargs,
-            input_data=self.input_data,
             expected_pyramid_output_keys=["P2", "P3", "P4", "P5"],
+            run_mixed_precision_check=False,
         )
 
     @pytest.mark.large

--- a/keras_nlp/src/models/densenet/densenet_backbone_test.py
+++ b/keras_nlp/src/models/densenet/densenet_backbone_test.py
@@ -14,6 +14,7 @@
 
 import numpy as np
 import pytest
+from keras import models
 
 from keras_nlp.src.models.densenet.densenet_backbone import DenseNetBackbone
 from keras_nlp.src.tests.test_case import TestCase
@@ -22,23 +23,39 @@ from keras_nlp.src.tests.test_case import TestCase
 class DenseNetBackboneTest(TestCase):
     def setUp(self):
         self.init_kwargs = {
-            "stackwise_num_repeats": [6, 12, 24, 16],
+            "stackwise_num_repeats": [2, 4, 6, 4],
             "include_rescaling": True,
             "compression_ratio": 0.5,
-            "growth_rate": 32,
-            "image_shape": (224, 224, 3),
+            "growth_rate": 2,
+            "image_shape": (32, 32, 3),
         }
-        self.input_data = np.ones((2, 224, 224, 3), dtype="float32")
+        self.input_size = 32
+        self.input_data = np.ones((2, self.input_size, self.input_size, 3), dtype="float32")
 
     def test_backbone_basics(self):
         self.run_backbone_test(
             cls=DenseNetBackbone,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,
-            expected_output_shape=(2, 7, 7, 1024),
+            expected_output_shape=(2, 1, 1, 24),
             run_mixed_precision_check=False,
         )
 
+    def test_pyramid_output_format(self):
+        init_kwargs = self.init_kwargs
+        backbone = DenseNetBackbone(**init_kwargs)
+        model = models.Model(backbone.inputs, backbone.pyramid_outputs)
+        output_data = model(self.input_data)
+
+        self.assertIsInstance(output_data, dict)
+        self.assertEqual(
+            list(output_data.keys()), list(backbone.pyramid_outputs.keys())
+        )
+        self.assertEqual(list(output_data.keys()), ["P2", "P3", "P4"])
+        for k, v in output_data.items():
+            size = self.input_size // (2 ** int(k[1:]))
+            self.assertEqual(tuple(v.shape[:3]), (2, size, size))
+            
     @pytest.mark.large
     def test_saved_model(self):
         self.run_model_saving_test(

--- a/keras_nlp/src/models/densenet/densenet_backbone_test.py
+++ b/keras_nlp/src/models/densenet/densenet_backbone_test.py
@@ -23,7 +23,6 @@ class DenseNetBackboneTest(TestCase):
     def setUp(self):
         self.init_kwargs = {
             "stackwise_num_repeats": [2, 4, 6, 4],
-            "include_rescaling": True,
             "compression_ratio": 0.5,
             "growth_rate": 2,
             "image_shape": (32, 32, 3),
@@ -40,7 +39,9 @@ class DenseNetBackboneTest(TestCase):
             input_data=self.input_data,
             expected_output_shape=(2, 1, 1, 24),
             expected_pyramid_output_keys=["P2", "P3", "P4", "P5"],
+            expected_pyramid_image_sizes=[(8, 8), (4, 4), (2, 2), (1, 1)],
             run_mixed_precision_check=False,
+            run_data_format_check=False,
         )
 
     @pytest.mark.large

--- a/keras_nlp/src/models/mix_transformer/mix_transformer_backbone.py
+++ b/keras_nlp/src/models/mix_transformer/mix_transformer_backbone.py
@@ -37,7 +37,7 @@ class MiTBackbone(FeaturePyramidBackbone):
         patch_sizes,
         strides,
         include_rescaling=True,
-        image_shape=(224, 224, 3),
+        image_shape=(None, None, 3),
         hidden_dims=None,
         **kwargs,
     ):
@@ -63,7 +63,7 @@ class MiTBackbone(FeaturePyramidBackbone):
             include_rescaling: bool, whether to rescale the inputs. If set
                 to `True`, inputs will be passed through a `Rescaling(1/255.0)`
                 layer. Defaults to `True`.
-            image_shape: optional shape tuple, defaults to (224, 224, 3).
+            image_shape: optional shape tuple, defaults to (None, None, 3).
             hidden_dims: the embedding dims per hierarchical layer, used as
                 the levels of the feature pyramid.
             patch_sizes: list of integers, the patch_size to apply for each layer.

--- a/keras_nlp/src/models/mix_transformer/mix_transformer_backbone_test.py
+++ b/keras_nlp/src/models/mix_transformer/mix_transformer_backbone_test.py
@@ -14,7 +14,6 @@
 
 import numpy as np
 import pytest
-from keras import models
 
 from keras_nlp.src.models.mix_transformer.mix_transformer_backbone import (
     MiTBackbone,
@@ -42,29 +41,17 @@ class MiTBackboneTest(TestCase):
         )
 
     def test_backbone_basics(self):
-        self.run_backbone_test(
+        self.run_vision_backbone_test(
             cls=MiTBackbone,
             init_kwargs=self.init_kwargs,
             input_data=self.input_data,
             expected_output_shape=(2, 2, 2, 8),
+            expected_pyramid_output_keys=["P1", "P2"],
+            expected_pyramid_image_sizes=[(4, 4), (2, 2)],
             run_quantization_check=False,
             run_mixed_precision_check=False,
+            run_data_format_check=False,
         )
-
-    def test_pyramid_output_format(self):
-        init_kwargs = self.init_kwargs
-        backbone = MiTBackbone(**init_kwargs)
-        model = models.Model(backbone.inputs, backbone.pyramid_outputs)
-        output_data = model(self.input_data)
-
-        self.assertIsInstance(output_data, dict)
-        self.assertEqual(
-            list(output_data.keys()), list(backbone.pyramid_outputs.keys())
-        )
-        self.assertEqual(list(output_data.keys()), ["P1", "P2"])
-        for k, v in output_data.items():
-            size = self.input_size // (2 ** (int(k[1:]) + 1))
-            self.assertEqual(tuple(v.shape[:3]), (2, size, size))
 
     @pytest.mark.large
     def test_saved_model(self):

--- a/keras_nlp/src/models/resnet/resnet_backbone_test.py
+++ b/keras_nlp/src/models/resnet/resnet_backbone_test.py
@@ -14,7 +14,6 @@
 
 import pytest
 from absl.testing import parameterized
-from keras import models
 from keras import ops
 
 from keras_nlp.src.models.resnet.resnet_backbone import ResNetBackbone
@@ -58,18 +57,12 @@ class ResNetBackboneTest(TestCase):
         init_kwargs.update(
             {"block_type": "basic_block", "use_pre_activation": False}
         )
-        backbone = ResNetBackbone(**init_kwargs)
-        model = models.Model(backbone.inputs, backbone.pyramid_outputs)
-        output_data = model(self.input_data)
-
-        self.assertIsInstance(output_data, dict)
-        self.assertEqual(
-            list(output_data.keys()), list(backbone.pyramid_outputs.keys())
+        self.run_pyramid_output_test(
+            cls=ResNetBackbone,
+            init_kwargs=init_kwargs,
+            input_data=self.input_data,
+            expected_pyramid_output_keys=["P2", "P3", "P4"],
         )
-        self.assertEqual(list(output_data.keys()), ["P2", "P3", "P4"])
-        for k, v in output_data.items():
-            size = self.input_size // (2 ** int(k[1:]))
-            self.assertEqual(tuple(v.shape[:3]), (2, size, size))
 
     @parameterized.named_parameters(
         ("v1_basic", False, "basic_block"),

--- a/keras_nlp/src/models/resnet/resnet_backbone_test.py
+++ b/keras_nlp/src/models/resnet/resnet_backbone_test.py
@@ -51,6 +51,7 @@ class ResNetBackboneTest(TestCase):
                 (2, 64) if block_type == "basic_block" else (2, 256)
             ),
             expected_pyramid_output_keys=["P2", "P3", "P4"],
+            expected_pyramid_image_sizes=[(16, 16), (8, 8), (4, 4)],
         )
 
     @parameterized.named_parameters(

--- a/keras_nlp/src/models/resnet/resnet_backbone_test.py
+++ b/keras_nlp/src/models/resnet/resnet_backbone_test.py
@@ -50,17 +50,6 @@ class ResNetBackboneTest(TestCase):
             expected_output_shape=(
                 (2, 64) if block_type == "basic_block" else (2, 256)
             ),
-        )
-
-    def test_pyramid_output_format(self):
-        init_kwargs = self.init_kwargs.copy()
-        init_kwargs.update(
-            {"block_type": "basic_block", "use_pre_activation": False}
-        )
-        self.run_pyramid_output_test(
-            cls=ResNetBackbone,
-            init_kwargs=init_kwargs,
-            input_data=self.input_data,
             expected_pyramid_output_keys=["P2", "P3", "P4"],
         )
 

--- a/keras_nlp/src/tests/test_case.py
+++ b/keras_nlp/src/tests/test_case.py
@@ -604,5 +604,27 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
 
             tree.map_structure(compare, output, expected_partial_output)
 
+    def run_pyramid_output_test(
+        self,
+        cls,
+        init_kwargs,
+        input_data,
+        expected_pyramid_output_keys,
+    ):
+        """Run Tests for Feature Pyramid output keys and shape."""
+        backbone = cls(**init_kwargs)
+        model = keras.models.Model(backbone.inputs, backbone.pyramid_outputs)
+        output_data = model(input_data)
+
+        self.assertIsInstance(output_data, dict)
+        self.assertEqual(
+            list(output_data.keys()), list(backbone.pyramid_outputs.keys())
+        )
+        self.assertEqual(list(output_data.keys()), expected_pyramid_output_keys)
+
+        for k, v in output_data.items():
+            size = input_data.shape[1] // (2 ** int(k[1:]))
+            self.assertEqual(tuple(v.shape[:3]), (2, size, size))
+
     def get_test_data_dir(self):
         return str(pathlib.Path(__file__).parent / "test_data")

--- a/keras_nlp/src/tests/test_case.py
+++ b/keras_nlp/src/tests/test_case.py
@@ -465,6 +465,7 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
         init_kwargs,
         input_data,
         expected_output_shape,
+        expected_pyramid_output_keys=None,
         variable_length_data=None,
         run_mixed_precision_check=True,
         run_quantization_check=True,
@@ -491,6 +492,13 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
             run_mixed_precision_check=run_mixed_precision_check,
             run_quantization_check=run_quantization_check,
         )
+        if expected_pyramid_output_keys:
+            self.run_pyramid_output_test(
+                cls=cls,
+                init_kwargs=init_kwargs,
+                input_data=input_data,
+                expected_pyramid_output_keys=expected_pyramid_output_keys,
+            )
 
         # Check data_format. We assume that `input_data` is in "channels_last"
         # format.
@@ -515,6 +523,13 @@ class TestCase(tf.test.TestCase, parameterized.TestCase):
                 run_mixed_precision_check=run_mixed_precision_check,
                 run_quantization_check=run_quantization_check,
             )
+            if expected_pyramid_output_keys:
+                self.run_pyramid_output_test(
+                    cls=cls,
+                    init_kwargs=init_kwargs,
+                    input_data=input_data,
+                    expected_pyramid_output_keys=expected_pyramid_output_keys,
+                )
 
         # Restore the original `image_data_format`.
         keras.config.set_image_data_format(ori_data_format)


### PR DESCRIPTION

- [x] Change from `Backbone` class to `FeaturePyramidBackbone` to get `pyramid outputs` for DenseNet and CSPdarkNet
- [x] Make common test case for pyramid outputs.
 