### PR TITLE
Add `add_bos=False, add_eos=False` to SentencePieceTokenizer.__init__()

### DIFF
--- a/keras_nlp/src/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_nlp/src/tokenizers/sentence_piece_tokenizer.py
@@ -221,6 +221,8 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
             {
                 "proto": None,  # Save vocabulary via an asset!
                 "sequence_length": self.sequence_length,
+                "add_bos": self.add_bos,
+                "add_eos": self.add_eos,
             }
         )
         return config

--- a/keras_nlp/src/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_nlp/src/tokenizers/sentence_piece_tokenizer.py
@@ -116,6 +116,8 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
         proto=None,
         sequence_length=None,
         dtype="int32",
+        add_bos=False,
+        add_eos=False,
         **kwargs,
     ) -> None:
         if not is_int_dtype(dtype) and not is_string_dtype(dtype):
@@ -128,6 +130,8 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
 
         self.proto = None
         self.sequence_length = sequence_length
+        self.add_bos = add_bos
+        self.add_eos = add_eos
         self.set_proto(proto)
         self.file_assets = [VOCAB_FILENAME]
 
@@ -172,6 +176,8 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
         self._sentence_piece = tf_text.SentencepieceTokenizer(
             model=proto_bytes,
             out_type=self.compute_dtype,
+            add_bos=self.add_bos,
+            add_eos=self.add_eos,
         )
         # Keras cannot serialize a bytestring, so we base64 encode the model
         # byte array as a string for saving.

--- a/keras_nlp/src/tokenizers/sentence_piece_tokenizer.py
+++ b/keras_nlp/src/tokenizers/sentence_piece_tokenizer.py
@@ -67,6 +67,9 @@ class SentencePieceTokenizer(tokenizer.Tokenizer):
             for more details on the format.
         sequence_length: If set, the output will be converted to a dense
             tensor and padded/trimmed so all outputs are of `sequence_length`.
+        add_bos: Add beginning of sentence token to the result.
+        add_eos: Add end of sentence token to the result. Token is always
+            truncated if output is longer than specified `sequence_length`.
 
     References:
         - [Kudo and Richardson, 2018](https://arxiv.org/abs/1808.06226)

--- a/keras_nlp/src/tokenizers/sentence_piece_tokenizer_test.py
+++ b/keras_nlp/src/tokenizers/sentence_piece_tokenizer_test.py
@@ -70,6 +70,29 @@ class SentencePieceTokenizerTest(TestCase):
             [["▁the", "▁quick", "▁brown", "▁fox."]],
         )
 
+    def test_scalar_bos_eos(self):
+        input_data = "the quick brown fox."
+        tokenizer = SentencePieceTokenizer(
+            proto=self.proto,
+            add_bos=True,
+            add_eos=True,
+        )
+        output_data = tokenizer(input_data)
+        self.assertAllEqual(output_data, [1, 6, 5, 3, 4, 2])
+
+    def test_string_bos_eos(self):
+        input_data = ["the quick brown fox."]
+        tokenizer = SentencePieceTokenizer(
+            proto=self.proto,
+            dtype="string",
+            add_bos=True,
+            add_eos=True,
+        )
+        output_data = tokenizer(input_data)
+        self.assertAllEqual(
+            output_data, [["<s>", "▁the", "▁quick", "▁brown", "▁fox.", "</s>"]]
+        )
+
     def test_detokenize(self):
         tokenizer = SentencePieceTokenizer(proto=self.proto)
         outputs = tokenizer.detokenize([6, 5, 3, 4])


### PR DESCRIPTION
Minor change that exposes the `add_bos` & `add_eos` parameters from `tf_text.SentencepieceTokenizer.__init__()` to `keras_nlp.tokenizers.SentencePieceTokenizer.__init__()`. from https://github.com/keras-team/keras-nlp/issues/1710

Also adds tests for bos/eos token emission.

There is a potential issue about truncating long sequences when emitting the EOS token (`'</s>'`).

The current behavior does not give the EOS token special treatment when truncating sequences based on `sequence_length`, meaning a truncated sequence will not have the EOS token at its end.
While this is necessary in some tasks (e.g. sequence generation) for the model to not learn wrong sequence terminators, always having the EOS token as the last token of a sequence may be potentially beneficial in others.

I did not believe this warrants an additional implementation of `tokenize()` however; I assume that users would not specify `sequence_length` in `SentencePieceTokenizer.__init__()` and add their own pad/truncator afterwards.