### PR TITLE
Add missing aliases

### DIFF
--- a/keras_nlp/api/models/__init__.py
+++ b/keras_nlp/api/models/__init__.py
@@ -25,6 +25,9 @@ from keras_nlp.src.models.albert.albert_masked_lm_preprocessor import (
 from keras_nlp.src.models.albert.albert_text_classifier import (
     AlbertTextClassifier,
 )
+from keras_nlp.src.models.albert.albert_text_classifier import (
+    AlbertTextClassifier as AlbertClassifier,
+)
 from keras_nlp.src.models.albert.albert_text_classifier_preprocessor import (
     AlbertTextClassifierPreprocessor,
 )
@@ -45,6 +48,9 @@ from keras_nlp.src.models.bert.bert_masked_lm_preprocessor import (
     BertMaskedLMPreprocessor,
 )
 from keras_nlp.src.models.bert.bert_text_classifier import BertTextClassifier
+from keras_nlp.src.models.bert.bert_text_classifier import (
+    BertTextClassifier as BertClassifier,
+)
 from keras_nlp.src.models.bert.bert_text_classifier_preprocessor import (
     BertTextClassifierPreprocessor,
 )
@@ -72,6 +78,9 @@ from keras_nlp.src.models.deberta_v3.deberta_v3_masked_lm_preprocessor import (
 from keras_nlp.src.models.deberta_v3.deberta_v3_text_classifier import (
     DebertaV3TextClassifier,
 )
+from keras_nlp.src.models.deberta_v3.deberta_v3_text_classifier import (
+    DebertaV3TextClassifier as DebertaV3Classifier,
+)
 from keras_nlp.src.models.deberta_v3.deberta_v3_text_classifier_preprocessor import (
     DebertaV3TextClassifierPreprocessor,
 )
@@ -93,6 +102,9 @@ from keras_nlp.src.models.distil_bert.distil_bert_masked_lm_preprocessor import 
 from keras_nlp.src.models.distil_bert.distil_bert_text_classifier import (
     DistilBertTextClassifier,
 )
+from keras_nlp.src.models.distil_bert.distil_bert_text_classifier import (
+    DistilBertTextClassifier as DistilBertClassifier,
+)
 from keras_nlp.src.models.distil_bert.distil_bert_text_classifier_preprocessor import (
     DistilBertTextClassifierPreprocessor,
 )
@@ -110,6 +122,9 @@ from keras_nlp.src.models.f_net.f_net_masked_lm_preprocessor import (
     FNetMaskedLMPreprocessor,
 )
 from keras_nlp.src.models.f_net.f_net_text_classifier import FNetTextClassifier
+from keras_nlp.src.models.f_net.f_net_text_classifier import (
+    FNetTextClassifier as FNetClassifier,
+)
 from keras_nlp.src.models.f_net.f_net_text_classifier_preprocessor import (
     FNetTextClassifierPreprocessor,
 )
@@ -195,6 +210,9 @@ from keras_nlp.src.models.roberta.roberta_masked_lm_preprocessor import (
 from keras_nlp.src.models.roberta.roberta_text_classifier import (
     RobertaTextClassifier,
 )
+from keras_nlp.src.models.roberta.roberta_text_classifier import (
+    RobertaTextClassifier as RobertaClassifier,
+)
 from keras_nlp.src.models.roberta.roberta_text_classifier_preprocessor import (
     RobertaTextClassifierPreprocessor,
 )
@@ -208,6 +226,7 @@ from keras_nlp.src.models.t5.t5_backbone import T5Backbone
 from keras_nlp.src.models.t5.t5_tokenizer import T5Tokenizer
 from keras_nlp.src.models.task import Task
 from keras_nlp.src.models.text_classifier import TextClassifier
+from keras_nlp.src.models.text_classifier import TextClassifier as Classifier
 from keras_nlp.src.models.text_classifier_preprocessor import (
     TextClassifierPreprocessor,
 )
@@ -224,6 +243,9 @@ from keras_nlp.src.models.xlm_roberta.xlm_roberta_masked_lm_preprocessor import 
 )
 from keras_nlp.src.models.xlm_roberta.xlm_roberta_text_classifier import (
     XLMRobertaTextClassifier,
+)
+from keras_nlp.src.models.xlm_roberta.xlm_roberta_text_classifier import (
+    XLMRobertaTextClassifier as XLMRobertaClassifier,
 )
 from keras_nlp.src.models.xlm_roberta.xlm_roberta_text_classifier_preprocessor import (
     XLMRobertaTextClassifierPreprocessor,

--- a/keras_nlp/src/models/albert/albert_text_classifier.py
+++ b/keras_nlp/src/models/albert/albert_text_classifier.py
@@ -25,7 +25,12 @@ from keras_nlp.src.models.albert.albert_text_classifier_preprocessor import (
 from keras_nlp.src.models.text_classifier import TextClassifier
 
 
-@keras_nlp_export("keras_nlp.models.AlbertTextClassifier")
+@keras_nlp_export(
+    [
+        "keras_nlp.models.AlbertTextClassifier",
+        "keras_nlp.models.AlbertClassifier",
+    ]
+)
 class AlbertTextClassifier(TextClassifier):
     """An end-to-end ALBERT model for classification tasks
 

--- a/keras_nlp/src/models/bert/bert_text_classifier.py
+++ b/keras_nlp/src/models/bert/bert_text_classifier.py
@@ -23,7 +23,12 @@ from keras_nlp.src.models.bert.bert_text_classifier_preprocessor import (
 from keras_nlp.src.models.text_classifier import TextClassifier
 
 
-@keras_nlp_export("keras_nlp.models.BertTextClassifier")
+@keras_nlp_export(
+    [
+        "keras_nlp.models.BertTextClassifier",
+        "keras_nlp.models.BertClassifier",
+    ]
+)
 class BertTextClassifier(TextClassifier):
     """An end-to-end BERT model for classification tasks.
 

--- a/keras_nlp/src/models/deberta_v3/deberta_v3_text_classifier.py
+++ b/keras_nlp/src/models/deberta_v3/deberta_v3_text_classifier.py
@@ -28,7 +28,12 @@ from keras_nlp.src.models.deberta_v3.deberta_v3_text_classifier_preprocessor imp
 from keras_nlp.src.models.text_classifier import TextClassifier
 
 
-@keras_nlp_export("keras_nlp.models.DebertaV3TextClassifier")
+@keras_nlp_export(
+    [
+        "keras_nlp.models.DebertaV3TextClassifier",
+        "keras_nlp.models.DebertaV3Classifier",
+    ]
+)
 class DebertaV3TextClassifier(TextClassifier):
     """An end-to-end DeBERTa model for classification tasks.
 

--- a/keras_nlp/src/models/distil_bert/distil_bert_text_classifier.py
+++ b/keras_nlp/src/models/distil_bert/distil_bert_text_classifier.py
@@ -28,7 +28,12 @@ from keras_nlp.src.models.distil_bert.distil_bert_text_classifier_preprocessor i
 from keras_nlp.src.models.text_classifier import TextClassifier
 
 
-@keras_nlp_export("keras_nlp.models.DistilBertTextClassifier")
+@keras_nlp_export(
+    [
+        "keras_nlp.models.DistilBertTextClassifier",
+        "keras_nlp.models.DistilBertClassifier",
+    ]
+)
 class DistilBertTextClassifier(TextClassifier):
     """An end-to-end DistilBERT model for classification tasks.
 

--- a/keras_nlp/src/models/f_net/f_net_text_classifier.py
+++ b/keras_nlp/src/models/f_net/f_net_text_classifier.py
@@ -24,7 +24,12 @@ from keras_nlp.src.models.f_net.f_net_text_classifier_preprocessor import (
 from keras_nlp.src.models.text_classifier import TextClassifier
 
 
-@keras_nlp_export("keras_nlp.models.FNetTextClassifier")
+@keras_nlp_export(
+    [
+        "keras_nlp.models.FNetTextClassifier",
+        "keras_nlp.models.FNetClassifier",
+    ]
+)
 class FNetTextClassifier(TextClassifier):
     """An end-to-end f_net model for classification tasks.
 

--- a/keras_nlp/src/models/roberta/roberta_text_classifier.py
+++ b/keras_nlp/src/models/roberta/roberta_text_classifier.py
@@ -26,7 +26,12 @@ from keras_nlp.src.models.roberta.roberta_text_classifier_preprocessor import (
 from keras_nlp.src.models.text_classifier import TextClassifier
 
 
-@keras_nlp_export("keras_nlp.models.RobertaTextClassifier")
+@keras_nlp_export(
+    [
+        "keras_nlp.models.RobertaTextClassifier",
+        "keras_nlp.models.RobertaClassifier",
+    ]
+)
 class RobertaTextClassifier(TextClassifier):
     """An end-to-end RoBERTa model for classification tasks.
 

--- a/keras_nlp/src/models/text_classifier.py
+++ b/keras_nlp/src/models/text_classifier.py
@@ -17,7 +17,12 @@ from keras_nlp.src.api_export import keras_nlp_export
 from keras_nlp.src.models.task import Task
 
 
-@keras_nlp_export("keras_nlp.models.TextClassifier")
+@keras_nlp_export(
+    [
+        "keras_nlp.models.TextClassifier",
+        "keras_nlp.models.Classifier",
+    ]
+)
 class TextClassifier(Task):
     """Base class for all classification tasks.
 

--- a/keras_nlp/src/models/xlm_roberta/xlm_roberta_text_classifier.py
+++ b/keras_nlp/src/models/xlm_roberta/xlm_roberta_text_classifier.py
@@ -28,7 +28,12 @@ from keras_nlp.src.models.xlm_roberta.xlm_roberta_text_classifier_preprocessor i
 )
 
 
-@keras_nlp_export("keras_nlp.models.XLMRobertaTextClassifier")
+@keras_nlp_export(
+    [
+        "keras_nlp.models.XLMRobertaTextClassifier",
+        "keras_nlp.models.XLMRobertaClassifier",
+    ]
+)
 class XLMRobertaTextClassifier(TextClassifier):
     """An end-to-end XLM-RoBERTa model for classification tasks.
 


### PR DESCRIPTION
Forgot these whoops! We need to keep the old `XXClassifier` class aliases around so we don't break folks.